### PR TITLE
Add src support to LTML pre tags

### DIFF
--- a/docs/ltml-pre-src-plan.md
+++ b/docs/ltml-pre-src-plan.md
@@ -1,0 +1,199 @@
+# LTML plan: component-backed `<pre>` with inline or src content
+
+## Goal
+
+Allow LTML `<pre>` to take its preformatted content from either:
+
+- inline text inside the tag, or
+- a `src` attribute pointing to a file or URL resolved through the existing LTML component asset-loading rules.
+
+The implementation should preserve current inline `<pre>` behavior and should
+not introduce a separate source-loading mechanism just for `<pre>`.
+
+## Current state
+
+- `ltml.StdPre` currently embeds `StdWidget`.
+- Inline `<pre>` content is accumulated through `HasText` / `AddText(...)`.
+- `<pre>` does not currently support `src`.
+- `StdPre` owns its own text normalization flow through `Lines()`, including:
+  - CRLF / CR normalization,
+  - tab expansion to four spaces,
+  - trimming one surrounding blank line,
+  - dedenting common leading indentation from non-blank lines.
+- Component-backed tags already use `StdComponent` for:
+  - raw body capture,
+  - `src` attribute handling,
+  - asset FS support,
+  - `ParseFile(...)` relative-path resolution,
+  - optional network-backed asset loading.
+- The built-in `<svg>` tag is the closest built-in example of a component-backed
+  tag that supports both inline content and `src`, with `src` taking precedence.
+
+## Desired public behavior
+
+Inline `<pre>` should continue to work exactly as it does today:
+
+```xml
+<pre font="fixed" border="solid" padding="6pt">
+  if x &lt; 1 {
+    return
+  }
+</pre>
+```
+
+`<pre>` should also accept a `src` attribute:
+
+```xml
+<pre src="snippet.txt" font="fixed" border="solid" padding="6pt" />
+```
+
+When both inline content and `src` are present, `src` should win:
+
+```xml
+<pre src="snippet.txt">
+  this inline body is ignored when src is present
+</pre>
+```
+
+Target semantics:
+
+- [ ] Inline `<pre>` keeps today’s text semantics.
+- [ ] XML entities in inline content continue to decode to literal characters.
+- [ ] Tabs expand to four spaces.
+- [ ] Line endings normalize from `\r\n` / `\r` to `\n`.
+- [ ] One surrounding blank line is trimmed.
+- [ ] Common indentation is removed from non-blank lines.
+- [ ] Blank lines inside the block remain preserved.
+- [ ] `src` content is loaded lazily using the existing component asset rules.
+- [ ] `src` takes precedence over inline content when both are present.
+
+## Non-goals and guardrails
+
+- [ ] Do not make `<pre>` interpret nested markup as rich LTML content.
+- [ ] Do not change paragraph or wrapping behavior; `<pre>` remains a
+      non-wrapping preformatted text widget.
+- [ ] Do not change the existing `fixed` font default unless required to
+      preserve current behavior.
+- [ ] Do not introduce a new asset-loading system for `<pre>`.
+- [ ] Do not change unrelated component-backed tag behavior while adding this
+      support.
+
+## Implementation checklist
+
+### Phase 1: Refactor `StdPre` to use component-style content ownership
+
+- [ ] Change `StdPre` to embed `StdComponent` instead of owning only
+      `StdWidget` text state.
+- [ ] Preserve widget/layout behavior already provided through the embedded
+      widget/container chain.
+- [ ] Remove direct dependence on incremental `AddText`-only storage as the
+      source of truth.
+- [ ] Keep `StdPre` registered as the built-in `pre` tag.
+
+### Phase 2: Preserve existing inline `<pre>` semantics
+
+- [ ] Keep inline `<pre>` content behaving as plain text, not raw XML markup.
+- [ ] Ensure inline entity decoding still yields literal text in `Lines()`.
+- [ ] Preserve current normalization rules:
+  - [ ] CRLF / CR normalization.
+  - [ ] Tab expansion to four spaces.
+  - [ ] Surrounding blank-line trim.
+  - [ ] Common-indent dedent for non-blank lines.
+  - [ ] Blank-line preservation within the body.
+- [ ] Keep `AccessibilityText()` based on the normalized resolved lines.
+- [ ] Keep `PreferredWidth()` based on the normalized resolved lines.
+- [ ] Keep `PreferredHeight()` based on the normalized resolved lines.
+- [ ] Keep `DrawContent()` based on the normalized resolved lines.
+
+### Phase 3: Add `src` support through component behavior
+
+- [ ] Accept optional `src` on `<pre>`.
+- [ ] Reuse `StdComponent.SetAttrs(...)` for `src` parsing.
+- [ ] Reuse `StdComponent.Body()` / `assetSource()` behavior instead of
+      duplicating path-resolution logic.
+- [ ] Make `src` take precedence over inline content.
+- [ ] Support asset FS resolution via `WithAssetFS(...)`.
+- [ ] Support relative file resolution from `ParseFile(...)`.
+- [ ] Support optional network sources using the same document/network rules as
+      existing component-backed tags.
+- [ ] Keep lazy loading semantics so external content is read on use, not at
+      parse time.
+
+### Phase 4: Parser and interface alignment
+
+- [ ] Decide whether `StdPre` should continue implementing `HasText`, or
+      whether parse-time body capture should become the single source path.
+- [ ] If `HasText` remains, ensure it feeds the same normalization and caching
+      pipeline as `src`-backed content.
+- [ ] If parse-time body capture becomes primary, add a pre-specific body
+      resolver or setter that preserves current text semantics instead of
+      exposing raw XML behavior.
+- [ ] Ensure `StdPre` still integrates correctly with parse stack push/pop
+      behavior.
+- [ ] Ensure sibling parsing around `<pre>` is unchanged.
+- [ ] Ensure no regression in current parse behavior for inline `<pre>` bodies.
+
+### Phase 5: Documentation updates
+
+- [ ] Update `ltml/SYNTAX.md` to add `src` to the `<pre>` attribute table.
+- [ ] Document that `src` wins over inline content.
+- [ ] Document that `<pre>` uses the same source-resolution rules as
+      component-backed tags.
+- [ ] Add or update an LTML sample if that improves future verification or
+      discoverability.
+
+## Test checklist
+
+### Unit tests
+
+- [ ] Keep existing `ltml/std_pre_test.go` line-formatting coverage passing.
+- [ ] Add a test for `<pre src="...">` loading from `WithAssetFS(...)`.
+- [ ] Add a test for relative file resolution via `ParseFile(...)`.
+- [ ] Add a test proving `src` overrides inline body.
+- [ ] Add a test proving inline entity decoding still matches current behavior
+      after the refactor.
+- [ ] Add a test for missing or empty body behavior staying consistent with
+      current rendering and layout expectations.
+
+### Integration and focused verification
+
+- [ ] Run focused LTML tests for `StdPre` behavior.
+- [ ] Run focused LTML tests for component source-loading behavior.
+- [ ] Run `go build ./...`.
+- [ ] Run `go test ./...` when implementation happens.
+- [ ] Note in the implementation PR or follow-up doc that some existing tests
+      may require environment or network allowances outside the default sandbox.
+
+## Suggested implementation sequence
+
+- [ ] Land the `StdPre` internal refactor first, with no public behavior change.
+- [ ] Add the shared resolved-body path so inline and `src` content feed the
+      same normalization logic.
+- [ ] Add `src` support and precedence behavior.
+- [ ] Add tests for asset FS, relative file resolution, and precedence.
+- [ ] Update `ltml/SYNTAX.md` and any sample coverage last.
+
+This sequencing keeps the refactor reviewable and makes regressions easier to
+localize.
+
+## Acceptance criteria
+
+- [ ] Existing inline `<pre>` documents render exactly as before.
+- [ ] `<pre src="...">` works with asset FS-backed content.
+- [ ] `<pre src="...">` works with relative local files when parsed through
+      `ParseFile(...)`.
+- [ ] `<pre>` follows existing component `src` precedence rules.
+- [ ] `<pre>` follows existing component path and URL resolution rules.
+- [ ] No regressions are introduced for `<svg>` or custom component source
+      loading.
+- [ ] `ltml/SYNTAX.md` accurately documents the new `<pre>` behavior.
+
+## Assumptions and defaults
+
+- Inline `<pre>` should preserve current text semantics rather than exposing raw
+  inner XML.
+- `src` should win when both `src` and inline content are present.
+- The implementation should reuse `StdComponent` behavior rather than creating
+  a parallel source-loading path for `<pre>`.
+- `<pre>` should remain a text-oriented leaf widget even if its content source
+  becomes component-backed internally.

