### PR TITLE
Document selector parsing and application functions in LTML

### DIFF
--- a/ltml/ltml.go
+++ b/ltml/ltml.go
@@ -226,6 +226,8 @@ func (doc *Doc) startElement(elem xml.StartElement) {
 	}
 }
 
+// applyPseudoRules performs a second pass over the parsed widget tree so rules
+// that rely on structural pseudo-classes can be matched with layout context.
 func (doc *Doc) applyPseudoRules() {
 	resolver := newSelectorStructureResolver()
 	for _, root := range doc.ltmls {
@@ -233,6 +235,8 @@ func (doc *Doc) applyPseudoRules() {
 	}
 }
 
+// applyPseudoRulesToWidget walks the widget subtree, applying any pseudo-class
+// rules that match each widget in scope order.
 func (doc *Doc) applyPseudoRulesToWidget(widget Widget, resolver *selectorStructureResolver) {
 	if widget == nil {
 		return
@@ -249,6 +253,8 @@ func (doc *Doc) applyPseudoRulesToWidget(widget Widget, resolver *selectorStruct
 	}
 }
 
+// applyElementAttrs applies default attrs, matching selector rules, and direct
+// element attrs to a target in that precedence order.
 func applyElementAttrs(scope HasScope, target any, defaultAttrs, attrs map[string]string, pathOverride string) {
 	if target == nil {
 		return
@@ -285,6 +291,8 @@ func applyElementAttrs(scope HasScope, target any, defaultAttrs, attrs map[strin
 	}
 }
 
+// applyPseudoRuleAttrs applies matching pseudo-class selector attrs to a
+// widget, then reapplies its raw attrs so explicit element attrs remain final.
 func applyPseudoRuleAttrs(scope HasScope, target Widget, resolver *selectorStructureResolver) {
 	pseudoScope, ok := scope.(interface {
 		EachPseudoRuleForWidget(Widget, *selectorStructureResolver, func(*Rule))

--- a/ltml/scope.go
+++ b/ltml/scope.go
@@ -116,6 +116,9 @@ func (scope *Scope) matchingRules(path string) []*Rule {
 	return matched
 }
 
+// EachPseudoRuleForWidget calls f for every pseudo-class Rule matching widget
+// in cascade order: lower tiers first, then lower specificity, then earlier
+// declarations.
 func (scope *Scope) EachPseudoRuleForWidget(widget Widget, resolver *selectorStructureResolver, f func(rule *Rule)) {
 	matched := scope.matchingPseudoRules(widget, resolver)
 	sort.SliceStable(matched, func(i, j int) bool {

--- a/ltml/selectors.go
+++ b/ltml/selectors.go
@@ -144,6 +144,8 @@ var pseudoMatchers = map[string]pseudoMatcher{
 	},
 }
 
+// compileSelectorList parses a possibly grouped selector string into compiled
+// selectors that can be matched repeatedly during rule evaluation.
 func compileSelectorList(selector string) (*compiledSelectorList, error) {
 	rawSelectors := splitRuleSelectors(selector)
 	list := &compiledSelectorList{selectors: make([]*compiledSelector, 0, len(rawSelectors))}
@@ -157,6 +159,8 @@ func compileSelectorList(selector string) (*compiledSelectorList, error) {
 	return list, nil
 }
 
+// splitRuleSelectors breaks a grouped selector list ("p, .note") into
+// individual selectors and removes empty items.
 func splitRuleSelectors(selector string) []string {
 	rawSelectors := strings.Split(selector, ",")
 	selectors := make([]string, 0, len(rawSelectors))
@@ -169,6 +173,8 @@ func splitRuleSelectors(selector string) []string {
 	return selectors
 }
 
+// compileSingleSelector parses one selector into ordered parts and
+// combinators, and computes its specificity metadata.
 func compileSingleSelector(selector string) (*compiledSelector, error) {
 	normalized := normalizeSelector(selector)
 	if normalized == "" {
@@ -211,6 +217,7 @@ func compileSingleSelector(selector string) (*compiledSelector, error) {
 	return &compiledSelector{parts: parts, specificity: spec, hasPseudo: hasPseudo}, nil
 }
 
+// normalizeSelector trims and canonicalizes spacing so tokenization is stable.
 func normalizeSelector(selector string) string {
 	selector = strings.TrimSpace(selector)
 	selector = reExtraSpaces.ReplaceAllLiteralString(selector, " ")
@@ -218,6 +225,8 @@ func normalizeSelector(selector string) string {
 	return selector
 }
 
+// tokenizeSelector converts a normalized selector into item and combinator
+// tokens while preserving descendant-space combinators.
 func tokenizeSelector(selector string) []string {
 	var tokens []string
 	var current strings.Builder
@@ -249,6 +258,8 @@ func tokenizeSelector(selector string) []string {
 	return tokens
 }
 
+// parseSelectorItem parses a single selector token such as "table.row:first-row"
+// into tag, id, classes, and pseudo-class components.
 func parseSelectorItem(token string) (selectorItem, error) {
 	var item selectorItem
 	base, pseudoText, _ := strings.Cut(token, ":")
@@ -271,6 +282,8 @@ func parseSelectorItem(token string) (selectorItem, error) {
 	return item, nil
 }
 
+// parseSelectorBase parses the non-pseudo selector component and assigns its
+// tag, id, and class values to item.
 func parseSelectorBase(base string, item *selectorItem) error {
 	if base == "" {
 		return nil
@@ -312,6 +325,7 @@ func parseSelectorBase(base string, item *selectorItem) error {
 	return nil
 }
 
+// parseSelectorPseudo validates and parses a supported pseudo-class expression.
 func parseSelectorPseudo(part string) (selectorPseudo, error) {
 	if part == "" {
 		return selectorPseudo{}, fmt.Errorf("invalid empty pseudo-class")


### PR DESCRIPTION
### Motivation
- Make the selector parsing and style-application code easier to understand by adding standard Go doc comments describing the role and behavior of each helper function.
- Clarify intent for both parsing helpers and the second-pass application of pseudo-class rules so future readers and maintainers can reason about precedence and structure-sensitive matching.

### Description
- Added function comments to selector parsing helpers in `ltml/selectors.go` including `compileSelectorList`, `splitRuleSelectors`, `compileSingleSelector`, `normalizeSelector`, `tokenizeSelector`, `parseSelectorItem`, `parseSelectorBase`, and `parseSelectorPseudo` to document tokenization and parsing behavior.
- Added function comments in `ltml/ltml.go` for the style-rule application flow including `applyPseudoRules`, `applyPseudoRulesToWidget`, `applyElementAttrs`, and `applyPseudoRuleAttrs` to document the pseudo-rule pass and attribute precedence.
- Added a function comment to `Scope.EachPseudoRuleForWidget` in `ltml/scope.go` describing cascade ordering when applying pseudo-class rules.
- Changes are comments only and do not alter runtime behavior.

### Testing
- Ran `go build ./...` successfully with no build errors.
- Ran `go test ./...` and all packages passed (`ok` results for the repository test suites).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d904296378832dbc37d422c66632b3)