### PR TITLE
Add custom font directory support to render-ltml and serve-ltml

### DIFF
--- a/cmd/render-ltml/renderltml/main.go
+++ b/cmd/render-ltml/renderltml/main.go
@@ -49,6 +49,7 @@ func (m *multiFlag) Set(v string) error {
 
 type runConfig struct {
 	assetsDir    string
+	fontDir      string
 	outputPath   string
 	submitURL    string
 	extraFiles   []string
@@ -121,6 +122,7 @@ func Main(ctx context.Context, args []string, stderr io.Writer, registerWidgets 
 	fs.SetOutput(stderr)
 	fs.StringVar(&cfg.assetsDir, "assets", "", "path to asset `directory`")
 	fs.StringVar(&cfg.assetsDir, "a", "", "path to asset `directory` (shorthand)")
+	fs.StringVar(&cfg.fontDir, "font-dir", "", "additional font `directory`")
 	fs.StringVar(&cfg.outputPath, "output", "", "output `file` or batch output `directory`")
 	fs.StringVar(&cfg.outputPath, "o", "", "output `file` or batch output `directory` (shorthand)")
 	fs.StringVar(&cfg.submitURL, "submit", "", "submit to remote render `url` instead of rendering locally")
@@ -400,7 +402,7 @@ func renderJobToFile(cfg runConfig, job renderJob) (err error) {
 	if cfg.submitURL != "" {
 		err = submitRemote(job.inputPath, cfg.assetsDir, cfg.submitURL, cfg.extraFiles, out)
 	} else {
-		err = renderLocal(job.inputPath, cfg.assetsDir, cfg.extraFiles, out)
+		err = renderLocal(job.inputPath, cfg.assetsDir, cfg.fontDir, cfg.extraFiles, out)
 	}
 	if err != nil {
 		return err
@@ -635,7 +637,7 @@ func dirToken(root string) (string, error) {
 	return b.String(), nil
 }
 
-func renderLocal(absInput, assetsDir string, extraFiles []string, out io.Writer) error {
+func renderLocal(absInput, assetsDir, fontDir string, extraFiles []string, out io.Writer) error {
 	assetFS, cleanup, err := buildOptionalAssetFS(assetsDir, extraFiles)
 	if err != nil {
 		return err
@@ -653,7 +655,14 @@ func renderLocal(absInput, assetsDir string, extraFiles []string, out io.Writer)
 		return fmt.Errorf("parsing %s: %w", displayPath(absInput), err)
 	}
 
-	w := ltpdf.NewDocWriter()
+	var fontDirs []string
+	if fontDir != "" {
+		fontDirs = []string{fontDir}
+	}
+	w, err := ltpdf.NewDocWriterWithFontDirs(fontDirs)
+	if err != nil {
+		return fmt.Errorf("initializing font sources: %w", err)
+	}
 	if assetFS != nil {
 		w.SetAssetFS(assetFS)
 	}

--- a/cmd/render-ltml/renderltml/main_test.go
+++ b/cmd/render-ltml/renderltml/main_test.go
@@ -133,7 +133,7 @@ func TestRenderLocal_SetsParserAssetFSForComponentSrc(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	if err := renderLocal(inputFile, assetsDir, nil, &out); err != nil {
+	if err := renderLocal(inputFile, assetsDir, "", nil, &out); err != nil {
 		t.Fatal(err)
 	}
 	if out.Len() == 0 {

--- a/cmd/serve-ltml/serveltml/config.go
+++ b/cmd/serve-ltml/serveltml/config.go
@@ -15,6 +15,7 @@ import (
 type Config struct {
 	Listen         string
 	BasePath       string
+	FontDir        string
 	OutputPath     string
 	MaxUploadBytes int64
 	ReadTimeout    time.Duration
@@ -29,6 +30,7 @@ func parseConfig() (*Config, error) {
 	var (
 		listen         string
 		basePath       string
+		fontDir        string
 		outputPath     string
 		maxUploadBytes int64
 		readTimeout    time.Duration
@@ -38,6 +40,7 @@ func parseConfig() (*Config, error) {
 	flag.StringVar(&listen, "listen", ":8080", "address to listen on (LISTEN)")
 	flag.StringVar(&basePath, "assets", "", "path to static asset directory (ASSETS, required)")
 	flag.StringVar(&basePath, "a", "", "path to static asset directory (shorthand)")
+	flag.StringVar(&fontDir, "font-dir", "", "additional font directory (FONT_DIR)")
 	flag.StringVar(&outputPath, "output-path", "", "root directory for file output (OUTPUT_PATH, optional; enables X-Output-File)")
 	flag.Int64Var(&maxUploadBytes, "max-upload-bytes", 32<<20, "maximum multipart request size in bytes (MAX_UPLOAD_BYTES)")
 	flag.DurationVar(&readTimeout, "read-timeout", 0, "HTTP server read timeout, e.g. 30s (READ_TIMEOUT)")
@@ -56,6 +59,16 @@ func parseConfig() (*Config, error) {
 		return nil, fmt.Errorf("assets %q is not a directory", basePath)
 	}
 
+	if fontDir != "" {
+		info, err := os.Stat(fontDir)
+		if err != nil {
+			return nil, fmt.Errorf("font-dir %q: %w", fontDir, err)
+		}
+		if !info.IsDir() {
+			return nil, fmt.Errorf("font-dir %q is not a directory", fontDir)
+		}
+	}
+
 	if outputPath != "" {
 		info, err := os.Stat(outputPath)
 		if err != nil {
@@ -69,6 +82,7 @@ func parseConfig() (*Config, error) {
 	return &Config{
 		Listen:         listen,
 		BasePath:       basePath,
+		FontDir:        fontDir,
 		OutputPath:     outputPath,
 		MaxUploadBytes: maxUploadBytes,
 		ReadTimeout:    readTimeout,

--- a/cmd/serve-ltml/serveltml/handler.go
+++ b/cmd/serve-ltml/serveltml/handler.go
@@ -196,8 +196,12 @@ func (h *renderHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	overlay := newOverlayFS(uploadFSys, baseFSys)
 	requestLogf(requestID, "rendering ltml: bytes=%d uploads=%d", len(ltmlBytes), uploadCount)
 
+	var fontDirs []string
+	if h.cfg.FontDir != "" {
+		fontDirs = []string{h.cfg.FontDir}
+	}
 	renderStart := time.Now()
-	pdfFile, err := renderLTML(ltmlBytes, overlay, tmpDir)
+	pdfFile, err := renderLTML(ltmlBytes, overlay, tmpDir, fontDirs)
 	if err != nil {
 		elapsedMs := time.Since(renderStart).Milliseconds()
 		requestLogf(requestID, "render: %v", err)

--- a/cmd/serve-ltml/serveltml/handler_test.go
+++ b/cmd/serve-ltml/serveltml/handler_test.go
@@ -199,7 +199,7 @@ func TestRenderLTML_SetsParserAssetFSForUploadedComponentSrc(t *testing.T) {
   <page>
     <xt:card src="snippet.xml" />
   </page>
-</ltml>`), overlay, tmpDir)
+</ltml>`), overlay, tmpDir, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/serve-ltml/serveltml/render.go
+++ b/cmd/serve-ltml/serveltml/render.go
@@ -21,7 +21,7 @@ var errInvalidLTML = errors.New("invalid LTML")
 // open *os.File positioned at the beginning of the PDF. The caller is
 // responsible for closing the file; the file itself lives inside tmpDir
 // and will be removed when tmpDir is cleaned up.
-func renderLTML(ltmlBytes []byte, overlay *overlayFS, tmpDir string) (*os.File, error) {
+func renderLTML(ltmlBytes []byte, overlay *overlayFS, tmpDir string, fontDirs []string) (*os.File, error) {
 	if overlay == nil {
 		return nil, fmt.Errorf("missing asset filesystem")
 	}
@@ -31,7 +31,10 @@ func renderLTML(ltmlBytes []byte, overlay *overlayFS, tmpDir string) (*os.File, 
 		return nil, fmt.Errorf("%w: %v", errInvalidLTML, err)
 	}
 
-	w := ltpdf.NewDocWriter()
+	w, err := ltpdf.NewDocWriterWithFontDirs(fontDirs)
+	if err != nil {
+		return nil, fmt.Errorf("initializing font sources: %w", err)
+	}
 	w.SetAssetFS(overlay)
 
 	if err := doc.Print(w); err != nil {

--- a/ltml/ltpdf/doc_writer.go
+++ b/ltml/ltpdf/doc_writer.go
@@ -58,18 +58,33 @@ func (dw *DocWriter) SetLineCapStyle(style string) (prev string) {
 }
 
 func NewDocWriter() *DocWriter {
+	dw, err := NewDocWriterWithFontDirs(nil)
+	if err != nil {
+		panic(err)
+	}
+	return dw
+}
+
+// NewDocWriterWithFontDirs creates a DocWriter that searches system fonts plus
+// each directory in dirs. It returns an error if any entry in dirs is invalid.
+func NewDocWriterWithFontDirs(dirs []string) (*DocWriter, error) {
 	dw := pdf.NewDocWriter()
 	ttFonts, err := ttf_fonts.NewFromSystemFonts()
 	if err != nil {
-		panic(err)
+		return nil, err
+	}
+	for _, dir := range dirs {
+		if err := ttFonts.AddDir(dir); err != nil {
+			return nil, err
+		}
 	}
 	dw.AddFontSource(ttFonts)
 
 	afmFonts, err := afm_fonts.Default()
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 	dw.AddFontSource(afmFonts)
 
-	return &DocWriter{dw}
+	return &DocWriter{dw}, nil
 }

--- a/ltml/ltpdf/doc_writer.go
+++ b/ltml/ltpdf/doc_writer.go
@@ -5,6 +5,7 @@ package ltpdf
 
 import (
 	"github.com/rowland/leadtype/afm_fonts"
+	"github.com/rowland/leadtype/font"
 	"github.com/rowland/leadtype/pdf"
 	"github.com/rowland/leadtype/ttf_fonts"
 )
@@ -22,8 +23,11 @@ func (dw *DocWriter) EnableTaggedPDF(value bool) {
 }
 
 func (dw *DocWriter) LayoutProbeWriter() any {
-	probe := NewDocWriter()
+	probe := newDocWriterWithFontSources(dw.FontSources())
 	probe.SetAssetFS(dw.AssetFS())
+	if dw.TaggedPDFEnabled() {
+		probe.EnableTaggedPDF(true)
+	}
 	return probe
 }
 
@@ -68,7 +72,6 @@ func NewDocWriter() *DocWriter {
 // NewDocWriterWithFontDirs creates a DocWriter that searches system fonts plus
 // each directory in dirs. It returns an error if any entry in dirs is invalid.
 func NewDocWriterWithFontDirs(dirs []string) (*DocWriter, error) {
-	dw := pdf.NewDocWriter()
 	ttFonts, err := ttf_fonts.NewFromSystemFonts()
 	if err != nil {
 		return nil, err
@@ -78,13 +81,18 @@ func NewDocWriterWithFontDirs(dirs []string) (*DocWriter, error) {
 			return nil, err
 		}
 	}
-	dw.AddFontSource(ttFonts)
-
 	afmFonts, err := afm_fonts.Default()
 	if err != nil {
 		return nil, err
 	}
-	dw.AddFontSource(afmFonts)
 
-	return &DocWriter{dw}, nil
+	return newDocWriterWithFontSources(font.FontSources{ttFonts, afmFonts}), nil
+}
+
+func newDocWriterWithFontSources(sources font.FontSources) *DocWriter {
+	dw := pdf.NewDocWriter()
+	for _, source := range sources {
+		dw.AddFontSource(source)
+	}
+	return &DocWriter{dw}
 }

--- a/ltml/ltpdf/doc_writer_test.go
+++ b/ltml/ltpdf/doc_writer_test.go
@@ -1,8 +1,50 @@
 package ltpdf_test
 
 import (
+	"io/fs"
+	"testing"
+	"testing/fstest"
+
 	"github.com/rowland/leadtype/ltml"
 	"github.com/rowland/leadtype/ltml/ltpdf"
+	"github.com/rowland/leadtype/options"
+	"github.com/rowland/leadtype/pdf"
+	"github.com/rowland/leadtype/ttf_fonts"
 )
 
 var _ ltml.Writer = (*ltpdf.DocWriter)(nil)
+
+func TestDocWriter_LayoutProbeWriterPreservesFontSourcesAndAssetFS(t *testing.T) {
+	customFonts, err := ttf_fonts.New("../../ttf/testdata/minimal.ttf")
+	if err != nil {
+		t.Fatalf("loading custom font source: %v", err)
+	}
+
+	assetFS := fstest.MapFS{
+		"logo.txt": &fstest.MapFile{Data: []byte("asset")},
+	}
+
+	base := &ltpdf.DocWriter{DocWriter: pdf.NewDocWriter()}
+	base.AddFontSource(customFonts)
+	base.SetAssetFS(assetFS)
+	base.EnableTaggedPDF(true)
+
+	probe, ok := base.LayoutProbeWriter().(*ltpdf.DocWriter)
+	if !ok {
+		t.Fatalf("LayoutProbeWriter type = %T, want *ltpdf.DocWriter", base.LayoutProbeWriter())
+	}
+
+	if _, err := probe.SetFont("Minimal", 12, options.Options{}); err != nil {
+		t.Fatalf("probe lost custom font source: %v", err)
+	}
+	if !probe.TaggedPDFEnabled() {
+		t.Fatal("probe should preserve tagged PDF state")
+	}
+	data, err := fs.ReadFile(probe.AssetFS(), "logo.txt")
+	if err != nil {
+		t.Fatalf("probe asset fs read failed: %v", err)
+	}
+	if string(data) != "asset" {
+		t.Fatalf("probe asset fs content = %q, want %q", data, "asset")
+	}
+}

--- a/ttf_fonts/ttf_fonts.go
+++ b/ttf_fonts/ttf_fonts.go
@@ -5,6 +5,7 @@ package ttf_fonts
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -106,6 +107,23 @@ func NewFromSystemFonts() (*TtfFonts, error) {
 		return nil, err
 	}
 	return &fc, nil
+}
+
+// AddDir adds all TTF and TTC fonts found in dir. It returns an error if dir
+// does not exist or is not a directory; errors loading individual font files
+// are silently ignored, matching the behaviour of AddSystemFonts.
+func (fc *TtfFonts) AddDir(dir string) error {
+	info, err := os.Stat(dir)
+	if err != nil {
+		return fmt.Errorf("font directory %q: %w", dir, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("font directory %q is not a directory", dir)
+	}
+	for _, ext := range []string{"*.ttf", "*.TTF", "*.ttc", "*.TTC"} {
+		fc.Add(filepath.Join(dir, ext)) // errors loading individual fonts are non-fatal
+	}
+	return nil
 }
 
 // AddSystemFonts adds all TTF and TTC fonts found in the platform's standard


### PR DESCRIPTION
Introduces -font-dir flag for render-ltml and FONT_DIR/-font-dir for
serve-ltml so both tools can load fonts from an additional directory
alongside OS system fonts. This is especially needed when serve-ltml
runs in a Linux container with few or no system fonts installed.

https://claude.ai/code/session_01GmSx4yC6x9VVgHk7x9paqd