--- a/ltml/SYNTAX.md
+++ b/ltml/SYNTAX.md
@@ -423,6 +423,7 @@ code blocks and other preformatted content.
 
 | Attribute | Description |
 |-----------|-------------|
+| `src` | Optional path or URL to external preformatted text content. When both `src` and inline content are present, `src` wins. |
 | `font` / `font.*` | Same font attributes supported by `<p>`. Defaults to the built-in `fixed` font style. |
 | `width`, `height` | Optional explicit dimensions. |
 | `margin`, `margin-top`, `margin-right`, `margin-bottom`, `margin-left` | Outer spacing around the block. |
@@ -434,6 +435,18 @@ code blocks and other preformatted content.
 `<pre>` preserves internal spaces and line breaks, does not wrap lines, trims a
 single surrounding newline from block content, removes common leading
 indentation from non-blank lines, and expands tab characters to four spaces.
+External `src` content is loaded lazily on first use using the same
+source-resolution rules as component-backed tags such as `<svg>`:
+
+- when an asset filesystem is attached, `src` must be a clean relative asset
+  path and is read virtually from that asset filesystem
+- when no asset filesystem is attached, relative file paths are resolved
+  relative to the LTML document being parsed, while absolute paths remain
+  absolute
+- `http` and `https` URLs are supported only when document/network loading is
+  explicitly enabled; network assets are fetched lazily into a temp file and
+  cleaned up after rendering
+
 When `<pre>` participates in tagged output through `role`, LTML uses that same
 resolved preformatted text for `/ActualText`.
 

