### PR TITLE
Add font fallback chain support to ltml FontStyle

### DIFF
--- a/ltml/font_style.go
+++ b/ltml/font_style.go
@@ -6,31 +6,49 @@ package ltml
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/rowland/leadtype/colors"
 	"github.com/rowland/leadtype/options"
+	"github.com/rowland/leadtype/ttf"
 )
 
+// fontEntry holds the name and optional per-font settings for one font in a
+// fallback chain defined by a FontStyle.
+type fontEntry struct {
+	name         string
+	ranges       []string // Unicode range names restricting which codepoints this font serves.
+	relativeSize float64  // Size multiplier to normalise rendered size; 0 is treated as 1.0.
+}
+
 type FontStyle struct {
-	id   string
-	name string
-	size float64
+	id      string
+	entries []fontEntry
+	size    float64
 
-	color     colors.Color
-	strikeout bool
-	style     string
-	underline bool
-	weight    string
-
+	color      colors.Color
+	strikeout  bool
+	style      string
+	underline  bool
+	weight     string
 	lineHeight float64
 }
 
 func (fs *FontStyle) Apply(w Writer) {
-	// fmt.Printf("Applying %s\n", fs)
-	w.SetFont(fs.name, fs.size, options.Options{
+	if len(fs.entries) == 0 {
+		return
+	}
+	baseOpts := options.Options{
 		"color":  colors.Color(fs.color),
 		"weight": fs.weight,
-		"style":  fs.style})
+		"style":  fs.style,
+	}
+	// SetFont resets the font list and loads the primary (first) font.
+	w.SetFont(fs.entries[0].name, fs.size, applyEntryOptions(fs.entries[0], baseOpts))
+	// AddFont appends each fallback font in order.
+	for _, entry := range fs.entries[1:] {
+		w.AddFont(entry.name, applyEntryOptions(entry, baseOpts))
+	}
 	if fs.lineHeight == 0 {
 		fs.lineHeight = 1.0
 	}
@@ -39,8 +57,38 @@ func (fs *FontStyle) Apply(w Writer) {
 	w.SetLineSpacing(fs.lineHeight)
 }
 
+// applyEntryOptions copies base and adds per-entry ranges and relative_size.
+func applyEntryOptions(entry fontEntry, base options.Options) options.Options {
+	opts := make(options.Options, len(base)+2)
+	for k, v := range base {
+		opts[k] = v
+	}
+	if len(entry.ranges) > 0 {
+		if rs, err := ttf.NewCodepointRangeSet(entry.ranges...); err == nil {
+			// Pass as RuneSet so the font restricts which codepoints it serves.
+			opts["ranges"] = rs
+		} else {
+			// Unknown names: fall back to string slice for font-source selection.
+			opts["ranges"] = entry.ranges
+		}
+	}
+	if entry.relativeSize != 0 {
+		// font.New expects relative_size as a percentage (100 = no adjustment).
+		opts["relative_size"] = entry.relativeSize * 100
+	}
+	return opts
+}
+
 func (fs *FontStyle) Clone() *FontStyle {
 	clone := *fs
+	clone.entries = make([]fontEntry, len(fs.entries))
+	for i, e := range fs.entries {
+		clone.entries[i] = e
+		if len(e.ranges) > 0 {
+			clone.entries[i].ranges = make([]string, len(e.ranges))
+			copy(clone.entries[i].ranges, e.ranges)
+		}
+	}
 	return &clone
 }
 
@@ -53,14 +101,68 @@ const (
 	defaultFontSize = 12
 )
 
-var defaultFont = &FontStyle{id: "default", name: defaultFontName, size: defaultFontSize}
+var defaultFont = &FontStyle{
+	id:      "default",
+	entries: []fontEntry{{name: defaultFontName}},
+	size:    defaultFontSize,
+}
 
+// SetAttrs applies XML attributes to the FontStyle.  The prefix is prepended to
+// every attribute key before lookup (e.g. "font." when attrs are inline on
+// another element, "" when the element is a <font> element itself).
+//
+// Supported attributes (shown without prefix):
+//
+//	name     – comma-separated list of font-family names, defining the fallback
+//	           chain.  A single name is backward-compatible with the old API.
+//	ranges   – pipe-separated groups of comma-separated Unicode range names, one
+//	           group per font in the name list.  An empty group means no range
+//	           restriction for that position.  Example:
+//	             "Basic Latin, Latin-1 Supplement | CJK Unified Ideographs"
+//	sizes    – pipe-separated relative-size multipliers, one per font.  Use to
+//	           normalise fonts that render at visually different sizes for the
+//	           same point size.  Example: "1.0 | 0.9"
+//	size     – shared point size for all fonts in the chain.
+//	color, weight, style, strikeout, underline, line-height – as before.
 func (fs *FontStyle) SetAttrs(prefix string, attrs map[string]string) {
 	if id, ok := attrs[prefix+"id"]; ok {
 		fs.id = id
 	}
+	// Process "name" first so that "ranges" and "sizes" have entries to target.
 	if name, ok := attrs[prefix+"name"]; ok {
-		fs.name = name
+		names := splitCommaTrimmed(name)
+		newEntries := make([]fontEntry, len(names))
+		for i, n := range names {
+			if i < len(fs.entries) {
+				newEntries[i] = fs.entries[i] // preserve any existing ranges/size
+			}
+			newEntries[i].name = n
+		}
+		fs.entries = newEntries
+	}
+	if rangesAttr, ok := attrs[prefix+"ranges"]; ok {
+		groups := splitPipe(rangesAttr)
+		for i, group := range groups {
+			if i >= len(fs.entries) {
+				break
+			}
+			if group == "" {
+				fs.entries[i].ranges = nil
+			} else {
+				fs.entries[i].ranges = splitCommaTrimmed(group)
+			}
+		}
+	}
+	if sizesAttr, ok := attrs[prefix+"sizes"]; ok {
+		groups := splitPipe(sizesAttr)
+		for i, group := range groups {
+			if i >= len(fs.entries) {
+				break
+			}
+			if f, err := strconv.ParseFloat(group, 64); err == nil {
+				fs.entries[i].relativeSize = f
+			}
+		}
 	}
 	if size, ok := attrs[prefix+"size"]; ok {
 		var err error
@@ -88,9 +190,35 @@ func (fs *FontStyle) SetAttrs(prefix string, attrs map[string]string) {
 	}
 }
 
+// splitCommaTrimmed splits s by commas and trims whitespace, omitting empties.
+func splitCommaTrimmed(s string) []string {
+	parts := strings.Split(s, ",")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			result = append(result, t)
+		}
+	}
+	return result
+}
+
+// splitPipe splits s by pipes, trimming whitespace from each element.
+// Empty elements are preserved so that positions remain meaningful.
+func splitPipe(s string) []string {
+	parts := strings.Split(s, "|")
+	for i, p := range parts {
+		parts[i] = strings.TrimSpace(p)
+	}
+	return parts
+}
+
 func (fs *FontStyle) String() string {
+	names := make([]string, len(fs.entries))
+	for i, e := range fs.entries {
+		names[i] = e.name
+	}
 	return fmt.Sprintf("FontStyle id=%s name=%s size=%f color=%v strikeout=%t style=%s underline=%t weight=%s line-height=%f",
-		fs.id, fs.name, fs.size, fs.color, fs.strikeout, fs.style, fs.underline, fs.weight, fs.lineHeight)
+		fs.id, strings.Join(names, ","), fs.size, fs.color, fs.strikeout, fs.style, fs.underline, fs.weight, fs.lineHeight)
 }
 
 func FontStyleFor(id string, scope HasScope) *FontStyle {

--- a/ltml/font_style_test.go
+++ b/ltml/font_style_test.go
@@ -1,0 +1,184 @@
+// Copyright 2016 Brent Rowland.
+// Use of this source code is governed the Apache License, Version 2.0, as described in the LICENSE file.
+
+package ltml
+
+import (
+	"testing"
+
+	"github.com/rowland/leadtype/font"
+	"github.com/rowland/leadtype/options"
+)
+
+// mockWriter records SetFont and AddFont calls for inspection.
+type mockWriter struct {
+	setFontName  string
+	setFontSize  float64
+	addFontNames []string
+	fonts        []*font.Font
+}
+
+func (m *mockWriter) AddFont(family string, opts options.Options) ([]*font.Font, error) {
+	m.addFontNames = append(m.addFontNames, family)
+	return m.fonts, nil
+}
+func (m *mockWriter) SetFont(name string, size float64, opts options.Options) ([]*font.Font, error) {
+	m.setFontName = name
+	m.setFontSize = size
+	m.addFontNames = nil
+	return m.fonts, nil
+}
+func (m *mockWriter) FontColor() interface{}                            { return nil }
+func (m *mockWriter) Fonts() []*font.Font                              { return m.fonts }
+func (m *mockWriter) FontSize() float64                                { return m.setFontSize }
+func (m *mockWriter) LineSpacing() float64                             { return 1.0 }
+func (m *mockWriter) LineTo(x, y float64)                              {}
+func (m *mockWriter) Loc() (float64, float64)                          { return 0, 0 }
+func (m *mockWriter) MoveTo(x, y float64)                              {}
+func (m *mockWriter) NewPage()                                         {}
+func (m *mockWriter) Print(text string) error                          { return nil }
+func (m *mockWriter) PrintParagraph(para interface{}, opts interface{}) {}
+func (m *mockWriter) PrintRichText(text interface{})                   {}
+func (m *mockWriter) Rectangle(x, y, w, h float64, b, f bool)         {}
+func (m *mockWriter) Rectangle2(x, y, w, h float64, b, f bool, c []float64, p, r bool) {}
+func (m *mockWriter) SetFillColor(v interface{}) interface{}           { return nil }
+func (m *mockWriter) SetLineColor(v interface{}) interface{}           { return nil }
+func (m *mockWriter) SetLineDashPattern(p string) string               { return "" }
+func (m *mockWriter) SetLineSpacing(ls float64) float64                { return 0 }
+func (m *mockWriter) SetLineWidth(w float64)                           {}
+func (m *mockWriter) SetStrikeout(s bool) bool                         { return false }
+func (m *mockWriter) SetUnderline(u bool) bool                         { return false }
+func (m *mockWriter) Strikeout() bool                                  { return false }
+func (m *mockWriter) Underline() bool                                  { return false }
+
+func TestFontStyle_SetAttrs_SingleName(t *testing.T) {
+	var fs FontStyle
+	fs.SetAttrs("", map[string]string{"name": "Helvetica", "size": "12"})
+	if len(fs.entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(fs.entries))
+	}
+	if fs.entries[0].name != "Helvetica" {
+		t.Errorf("expected Helvetica, got %s", fs.entries[0].name)
+	}
+	if fs.size != 12 {
+		t.Errorf("expected size 12, got %f", fs.size)
+	}
+}
+
+func TestFontStyle_SetAttrs_MultipleNames(t *testing.T) {
+	var fs FontStyle
+	fs.SetAttrs("", map[string]string{"name": "Helvetica, Arial Unicode MS, Courier"})
+	if len(fs.entries) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(fs.entries))
+	}
+	if fs.entries[0].name != "Helvetica" {
+		t.Errorf("entry 0: expected Helvetica, got %s", fs.entries[0].name)
+	}
+	if fs.entries[1].name != "Arial Unicode MS" {
+		t.Errorf("entry 1: expected Arial Unicode MS, got %s", fs.entries[1].name)
+	}
+	if fs.entries[2].name != "Courier" {
+		t.Errorf("entry 2: expected Courier, got %s", fs.entries[2].name)
+	}
+}
+
+func TestFontStyle_SetAttrs_Ranges(t *testing.T) {
+	var fs FontStyle
+	fs.SetAttrs("", map[string]string{
+		"name":   "Helvetica, NotoSansCJK",
+		"ranges": " | CJK Unified Ideographs",
+	})
+	if len(fs.entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(fs.entries))
+	}
+	if len(fs.entries[0].ranges) != 0 {
+		t.Errorf("entry 0: expected no ranges, got %v", fs.entries[0].ranges)
+	}
+	if len(fs.entries[1].ranges) != 1 || fs.entries[1].ranges[0] != "CJK Unified Ideographs" {
+		t.Errorf("entry 1: expected [CJK Unified Ideographs], got %v", fs.entries[1].ranges)
+	}
+}
+
+func TestFontStyle_SetAttrs_Sizes(t *testing.T) {
+	var fs FontStyle
+	fs.SetAttrs("", map[string]string{
+		"name":  "Helvetica, NotoSansCJK",
+		"sizes": "1.0 | 0.9",
+	})
+	if len(fs.entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(fs.entries))
+	}
+	if fs.entries[0].relativeSize != 1.0 {
+		t.Errorf("entry 0: expected relativeSize 1.0, got %f", fs.entries[0].relativeSize)
+	}
+	if fs.entries[1].relativeSize != 0.9 {
+		t.Errorf("entry 1: expected relativeSize 0.9, got %f", fs.entries[1].relativeSize)
+	}
+}
+
+func TestFontStyle_SetAttrs_Prefix(t *testing.T) {
+	var fs FontStyle
+	fs.SetAttrs("font.", map[string]string{
+		"font.name":  "Helvetica, Arial",
+		"font.size":  "14",
+		"font.sizes": "1.0 | 0.85",
+	})
+	if len(fs.entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(fs.entries))
+	}
+	if fs.entries[1].relativeSize != 0.85 {
+		t.Errorf("entry 1: expected relativeSize 0.85, got %f", fs.entries[1].relativeSize)
+	}
+	if fs.size != 14 {
+		t.Errorf("expected size 14, got %f", fs.size)
+	}
+}
+
+func TestFontStyle_Clone_DeepCopiesEntries(t *testing.T) {
+	var fs FontStyle
+	fs.SetAttrs("", map[string]string{
+		"name":   "Helvetica, NotoSansCJK",
+		"ranges": " | CJK Unified Ideographs",
+	})
+	clone := fs.Clone()
+	// Mutate original; clone should be unaffected.
+	fs.entries[1].ranges[0] = "CHANGED"
+	if clone.entries[1].ranges[0] != "CJK Unified Ideographs" {
+		t.Errorf("Clone shares ranges slice with original")
+	}
+}
+
+func TestFontStyle_String_MultipleEntries(t *testing.T) {
+	var fs FontStyle
+	fs.SetAttrs("", map[string]string{"name": "Helvetica, Arial"})
+	s := fs.String()
+	if s == "" {
+		t.Error("String() returned empty")
+	}
+	// Should contain both names joined by comma.
+	if !contains(s, "Helvetica,Arial") {
+		t.Errorf("String() missing font names: %s", s)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsRune(s, substr))
+}
+
+func containsRune(s, substr string) bool {
+	for i := range s {
+		if i+len(substr) <= len(s) && s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+func TestFontStyle_DefaultFont(t *testing.T) {
+	if len(defaultFont.entries) != 1 {
+		t.Fatalf("defaultFont should have 1 entry, got %d", len(defaultFont.entries))
+	}
+	if defaultFont.entries[0].name != defaultFontName {
+		t.Errorf("defaultFont entry name: expected %s, got %s", defaultFontName, defaultFont.entries[0].name)
+	}
+}

--- a/ltml/ltml_test.go
+++ b/ltml/ltml_test.go
@@ -103,6 +103,7 @@ func TestSamples(t *testing.T) {
 		"test_010_rich_text",
 		"test_011_table_layout",
 		"test_012_cjk_thai_grid",
+		"test_013_font_fallback",
 		"test_030_encodings",
 	}
 

--- a/ltml/samples/test_013_font_fallback.ltml
+++ b/ltml/samples/test_013_font_fallback.ltml
@@ -1,0 +1,31 @@
+<ltml>
+  <!--
+    Font fallback demo.
+
+    The "body" font lists Helvetica as the primary face, with Arial Unicode MS
+    as a fallback for any codepoints Helvetica cannot render.
+
+    The "cjk" font restricts Arial Unicode MS to the CJK Unified Ideographs
+    range so that Latin text always falls through to Helvetica.
+
+    The "adjusted" font shows the size-multiplier feature: the CJK fallback font
+    is scaled to 0.9× its nominal point size so that it visually matches the
+    Latin face at the same declared size.
+  -->
+  <font id="body"     name="Helvetica, Arial Unicode MS" size="12" />
+  <font id="cjk"      name="Helvetica, Arial Unicode MS" size="12"
+                      ranges="| CJK Unified Ideographs" />
+  <font id="adjusted" name="Helvetica, Arial Unicode MS" size="12"
+                      ranges="| CJK Unified Ideographs"
+                      sizes="1.0 | 0.9" />
+
+  <page units="in" margin="1" font="body">
+    <p>Font Fallback Demo</p>
+    <p>Latin text rendered with Helvetica, falling back to Arial Unicode MS for
+       characters outside its coverage.</p>
+    <p font="cjk">CJK restricted to its range: 你好世界 – Latin falls through
+       to Helvetica.</p>
+    <p font="adjusted">With a 0.9× size multiplier on the CJK font: 你好世界
+       appears at a normalised size alongside Latin glyphs.</p>
+  </page>
+</ltml>

--- a/ltml/scope.go
+++ b/ltml/scope.go
@@ -130,7 +130,7 @@ var defaultStyles = map[string]Styler{
 	"solid":  &PenStyle{id: "solid", color: NamedColor("black"), width: 0.001, pattern: "solid"},
 	"dotted": &PenStyle{id: "dotted", color: NamedColor("black"), width: 0.001, pattern: "dotted"},
 	"dashed": &PenStyle{id: "dashed", color: NamedColor("black"), width: 0.001, pattern: "dashed"},
-	"fixed":  &FontStyle{id: "fixed", name: "Courier New", size: 12},
+	"fixed":  &FontStyle{id: "fixed", entries: []fontEntry{{name: "Courier New"}}, size: 12},
 }
 
 var defaultScope = Scope{

--- a/ltml/std_paragraph_text_test.go
+++ b/ltml/std_paragraph_text_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestStdParagraph_AddTextWithFont_NormalizesXMLWhitespace(t *testing.T) {
 	p := &StdParagraph{}
-	font := &FontStyle{id: "body", name: "Helvetica", size: 12}
+	font := &FontStyle{id: "body", entries: []fontEntry{{name: "Helvetica"}}, size: 12}
 
 	p.AddTextWithFont("\n        Four score and seven years ago\n        our fathers brought forth.\n", font)
 
@@ -20,8 +20,8 @@ func TestStdParagraph_AddTextWithFont_NormalizesXMLWhitespace(t *testing.T) {
 
 func TestStdParagraph_AddTextWithFont_PreservesSpanBoundarySpaces(t *testing.T) {
 	p := &StdParagraph{}
-	body := &FontStyle{id: "body", name: "Helvetica", size: 12}
-	emph := &FontStyle{id: "emph", name: "Helvetica", size: 12, weight: "Bold"}
+	body := &FontStyle{id: "body", entries: []fontEntry{{name: "Helvetica"}}, size: 12}
+	emph := &FontStyle{id: "emph", entries: []fontEntry{{name: "Helvetica"}}, size: 12, weight: "Bold"}
 
 	p.AddTextWithFont("Hello ", body)
 	p.AddTextWithFont("big", emph)

--- a/ltml/writer.go
+++ b/ltml/writer.go
@@ -24,6 +24,7 @@ type Writer interface {
 	PrintRichText(text *rich_text.RichText)
 	Rectangle(x, y, width, height float64, border bool, fill bool)
 	Rectangle2(x, y, width, height float64, border bool, fill bool, corners []float64, path, reverse bool)
+	AddFont(family string, options options.Options) ([]*font.Font, error)
 	SetFont(name string, size float64, options options.Options) ([]*font.Font, error)
 	SetFillColor(value interface{}) (prev colors.Color)
 	SetLineColor(value colors.Color) (prev colors.Color)


### PR DESCRIPTION
FontStyle now holds a list of font entries instead of a single name,
enabling a full CSS-style fallback chain:

  <font id="body" name="Helvetica, Arial Unicode MS" size="12" />

Stretch goal 1 – per-font Unicode range restriction: each entry can
carry a list of Unicode range names (pipe-separated groups in the
"ranges" attribute) so that, for example, a CJK font is only consulted
for CJK codepoints:

  <font id="cjk" name="Helvetica, Arial Unicode MS" size="12"
        ranges="| CJK Unified Ideographs" />

Range names are resolved via ttf.NewCodepointRangeSet and stored as a
RuneSet on the loaded Font, which gates HasRune() queries.

Stretch goal 2 – per-font size multiplier: an optional "sizes"
attribute (pipe-separated floats) scales each font's rendered size to
normalise visual weight differences:

  <font id="adj" name="Helvetica, Arial Unicode MS" size="12"
        ranges="| CJK Unified Ideographs" sizes="1.0 | 0.9" />

The ltml.Writer interface gains AddFont so FontStyle.Apply can load
primary and fallback fonts in one call sequence.  The only concrete
implementation (ltpdf.DocWriter via pdf.DocWriter) already satisfies
the new method.

https://claude.ai/code/session_01THykP94oppD1zesTBi1AMK