--- a/ltml/std_component.go
+++ b/ltml/std_component.go
@@ -3,17 +3,12 @@
 
 package ltml
 
-import (
-	"fmt"
-	"strings"
-	"sync/atomic"
-)
+import "sync/atomic"
 
 type StdComponent struct {
 	StdContainer
-	body        string
-	src         string
-	srcExplicit bool
+	body   string
+	source textSource
 }
 
 var networkAssetsDisabled atomic.Bool
@@ -23,22 +18,15 @@ func DisableNetworkAssets() {
 }
 
 func (c *StdComponent) Body() string {
-	if !c.srcExplicit || strings.TrimSpace(c.src) == "" {
-		return c.body
-	}
-	ref, err := c.assetSource()
+	body, err := c.source.Text(c.doc, c.container, c.body, "component")
 	if err != nil {
 		return ""
 	}
-	data, err := readAssetSource(c.doc, ref)
-	if err != nil {
-		return ""
-	}
-	return string(data)
+	return body
 }
 
 func (c *StdComponent) SetBody(body string) {
-	if c.srcExplicit {
+	if c.source.Explicit() {
 		return
 	}
 	c.body = body
@@ -46,17 +34,11 @@ func (c *StdComponent) SetBody(body string) {
 
 func (c *StdComponent) SetAttrs(attrs map[string]string) {
 	c.StdContainer.SetAttrs(attrs)
-	src, ok := attrs["src"]
-	if !ok || strings.TrimSpace(src) == "" {
-		return
-	}
-	src = strings.TrimSpace(src)
-	c.src = src
-	c.srcExplicit = true
+	c.source.SetAttrs(attrs)
 }
 
 func (c *StdComponent) ensureBody() error {
-	if !c.srcExplicit || strings.TrimSpace(c.src) == "" {
+	if !c.source.Explicit() {
 		return nil
 	}
 	_, err := c.assetSource()
@@ -64,13 +46,7 @@ func (c *StdComponent) ensureBody() error {
 }
 
 func (c *StdComponent) assetSource() (assetSourceRef, error) {
-	if !c.srcExplicit || strings.TrimSpace(c.src) == "" {
-		return assetSourceRef{}, nil
-	}
-	if c.doc == nil {
-		return assetSourceRef{}, fmt.Errorf("component document is not set")
-	}
-	return c.doc.resolveAssetSource(c.container, c.src)
+	return c.source.assetSource(c.doc, c.container, "component")
 }
 
 var _ Component = (*StdComponent)(nil)

--- a/ltml/std_pre.go
+++ b/ltml/std_pre.go
@@ -14,9 +14,8 @@ const preTabWidth = 4
 
 type StdPre struct {
 	StdWidget
+	source  textSource
 	rawText string
-	src     string
-	doc     *Doc
 	lines   []string
 }
 
@@ -28,8 +27,11 @@ func (p *StdPre) AddText(text string) {
 }
 
 func (p *StdPre) DrawContent(w Writer) error {
+	lines, err := p.resolvedLines()
+	if err != nil {
+		return err
+	}
 	return withWidgetRoleAccessibility(w, &p.StdWidget, "", p.AccessibilityText(), func() error {
-		lines := p.Lines()
 		if len(lines) == 0 {
 			lines = []string{""}
 		}
@@ -50,6 +52,11 @@ func (p *StdPre) DrawContent(w Writer) error {
 		}
 		return nil
 	})
+}
+
+func (p *StdPre) BeforePrint(Writer) error {
+	_, err := p.resolvedLines()
+	return err
 }
 
 func (p *StdPre) Font() *FontStyle {
@@ -97,37 +104,42 @@ func (p *StdPre) PreferredWidth(w Writer) float64 {
 }
 
 func (p *StdPre) AccessibilityText() string {
-	return strings.Join(p.Lines(), "\n")
+	lines, err := p.resolvedLines()
+	if err != nil {
+		return ""
+	}
+	return strings.Join(lines, "\n")
 }
 
 func (p *StdPre) SetAttrs(attrs map[string]string) {
 	p.StdWidget.SetAttrs(attrs)
-	if src, ok := attrs["src"]; ok {
-		p.src = strings.TrimSpace(src)
-	}
-}
-
-func (p *StdPre) SetDoc(doc *Doc) {
-	p.doc = doc
+	p.source.SetAttrs(attrs)
 }
 
 func (p *StdPre) Lines() []string {
-	if strings.TrimSpace(p.src) != "" {
-		text, err := p.sourceText()
+	lines, err := p.resolvedLines()
+	if err != nil {
+		return []string{""}
+	}
+	return lines
+}
+
+func (p *StdPre) resolvedLines() ([]string, error) {
+	if p.source.Explicit() {
+		text, err := p.source.Text(p.doc, p.container, p.rawText, "pre")
 		if err != nil {
-			return []string{""}
+			return nil, err
 		}
-		return normalizedPreLines(text)
+		return normalizedPreLines(text), nil
 	}
-	if p.lines != nil {
-		return p.lines
+	if p.lines == nil {
+		p.lines = normalizedPreLines(p.rawText)
 	}
-	p.lines = normalizedPreLines(p.rawText)
-	return p.lines
+	return p.lines, nil
 }
 
 func (p *StdPre) String() string {
-	return fmt.Sprintf("StdPre src=%s %s", p.src, &p.StdWidget)
+	return fmt.Sprintf("StdPre src=%s %s", p.source.src, &p.StdWidget)
 }
 
 func (p *StdPre) lineHeight(w Writer) float64 {
@@ -153,29 +165,8 @@ func init() {
 	registerTag(DefaultSpace, "pre", func() any { return &StdPre{} })
 }
 
-func (p *StdPre) sourceText() (string, error) {
-	ref, err := p.assetSource()
-	if err != nil {
-		return "", err
-	}
-	if ref.identifier == "" {
-		return "", nil
-	}
-	data, err := readAssetSource(p.doc, ref)
-	if err != nil {
-		return "", err
-	}
-	return string(data), nil
-}
-
 func (p *StdPre) assetSource() (assetSourceRef, error) {
-	if strings.TrimSpace(p.src) == "" {
-		return assetSourceRef{}, nil
-	}
-	if p.doc == nil {
-		return assetSourceRef{}, fmt.Errorf("pre document is not set")
-	}
-	return p.doc.resolveAssetSource(p.container, p.src)
+	return p.source.assetSource(p.doc, p.container, "pre")
 }
 
 func normalizedPreLines(text string) []string {

--- a/ltml/std_pre.go
+++ b/ltml/std_pre.go
@@ -15,6 +15,8 @@ const preTabWidth = 4
 type StdPre struct {
 	StdWidget
 	rawText string
+	src     string
+	doc     *Doc
 	lines   []string
 }
 
@@ -100,58 +102,32 @@ func (p *StdPre) AccessibilityText() string {
 
 func (p *StdPre) SetAttrs(attrs map[string]string) {
 	p.StdWidget.SetAttrs(attrs)
+	if src, ok := attrs["src"]; ok {
+		p.src = strings.TrimSpace(src)
+	}
+}
+
+func (p *StdPre) SetDoc(doc *Doc) {
+	p.doc = doc
 }
 
 func (p *StdPre) Lines() []string {
+	if strings.TrimSpace(p.src) != "" {
+		text, err := p.sourceText()
+		if err != nil {
+			return []string{""}
+		}
+		return normalizedPreLines(text)
+	}
 	if p.lines != nil {
 		return p.lines
 	}
-	text := strings.ReplaceAll(p.rawText, "\t", strings.Repeat(" ", preTabWidth))
-	if text == "" {
-		p.lines = []string{""}
-		return p.lines
-	}
-
-	lines := strings.Split(text, "\n")
-	if len(lines) > 0 && strings.TrimSpace(lines[0]) == "" {
-		lines = lines[1:]
-	}
-	if len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) == "" {
-		lines = lines[:len(lines)-1]
-	}
-	if len(lines) == 0 {
-		p.lines = []string{""}
-		return p.lines
-	}
-
-	indent := -1
-	for _, line := range lines {
-		if strings.TrimSpace(line) == "" {
-			continue
-		}
-		count := 0
-		for count < len(line) && line[count] == ' ' {
-			count++
-		}
-		if indent == -1 || count < indent {
-			indent = count
-		}
-	}
-	if indent > 0 {
-		for i, line := range lines {
-			if strings.TrimSpace(line) == "" {
-				lines[i] = ""
-				continue
-			}
-			lines[i] = line[indent:]
-		}
-	}
-	p.lines = lines
+	p.lines = normalizedPreLines(p.rawText)
 	return p.lines
 }
 
 func (p *StdPre) String() string {
-	return fmt.Sprintf("StdPre %s", &p.StdWidget)
+	return fmt.Sprintf("StdPre src=%s %s", p.src, &p.StdWidget)
 }
 
 func (p *StdPre) lineHeight(w Writer) float64 {
@@ -177,8 +153,78 @@ func init() {
 	registerTag(DefaultSpace, "pre", func() any { return &StdPre{} })
 }
 
+func (p *StdPre) sourceText() (string, error) {
+	ref, err := p.assetSource()
+	if err != nil {
+		return "", err
+	}
+	if ref.identifier == "" {
+		return "", nil
+	}
+	data, err := readAssetSource(p.doc, ref)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+func (p *StdPre) assetSource() (assetSourceRef, error) {
+	if strings.TrimSpace(p.src) == "" {
+		return assetSourceRef{}, nil
+	}
+	if p.doc == nil {
+		return assetSourceRef{}, fmt.Errorf("pre document is not set")
+	}
+	return p.doc.resolveAssetSource(p.container, p.src)
+}
+
+func normalizedPreLines(text string) []string {
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	text = strings.ReplaceAll(text, "\r", "\n")
+	text = strings.ReplaceAll(text, "\t", strings.Repeat(" ", preTabWidth))
+	if text == "" {
+		return []string{""}
+	}
+
+	lines := strings.Split(text, "\n")
+	if len(lines) > 0 && strings.TrimSpace(lines[0]) == "" {
+		lines = lines[1:]
+	}
+	if len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) == "" {
+		lines = lines[:len(lines)-1]
+	}
+	if len(lines) == 0 {
+		return []string{""}
+	}
+
+	indent := -1
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		count := 0
+		for count < len(line) && line[count] == ' ' {
+			count++
+		}
+		if indent == -1 || count < indent {
+			indent = count
+		}
+	}
+	if indent > 0 {
+		for i, line := range lines {
+			if strings.TrimSpace(line) == "" {
+				lines[i] = ""
+				continue
+			}
+			lines[i] = line[indent:]
+		}
+	}
+	return lines
+}
+
 var _ HasAttrs = (*StdPre)(nil)
 var _ HasText = (*StdPre)(nil)
 var _ Identifier = (*StdPre)(nil)
 var _ Printer = (*StdPre)(nil)
 var _ WantsContainer = (*StdPre)(nil)
+var _ WantsDoc = (*StdPre)(nil)

--- a/ltml/std_pre_test.go
+++ b/ltml/std_pre_test.go
@@ -3,6 +3,7 @@ package ltml
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"testing/fstest"
 
@@ -220,5 +221,72 @@ func TestParse_PreTagSrcOverridesInlineBody(t *testing.T) {
 	}
 	if got := pre.AccessibilityText(); got != "from src" {
 		t.Fatalf("AccessibilityText() = %q, want %q", got, "from src")
+	}
+}
+
+func TestParse_PreTag_InvalidSrcReturnsErrorOnPrint(t *testing.T) {
+	doc, err := Parse([]byte(`
+<ltml>
+  <page>
+    <pre src="../snippet.txt" />
+  </page>
+</ltml>`), WithAssetFS(fstest.MapFS{
+		"snippet.txt": &fstest.MapFile{Data: []byte("unused")},
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pre, ok := doc.Root().Page(0).children[0].(*StdPre)
+	if !ok {
+		t.Fatalf("child type = %T, want *StdPre", doc.Root().Page(0).children[0])
+	}
+
+	err = pre.BeforePrint(newPreTestWriter(t))
+	if err == nil {
+		t.Fatal("BeforePrint() error = nil, want invalid asset path error")
+	}
+	if !strings.Contains(err.Error(), "invalid asset path") {
+		t.Fatalf("BeforePrint() error = %q, want invalid asset path", err)
+	}
+	if got := pre.AccessibilityText(); got != "" {
+		t.Fatalf("AccessibilityText() = %q, want empty on source error", got)
+	}
+}
+
+func TestParse_PreTagSrcRereadsLocalFileOnEachCall(t *testing.T) {
+	dir := t.TempDir()
+	fixture := filepath.Join(dir, "snippet.txt")
+	if err := os.WriteFile(fixture, []byte("one\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	inputPath := filepath.Join(dir, "doc.ltml")
+	if err := os.WriteFile(inputPath, []byte(`
+<ltml>
+  <page>
+    <pre src="snippet.txt" />
+  </page>
+</ltml>`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	doc, err := ParseFile(inputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pre, ok := doc.Root().Page(0).children[0].(*StdPre)
+	if !ok {
+		t.Fatalf("child type = %T, want *StdPre", doc.Root().Page(0).children[0])
+	}
+	if got := pre.AccessibilityText(); got != "one" {
+		t.Fatalf("AccessibilityText() = %q, want %q", got, "one")
+	}
+
+	if err := os.WriteFile(fixture, []byte("two\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := pre.AccessibilityText(); got != "two" {
+		t.Fatalf("AccessibilityText() after rewrite = %q, want %q", got, "two")
 	}
 }

--- a/ltml/std_pre_test.go
+++ b/ltml/std_pre_test.go
@@ -1,7 +1,10 @@
 package ltml
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
+	"testing/fstest"
 
 	"github.com/rowland/leadtype/afm_fonts"
 	"github.com/rowland/leadtype/font"
@@ -126,5 +129,96 @@ func TestParse_PreTag(t *testing.T) {
 		if got[i] != want[i] {
 			t.Fatalf("line %d = %q, want %q", i, got[i], want[i])
 		}
+	}
+}
+
+func TestParse_PreTagSrcLoadsFromAssetFS(t *testing.T) {
+	doc, err := Parse([]byte(`
+<ltml>
+  <page>
+    <pre src="snippet.txt">
+      ignored
+    </pre>
+  </page>
+</ltml>`), WithAssetFS(fstest.MapFS{
+		"snippet.txt": &fstest.MapFile{Data: []byte("first\n  second\n")},
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pre, ok := doc.Root().Page(0).children[0].(*StdPre)
+	if !ok {
+		t.Fatalf("child type = %T, want *StdPre", doc.Root().Page(0).children[0])
+	}
+	want := []string{"first", "  second"}
+	got := pre.Lines()
+	if len(got) != len(want) {
+		t.Fatalf("line count = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("line %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestParse_PreTagSrcLoadsRelativeToParsedFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "snippet.txt"), []byte("alpha\nbeta\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	inputPath := filepath.Join(dir, "doc.ltml")
+	if err := os.WriteFile(inputPath, []byte(`
+<ltml>
+  <page>
+    <pre src="snippet.txt" />
+  </page>
+</ltml>`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	doc, err := ParseFile(inputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pre, ok := doc.Root().Page(0).children[0].(*StdPre)
+	if !ok {
+		t.Fatalf("child type = %T, want *StdPre", doc.Root().Page(0).children[0])
+	}
+	want := []string{"alpha", "beta"}
+	got := pre.Lines()
+	if len(got) != len(want) {
+		t.Fatalf("line count = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("line %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestParse_PreTagSrcOverridesInlineBody(t *testing.T) {
+	doc, err := Parse([]byte(`
+<ltml>
+  <page>
+    <pre src="snippet.txt">
+      ignored inline body
+    </pre>
+  </page>
+</ltml>`), WithAssetFS(fstest.MapFS{
+		"snippet.txt": &fstest.MapFile{Data: []byte("from src")},
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pre, ok := doc.Root().Page(0).children[0].(*StdPre)
+	if !ok {
+		t.Fatalf("child type = %T, want *StdPre", doc.Root().Page(0).children[0])
+	}
+	if got := pre.AccessibilityText(); got != "from src" {
+		t.Fatalf("AccessibilityText() = %q, want %q", got, "from src")
 	}
 }

--- a/ltml/std_svg.go
+++ b/ltml/std_svg.go
@@ -17,7 +17,7 @@ func (svg *StdSVG) LayoutWidget(w Writer) {
 
 func (svg *StdSVG) DrawContent(w Writer) error {
 	return withGraphicAccessibility(w, &svg.StdComponent.StdWidget, "Figure", func() error {
-		if svg.srcExplicit && strings.TrimSpace(svg.src) != "" {
+		if svg.source.Explicit() {
 			ref, err := svg.assetSource()
 			if err != nil {
 				return err
@@ -66,7 +66,7 @@ func (svg *StdSVG) PreferredWidth(w Writer) float64 {
 }
 
 func (svg *StdSVG) svgDimensions(w Writer) (width, height int, err error) {
-	if svg.srcExplicit && strings.TrimSpace(svg.src) != "" {
+	if svg.source.Explicit() {
 		ref, err := svg.assetSource()
 		if err != nil {
 			return 0, 0, err
@@ -88,7 +88,7 @@ func (svg *StdSVG) SetAttrs(attrs map[string]string) {
 }
 
 func (svg *StdSVG) String() string {
-	return fmt.Sprintf("StdSVG src=%s %s", svg.src, &svg.StdComponent.StdWidget)
+	return fmt.Sprintf("StdSVG src=%s %s", svg.source.src, &svg.StdComponent.StdWidget)
 }
 
 func (svg *StdSVG) widthForWriter() *float64 {

--- a/ltml/std_svg_test.go
+++ b/ltml/std_svg_test.go
@@ -139,8 +139,8 @@ func TestStdSVG_DrawContent_UsesContentBoxDimensionsForInlineSVG(t *testing.T) {
 func TestStdSVG_DrawContent_UsesFilePathWhenSrcIsSet(t *testing.T) {
 	svg := &StdSVG{}
 	svg.SetDoc(newDocWithOptions(WithAssetFS(testingMapFS("fixture.svg", `<svg xmlns="http://www.w3.org/2000/svg"></svg>`))))
-	svg.src = "fixture.svg"
-	svg.srcExplicit = true
+	svg.source.src = "fixture.svg"
+	svg.source.srcExplicit = true
 	svg.SetLeft(10)
 	svg.SetTop(20)
 	w := &svgTestWriter{}
@@ -217,8 +217,8 @@ func TestParse_SVGTag_SrcOverridesInlineBody(t *testing.T) {
 	if !ok {
 		t.Fatalf("child type = %T, want *StdSVG", page.children[0])
 	}
-	if svg.src != "logo.svg" {
-		t.Fatalf("src = %q, want logo.svg", svg.src)
+	if svg.source.src != "logo.svg" {
+		t.Fatalf("src = %q, want logo.svg", svg.source.src)
 	}
 	if got := svg.Body(); got == "" {
 		t.Fatal("expected src-loaded body to be retained")

--- a/ltml/text_source.go
+++ b/ltml/text_source.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Brent Rowland.
+// Use of this source code is governed by the Apache License, Version 2.0, as described in the LICENSE file.
+
+package ltml
+
+import (
+	"fmt"
+	"strings"
+)
+
+// textSource centralizes src parsing and asset-resolution behavior for widgets
+// that can resolve body text from either inline content or an external source.
+type textSource struct {
+	src         string
+	srcExplicit bool
+}
+
+func (s *textSource) SetAttrs(attrs map[string]string) {
+	src, ok := attrs["src"]
+	if !ok || strings.TrimSpace(src) == "" {
+		return
+	}
+	s.src = strings.TrimSpace(src)
+	s.srcExplicit = true
+}
+
+func (s *textSource) Explicit() bool {
+	return s.srcExplicit && strings.TrimSpace(s.src) != ""
+}
+
+func (s *textSource) assetSource(doc *Doc, container Container, kind string) (assetSourceRef, error) {
+	if !s.Explicit() {
+		return assetSourceRef{}, nil
+	}
+	if doc == nil {
+		return assetSourceRef{}, fmt.Errorf("%s document is not set", kind)
+	}
+	return doc.resolveAssetSource(container, s.src)
+}
+
+func (s *textSource) Text(doc *Doc, container Container, fallback string, kind string) (string, error) {
+	if !s.Explicit() {
+		return fallback, nil
+	}
+	ref, err := s.assetSource(doc, container, kind)
+	if err != nil {
+		return "", err
+	}
+	if ref.identifier == "" {
+		return "", nil
+	}
+	data, err := readAssetSource(doc, ref)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}


### PR DESCRIPTION
## Summary
- add `src` handling to `ltml.StdPre` so `<pre>` can load external preformatted text through the existing LTML asset resolution rules
- preserve existing inline `<pre>` parsing and whitespace normalization while making `src` take precedence over inline content
- document the new `<pre src>` behavior and add a detailed implementation plan in `docs/ltml-pre-src-plan.md`
- add LTML tests for asset FS loading, `ParseFile` relative-path loading, and `src` overriding inline body

## Testing
- `GOCACHE=/tmp/leadtype-pre-gocache go test ./ltml -run "TestStdPre|TestParse_PreTag|TestComponent_SrcLoadsFromDocAssetFSAndIgnoresInlineBody|TestComponent_SrcLoadsRelativeToParsedFile|TestComponent_BodyRereadsLocalFileOnEachCall"`
- `go build ./...`