### PR TITLE
Add built-in paper size catalogs and Avery label support

### DIFF
--- a/avery/labelsheet.go
+++ b/avery/labelsheet.go
@@ -1,0 +1,349 @@
+package avery
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/rowland/leadtype/colors"
+	"github.com/rowland/leadtype/ltml"
+	"github.com/rowland/leadtype/options"
+)
+
+const Namespace = "avery"
+
+type Stock struct {
+	ID              string
+	SheetWidth      float64
+	SheetHeight     float64
+	LabelWidth      float64
+	LabelHeight     float64
+	Columns         int
+	Rows            int
+	LeftMargin      float64
+	TopMargin       float64
+	HorizontalPitch float64
+	VerticalPitch   float64
+	Aliases         []string
+}
+
+type LabelSheet struct {
+	ltml.StdContainer
+	stockID     string
+	showMetrics bool
+	showOutline bool
+}
+
+type Label struct {
+	ltml.StdContainer
+	text *ltml.StdParagraph
+}
+
+var builtInStocks = []Stock{
+	{
+		ID:              "avery5160",
+		SheetWidth:      inchesToPoints(8.5),
+		SheetHeight:     inchesToPoints(11),
+		LabelWidth:      inchesToPoints(2.625),
+		LabelHeight:     inchesToPoints(1.0),
+		Columns:         3,
+		Rows:            10,
+		LeftMargin:      inchesToPoints(0.1875),
+		TopMargin:       inchesToPoints(0.5),
+		HorizontalPitch: inchesToPoints(2.75),
+		VerticalPitch:   inchesToPoints(1.0),
+		Aliases:         []string{"5160", "8160"},
+	},
+	{
+		ID:              "avery5161",
+		SheetWidth:      inchesToPoints(8.5),
+		SheetHeight:     inchesToPoints(11),
+		LabelWidth:      inchesToPoints(4.0),
+		LabelHeight:     inchesToPoints(1.0),
+		Columns:         2,
+		Rows:            10,
+		LeftMargin:      inchesToPoints(0.1875),
+		TopMargin:       inchesToPoints(0.5),
+		HorizontalPitch: inchesToPoints(4.125),
+		VerticalPitch:   inchesToPoints(1.0),
+		Aliases:         []string{"5161", "8161"},
+	},
+	{
+		ID:              "avery5162",
+		SheetWidth:      inchesToPoints(8.5),
+		SheetHeight:     inchesToPoints(11),
+		LabelWidth:      inchesToPoints(4.0),
+		LabelHeight:     inchesToPoints(4.0 / 3.0),
+		Columns:         2,
+		Rows:            7,
+		LeftMargin:      inchesToPoints(0.1875),
+		TopMargin:       inchesToPoints(0.5),
+		HorizontalPitch: inchesToPoints(4.125),
+		VerticalPitch:   inchesToPoints(4.0 / 3.0),
+		Aliases:         []string{"5162", "8162"},
+	},
+	{
+		ID:              "avery5163",
+		SheetWidth:      inchesToPoints(8.5),
+		SheetHeight:     inchesToPoints(11),
+		LabelWidth:      inchesToPoints(4.0),
+		LabelHeight:     inchesToPoints(2.0),
+		Columns:         2,
+		Rows:            5,
+		LeftMargin:      inchesToPoints(0.1875),
+		TopMargin:       inchesToPoints(0.5),
+		HorizontalPitch: inchesToPoints(4.125),
+		VerticalPitch:   inchesToPoints(2.0),
+		Aliases:         []string{"5163", "8163"},
+	},
+	{
+		ID:              "avery5164",
+		SheetWidth:      inchesToPoints(8.5),
+		SheetHeight:     inchesToPoints(11),
+		LabelWidth:      inchesToPoints(10.0 / 3.0),
+		LabelHeight:     inchesToPoints(4.0),
+		Columns:         2,
+		Rows:            3,
+		LeftMargin:      inchesToPoints(0.15625),
+		TopMargin:       inchesToPoints(0.5),
+		HorizontalPitch: inchesToPoints(4.1875),
+		VerticalPitch:   inchesToPoints(3.5),
+		Aliases:         []string{"5164", "8164"},
+	},
+	{
+		ID:              "avery5167",
+		SheetWidth:      inchesToPoints(8.5),
+		SheetHeight:     inchesToPoints(11),
+		LabelWidth:      inchesToPoints(1.75),
+		LabelHeight:     inchesToPoints(0.5),
+		Columns:         4,
+		Rows:            20,
+		LeftMargin:      inchesToPoints(0.25),
+		TopMargin:       inchesToPoints(0.5),
+		HorizontalPitch: inchesToPoints(2.0),
+		VerticalPitch:   inchesToPoints(0.5),
+		Aliases:         []string{"5167", "8167"},
+	},
+	{
+		ID:              "avery5366",
+		SheetWidth:      inchesToPoints(8.5),
+		SheetHeight:     inchesToPoints(11),
+		LabelWidth:      inchesToPoints(3.4375),
+		LabelHeight:     inchesToPoints(2.0 / 3.0),
+		Columns:         2,
+		Rows:            15,
+		LeftMargin:      inchesToPoints(0.5625),
+		TopMargin:       inchesToPoints(0.5),
+		HorizontalPitch: inchesToPoints(3.875),
+		VerticalPitch:   inchesToPoints(2.0 / 3.0),
+		Aliases:         []string{"5366"},
+	},
+	{
+		ID:              "avery5395",
+		SheetWidth:      inchesToPoints(8.5),
+		SheetHeight:     inchesToPoints(11),
+		LabelWidth:      inchesToPoints(3.375),
+		LabelHeight:     inchesToPoints(7.0 / 3.0),
+		Columns:         2,
+		Rows:            4,
+		LeftMargin:      inchesToPoints(0.6875),
+		TopMargin:       inchesToPoints(0.55),
+		HorizontalPitch: inchesToPoints(3.75),
+		VerticalPitch:   inchesToPoints(2.5233333333333334),
+		Aliases:         []string{"5395"},
+	},
+}
+
+var builtInStocksByID = initBuiltInStocks()
+
+func init() {
+	if err := ltml.RegisterTag(Namespace, "labelsheet", func() any { return &LabelSheet{} }); err != nil {
+		panic(err)
+	}
+	if err := ltml.RegisterTag(Namespace, "label", func() any { return &Label{} }); err != nil {
+		panic(err)
+	}
+}
+
+func LookupStock(id string) (Stock, bool) {
+	stock, ok := builtInStocksByID[normalizeStockID(id)]
+	return stock, ok
+}
+
+func Stocks() []Stock {
+	out := make([]Stock, len(builtInStocks))
+	copy(out, builtInStocks)
+	return out
+}
+
+func (ls *LabelSheet) BeforePrint(w ltml.Writer) error {
+	stock, ok := LookupStock(ls.stockID)
+	if !ok {
+		return fmt.Errorf("unknown avery labelsheet stock %q", ls.stockID)
+	}
+	if len(ls.Widgets()) > stock.Columns*stock.Rows {
+		return fmt.Errorf("avery labelsheet stock %q holds %d labels, got %d", stock.ID, stock.Columns*stock.Rows, len(ls.Widgets()))
+	}
+	return ls.StdContainer.BeforePrint(w)
+}
+
+func (ls *LabelSheet) DrawContent(w ltml.Writer) error {
+	stock, ok := LookupStock(ls.stockID)
+	if !ok {
+		return fmt.Errorf("unknown avery labelsheet stock %q", ls.stockID)
+	}
+	if ls.showOutline {
+		w.SetLineColor(colors.DimGray)
+		w.SetLineWidth(0.4)
+		w.SetLineDashPattern("solid")
+		w.SetLineCapStyle("butt_cap")
+		for row := 0; row < stock.Rows; row++ {
+			for col := 0; col < stock.Columns; col++ {
+				x := ls.Left() + stock.LeftMargin + float64(col)*stock.HorizontalPitch
+				y := ls.Top() + stock.TopMargin + float64(row)*stock.VerticalPitch
+				w.Rectangle2(x, y, stock.LabelWidth, stock.LabelHeight, true, false, nil, false, false)
+			}
+		}
+	}
+	if ls.showMetrics {
+		if _, err := w.SetFont("Helvetica", 10, options.Options{"color": colors.DimGray}); err != nil {
+			return err
+		}
+		w.MoveTo(ls.Left()+6, ls.Top()+14)
+		if err := w.Print(fmt.Sprintf("Avery stock: %s  %.3fin x %.3fin  %dx%d  order=%s", stock.ID, stock.LabelWidth/72.0, stock.LabelHeight/72.0, stock.Columns, stock.Rows, orderName(ls.Order()))); err != nil {
+			return err
+		}
+	}
+	children := slices.Clone(ls.Widgets())
+	slices.SortStableFunc(children, func(a, b ltml.Widget) int {
+		return a.ZIndex() - b.ZIndex()
+	})
+	for _, child := range children {
+		if !child.Visible() || child.Disabled() {
+			continue
+		}
+		if err := ltml.Print(child, w); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (ls *LabelSheet) LayoutWidget(w ltml.Writer) {
+	stock, ok := LookupStock(ls.stockID)
+	if !ok {
+		return
+	}
+	ls.applySheetGeometry(stock)
+	for i, child := range ls.Widgets() {
+		row, col := slotPosition(i, stock, ls.Order())
+		child.SetPosition(ltml.Static)
+		child.SetVisible(true)
+		child.SetLeft(ls.Left() + stock.LeftMargin + float64(col)*stock.HorizontalPitch)
+		child.SetTop(ls.Top() + stock.TopMargin + float64(row)*stock.VerticalPitch)
+		child.SetWidth(stock.LabelWidth)
+		child.SetHeight(stock.LabelHeight)
+		child.LayoutWidget(w)
+	}
+}
+
+func (ls *LabelSheet) PreferredHeight(ltml.Writer) float64 {
+	if ls.HeightIsSet() {
+		return ls.Height()
+	}
+	stock, ok := LookupStock(ls.stockID)
+	if !ok {
+		return 0
+	}
+	return stock.SheetHeight
+}
+
+func (ls *LabelSheet) PreferredWidth(ltml.Writer) float64 {
+	if ls.WidthIsSet() {
+		return ls.Width()
+	}
+	stock, ok := LookupStock(ls.stockID)
+	if !ok {
+		return 0
+	}
+	return stock.SheetWidth
+}
+
+func (ls *LabelSheet) SetAttrs(attrs map[string]string) {
+	ls.StdContainer.SetAttrs(attrs)
+	ls.stockID = attrs["stock"]
+	ls.showMetrics = attrs["show-metrics"] == "true"
+	ls.showOutline = attrs["show-outline"] == "true"
+}
+
+func (ls *LabelSheet) applySheetGeometry(stock Stock) {
+	if !ls.WidthIsSet() {
+		ls.SetWidth(stock.SheetWidth)
+	}
+	if !ls.HeightIsSet() {
+		ls.SetHeight(stock.SheetHeight)
+	}
+}
+
+func (l *Label) AddText(text string) {
+	if strings.TrimSpace(text) == "" {
+		return
+	}
+	l.ensureTextParagraph().AddText(text)
+}
+
+func (l *Label) SetAttrs(attrs map[string]string) {
+	l.StdContainer.SetAttrs(attrs)
+}
+
+func (l *Label) ensureTextParagraph() *ltml.StdParagraph {
+	if l.text != nil {
+		return l.text
+	}
+	l.text = &ltml.StdParagraph{}
+	l.text.SetScope(l.Scope())
+	l.text.SetContainer(l)
+	l.text.SetAttrs(map[string]string{"width": "100%", "height": "100%"})
+	l.AddChild(l.text)
+	return l.text
+}
+
+func inchesToPoints(inches float64) float64 {
+	return inches * 72.0
+}
+
+func initBuiltInStocks() map[string]Stock {
+	byID := make(map[string]Stock, len(builtInStocks)*2)
+	for _, stock := range builtInStocks {
+		byID[normalizeStockID(stock.ID)] = stock
+		for _, alias := range stock.Aliases {
+			byID[normalizeStockID(alias)] = stock
+		}
+	}
+	return byID
+}
+
+func normalizeStockID(id string) string {
+	return strings.ToLower(strings.TrimSpace(id))
+}
+
+func slotPosition(index int, stock Stock, order ltml.TableOrder) (row, col int) {
+	switch order {
+	case ltml.TableOrderCols:
+		col = index / stock.Rows
+		row = index % stock.Rows
+	default:
+		row = index / stock.Columns
+		col = index % stock.Columns
+	}
+	return row, col
+}
+
+func orderName(order ltml.TableOrder) string {
+	switch order {
+	case ltml.TableOrderCols:
+		return "cols"
+	default:
+		return "rows"
+	}
+}

--- a/avery/labelsheet_test.go
+++ b/avery/labelsheet_test.go
@@ -1,0 +1,363 @@
+package avery
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/rowland/leadtype/colors"
+	"github.com/rowland/leadtype/font"
+	"github.com/rowland/leadtype/ltml"
+	"github.com/rowland/leadtype/options"
+	"github.com/rowland/leadtype/pdf"
+	"github.com/rowland/leadtype/rich_text"
+)
+
+type testWriter struct {
+	rectCount int
+	printed   []string
+}
+
+func (w *testWriter) Arch(x, y, r1, r2, startAngle, endAngle float64, border, fill, reverse bool) error {
+	return nil
+}
+func (w *testWriter) Arc(x, y, r, startAngle, endAngle float64, moveToStart bool) error { return nil }
+func (w *testWriter) Clip(fn func()) error {
+	if fn != nil {
+		fn()
+	}
+	return nil
+}
+func (w *testWriter) ClipClosedShape(shape pdf.ClosedShape, fn func()) error {
+	if fn != nil {
+		fn()
+	}
+	return nil
+}
+func (w *testWriter) ClipRichText(text *rich_text.RichText, fn func()) error {
+	if fn != nil {
+		fn()
+	}
+	return nil
+}
+func (w *testWriter) ClipText(text string, fn func()) error {
+	if fn != nil {
+		fn()
+	}
+	return nil
+}
+func (w *testWriter) ClosedShapeBounds(shape pdf.ClosedShape) (pdf.Bounds, error) {
+	return shape.Bounds()
+}
+func (w *testWriter) DrawRichTextOnCircle(text *rich_text.RichText, x, y, r, startAngle float64, opts pdf.CurvedTextOptions) error {
+	return nil
+}
+func (w *testWriter) DrawTextOnCircle(text string, x, y, r, startAngle float64, opts pdf.CurvedTextOptions) error {
+	return nil
+}
+func (w *testWriter) DrawClosedShape(shape pdf.ClosedShape, border, fill bool) error { return nil }
+func (w *testWriter) EnableTaggedPDF(bool)                                           {}
+func (w *testWriter) Circle(x, y, r float64, border, fill, reverse bool) error       { return nil }
+func (w *testWriter) Ellipse(x, y, rx, ry float64, border, fill, reverse bool) error { return nil }
+func (w *testWriter) FontColor() colors.Color                                        { return colors.Black }
+func (w *testWriter) Fonts() []*font.Font                                            { return nil }
+func (w *testWriter) FontSize() float64                                              { return 12 }
+func (w *testWriter) ImageDimensions(data []byte) (width, height int, err error)     { return 0, 0, nil }
+func (w *testWriter) SVGDimensions(data []byte) (width, height int, err error)       { return 0, 0, nil }
+func (w *testWriter) SVGDimensionsFromFile(filename string) (width, height int, err error) {
+	return 0, 0, nil
+}
+func (w *testWriter) ImageDimensionsFromFile(filename string) (width, height int, err error) {
+	return 0, 0, nil
+}
+func (w *testWriter) LineSpacing() float64                       { return 1.0 }
+func (w *testWriter) SetLineCapStyle(style string) (prev string) { return "" }
+func (w *testWriter) Line(x, y, angle, length float64)           {}
+func (w *testWriter) LineTo(x, y float64)                        {}
+func (w *testWriter) Loc() (x, y float64)                        { return 0, 0 }
+func (w *testWriter) MoveTo(x, y float64)                        {}
+func (w *testWriter) NewPage()                                   {}
+func (w *testWriter) Print(text string) error                    { w.printed = append(w.printed, text); return nil }
+func (w *testWriter) PrintImage(data []byte, x, y float64, width, height *float64) (actualWidth, actualHeight float64, err error) {
+	return 0, 0, nil
+}
+func (w *testWriter) PrintSVG(data []byte, x, y float64, width, height *float64) (actualWidth, actualHeight float64, err error) {
+	return 0, 0, nil
+}
+func (w *testWriter) PrintSVGFile(filename string, x, y float64, width, height *float64) (actualWidth, actualHeight float64, err error) {
+	return 0, 0, nil
+}
+func (w *testWriter) PrintImageFile(filename string, x, y float64, width, height *float64) (actualWidth, actualHeight float64, err error) {
+	return 0, 0, nil
+}
+func (w *testWriter) PaintImageFile(filename string, x, y, width, height, opacity float64) error {
+	return nil
+}
+func (w *testWriter) PaintLinearGradient(lg *pdf.LinearGradient) error                   { return nil }
+func (w *testWriter) PaintRadialGradient(rg *pdf.RadialGradient) error                   { return nil }
+func (w *testWriter) PrintParagraph(para []*rich_text.RichText, options options.Options) {}
+func (w *testWriter) PrintRichText(text *rich_text.RichText)                             {}
+func (w *testWriter) Path(fn func()) error {
+	if fn != nil {
+		fn()
+	}
+	return nil
+}
+func (w *testWriter) Pie(x, y, r, startAngle, endAngle float64, border, fill, reverse bool) error {
+	return nil
+}
+func (w *testWriter) Polygon(x, y, r float64, sides int, border, fill, reverse bool, rotation float64) error {
+	return nil
+}
+func (w *testWriter) Rectangle(x, y, width, height float64, border bool, fill bool) {}
+func (w *testWriter) Rectangle2(x, y, width, height float64, border bool, fill bool, corners []float64, path, reverse bool) {
+	w.rectCount++
+}
+func (w *testWriter) Rotate(angle, x, y float64, fn func()) error {
+	if fn != nil {
+		fn()
+	}
+	return nil
+}
+func (w *testWriter) AddFont(family string, options options.Options) ([]*font.Font, error) {
+	return nil, nil
+}
+func (w *testWriter) SetFont(name string, size float64, options options.Options) ([]*font.Font, error) {
+	return nil, nil
+}
+func (w *testWriter) SetFillColor(value any) (prev colors.Color)          { return colors.Black }
+func (w *testWriter) SetFillLinearGradient(lg *pdf.LinearGradient) error  { return nil }
+func (w *testWriter) SetFillRadialGradient(rg *pdf.RadialGradient) error  { return nil }
+func (w *testWriter) ClearFillGradient()                                  {}
+func (w *testWriter) SetLineColor(value colors.Color) (prev colors.Color) { return colors.Black }
+func (w *testWriter) SetLineDashPattern(pattern string) (prev string)     { return "" }
+func (w *testWriter) SetLineSpacing(lineSpacing float64) (prev float64)   { return 1.0 }
+func (w *testWriter) SetLineWidth(width float64)                          {}
+func (w *testWriter) SetStrikeout(strikeout bool) (prev bool)             { return false }
+func (w *testWriter) SetUnderline(underline bool) (prev bool)             { return false }
+func (w *testWriter) Star(x, y, r1, r2 float64, points int, border, fill, reverse bool, rotation float64) error {
+	return nil
+}
+func (w *testWriter) Stroke() error { return nil }
+func (w *testWriter) Strikeout() bool {
+	return false
+}
+func (w *testWriter) TaggedPDFEnabled() bool { return false }
+func (w *testWriter) Underline() bool        { return false }
+func (w *testWriter) WithAccessibilityArtifact(fn func()) error {
+	if fn != nil {
+		fn()
+	}
+	return nil
+}
+func (w *testWriter) WithAccessibilityTag(tag string, opts pdf.AccessibilityOptions, fn func()) error {
+	if fn != nil {
+		fn()
+	}
+	return nil
+}
+
+func TestLookupStock_CanonicalAndAlias(t *testing.T) {
+	canonical, ok := LookupStock("avery5160")
+	if !ok {
+		t.Fatal("avery5160 stock not found")
+	}
+	alias, ok := LookupStock("8160")
+	if !ok {
+		t.Fatal("8160 alias not found")
+	}
+	if canonical.ID != alias.ID {
+		t.Fatalf("alias resolved to %q, want %q", alias.ID, canonical.ID)
+	}
+}
+
+func TestLookupStock_Geometry(t *testing.T) {
+	tests := []struct {
+		id          string
+		labelWidth  float64
+		labelHeight float64
+		columns     int
+		rows        int
+	}{
+		{id: "5160", labelWidth: 2.625 * 72, labelHeight: 1.0 * 72, columns: 3, rows: 10},
+		{id: "5163", labelWidth: 4.0 * 72, labelHeight: 2.0 * 72, columns: 2, rows: 5},
+		{id: "5167", labelWidth: 1.75 * 72, labelHeight: 0.5 * 72, columns: 4, rows: 20},
+		{id: "5395", labelWidth: 3.375 * 72, labelHeight: (7.0 / 3.0) * 72, columns: 2, rows: 4},
+	}
+	for _, tt := range tests {
+		stock, ok := LookupStock(tt.id)
+		if !ok {
+			t.Fatalf("%s stock not found", tt.id)
+		}
+		if got := stock.Columns; got != tt.columns {
+			t.Fatalf("%s columns = %d, want %d", tt.id, got, tt.columns)
+		}
+		if got := stock.Rows; got != tt.rows {
+			t.Fatalf("%s rows = %d, want %d", tt.id, got, tt.rows)
+		}
+		if got := stock.LabelWidth; got != tt.labelWidth {
+			t.Fatalf("%s label width = %v, want %v", tt.id, got, tt.labelWidth)
+		}
+		if got := stock.LabelHeight; got != tt.labelHeight {
+			t.Fatalf("%s label height = %v, want %v", tt.id, got, tt.labelHeight)
+		}
+	}
+}
+
+func TestLabelSheet_PrintDrawsExpectedCellCount(t *testing.T) {
+	doc, err := ltml.Parse([]byte(`
+		<ltml xmlns:avery="avery">
+			<page style="letter" margin="0">
+				<avery:labelsheet stock="5160" show-metrics="true" show-outline="true"/>
+			</page>
+		</ltml>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := &testWriter{}
+	if err := doc.Print(w); err != nil {
+		t.Fatal(err)
+	}
+	if got := w.rectCount; got != 30 {
+		t.Fatalf("rect count = %d, want 30", got)
+	}
+	if len(w.printed) == 0 || !strings.Contains(w.printed[0], "Avery stock: avery5160") {
+		t.Fatalf("first printed text = %q, want avery metrics", firstPrinted(w.printed))
+	}
+}
+
+func TestLabelSheet_LaysOutLabelsByRows(t *testing.T) {
+	doc, err := ltml.Parse([]byte(`
+		<ltml xmlns:avery="avery">
+			<page style="letter" margin="0">
+				<avery:labelsheet stock="5160" order="rows">
+					<avery:label>One</avery:label>
+					<avery:label>Two</avery:label>
+					<avery:label>Three</avery:label>
+					<avery:label>Four</avery:label>
+				</avery:labelsheet>
+			</page>
+		</ltml>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := &testWriter{}
+	if err := doc.Print(w); err != nil {
+		t.Fatal(err)
+	}
+
+	page := doc.Page(0)
+	sheet, ok := page.Widgets()[0].(*LabelSheet)
+	if !ok {
+		t.Fatalf("page child type = %T, want *LabelSheet", page.Widgets()[0])
+	}
+	if len(sheet.Widgets()) != 4 {
+		t.Fatalf("label count = %d, want 4", len(sheet.Widgets()))
+	}
+	first := sheet.Widgets()[0]
+	second := sheet.Widgets()[1]
+	third := sheet.Widgets()[2]
+	fourth := sheet.Widgets()[3]
+
+	if first.Left() != 13.5 || first.Top() != 36 {
+		t.Fatalf("first label at (%v,%v), want (13.5,36)", first.Left(), first.Top())
+	}
+	if second.Left() != 211.5 || second.Top() != 36 {
+		t.Fatalf("second label at (%v,%v), want (211.5,36)", second.Left(), second.Top())
+	}
+	if third.Left() != 409.5 || third.Top() != 36 {
+		t.Fatalf("third label at (%v,%v), want (409.5,36)", third.Left(), third.Top())
+	}
+	if fourth.Left() != 13.5 || fourth.Top() != 108 {
+		t.Fatalf("fourth label at (%v,%v), want (13.5,108)", fourth.Left(), fourth.Top())
+	}
+}
+
+func TestLabelSheet_LaysOutLabelsByCols(t *testing.T) {
+	doc, err := ltml.Parse([]byte(`
+		<ltml xmlns:avery="avery">
+			<page style="letter" margin="0">
+				<avery:labelsheet stock="5163" order="cols">
+					<avery:label>One</avery:label>
+					<avery:label>Two</avery:label>
+					<avery:label>Three</avery:label>
+				</avery:labelsheet>
+			</page>
+		</ltml>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := &testWriter{}
+	if err := doc.Print(w); err != nil {
+		t.Fatal(err)
+	}
+
+	page := doc.Page(0)
+	sheet := page.Widgets()[0].(*LabelSheet)
+	first := sheet.Widgets()[0]
+	second := sheet.Widgets()[1]
+	third := sheet.Widgets()[2]
+
+	if first.Left() != 13.5 || first.Top() != 36 {
+		t.Fatalf("first label at (%v,%v), want (13.5,36)", first.Left(), first.Top())
+	}
+	if second.Left() != 13.5 || second.Top() != 180 {
+		t.Fatalf("second label at (%v,%v), want (13.5,180)", second.Left(), second.Top())
+	}
+	if third.Left() != 13.5 || third.Top() != 324 {
+		t.Fatalf("third label at (%v,%v), want (13.5,324)", third.Left(), third.Top())
+	}
+}
+
+func TestLabelSheet_PrintUnknownStockFailsClearly(t *testing.T) {
+	doc, err := ltml.Parse([]byte(`
+		<ltml xmlns:avery="avery">
+			<page style="letter" margin="0">
+				<avery:labelsheet stock="bogus"/>
+			</page>
+		</ltml>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := &testWriter{}
+	err = doc.Print(w)
+	if err == nil || !strings.Contains(err.Error(), `unknown avery labelsheet stock "bogus"`) {
+		t.Fatalf("print err = %v, want unknown stock error", err)
+	}
+}
+
+func TestLabelSheet_RejectsTooManyLabels(t *testing.T) {
+	doc, err := ltml.Parse([]byte(`
+		<ltml xmlns:avery="avery">
+			<page style="letter" margin="0">
+				<avery:labelsheet stock="5395">
+					<avery:label>1</avery:label>
+					<avery:label>2</avery:label>
+					<avery:label>3</avery:label>
+					<avery:label>4</avery:label>
+					<avery:label>5</avery:label>
+					<avery:label>6</avery:label>
+					<avery:label>7</avery:label>
+					<avery:label>8</avery:label>
+					<avery:label>9</avery:label>
+				</avery:labelsheet>
+			</page>
+		</ltml>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := &testWriter{}
+	err = doc.Print(w)
+	if err == nil || !strings.Contains(err.Error(), `avery labelsheet stock "avery5395" holds 8 labels, got 9`) {
+		t.Fatalf("print err = %v, want overflow error", err)
+	}
+}
+
+func firstPrinted(values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	return values[0]
+}

--- a/ltml/SYNTAX.md
+++ b/ltml/SYNTAX.md
@@ -808,20 +808,27 @@ Pre-defines a named layout configuration that can be referenced by containers.
 
 **Built-in page sizes** (set via `style` on `<page>`):
 
-| Name     | Width × Height (pt) |
-|----------|---------------------|
-| `letter` | 612 × 792 (default) |
-| `legal`  | 612 × 1008 |
-| `A4`     | 595 × 842 |
-| `B5`     | 499 × 708 |
-| `C5`     | 459 × 649 |
+- ISO A: `A0` through `A10`
+- ISO B: `B0` through `B10`
+- ISO C: `C0` through `C10`
+- ISO raw: `RA0` through `RA4`, `SRA0` through `SRA4`
+- North American: `halfletter`, `statement`, `letter`, `legal`,
+  `juniorlegal`, `tabloid`, `ledger`, `governmentletter`,
+  `governmentlegal`, `executive`, `folio`, `quarto`
+- ANSI: `ansia` through `ansie`
+- ARCH: `archa`, `archb`, `archc`, `archd`, `arche`, `arche1`, `arche2`,
+  `arche3`
 
-The `orientation` attribute (`portrait` or `landscape`) swaps width and height
-when combined with `style`. Explicit `width` and `height` values can also be
-set directly on `<page>` to use a one-off custom page size.
+Built-in page-size lookup is case-insensitive, so `A4` and `a4` resolve to the
+same built-in size. `letter` remains the default page size.
+
+The page-style override attribute `style.orientation` (`portrait` or
+`landscape`) swaps width and height when combined with `style`. Explicit
+`width` and `height` values can also be set directly on `<page>` to use a
+one-off custom page size.
 
 ```xml
-<page style="A4" orientation="landscape" units="cm" margin="2">
+<page style="A4" style.orientation="landscape" units="cm" margin="2">
   <!-- content -->
 </page>
 ```
@@ -848,6 +855,70 @@ not yet been opened (typically at the top of the document):
 
 Once defined, the name is available to all subsequent `<page>` elements in the
 same scope, just like the built-in size names.
+
+#### Avery extension package
+
+Avery label-stock support is provided by the optional
+`github.com/rowland/leadtype/avery` package rather than the core `std`
+namespace. Import it for registration, then use the `avery` XML namespace:
+
+```go
+import _ "github.com/rowland/leadtype/avery"
+```
+
+```xml
+<ltml xmlns:avery="avery">
+  <page style="letter" margin="0">
+    <avery:labelsheet stock="5160" show-metrics="true" show-outline="true">
+      <avery:label border="thin" padding="6pt">
+        <p font.weight="Bold">Jamie Smith</p>
+        <p>123 Main St</p>
+        <p>Seattle, WA 98101</p>
+      </avery:label>
+      <avery:label border="thin" padding="6pt">
+        <p font.weight="Bold">Morgan Lee</p>
+        <p>987 Market Ave</p>
+        <p>Portland, OR 97205</p>
+      </avery:label>
+    </avery:labelsheet>
+  </page>
+</ltml>
+```
+
+The extension currently includes this built-in catalog of Avery-compatible US
+Letter label stocks:
+
+| Canonical ID | Accepted Aliases | Layout |
+|--------------|------------------|--------|
+| `avery5160` | `5160`, `8160` | 3 × 10 labels, 1" × 2-5/8" |
+| `avery5161` | `5161`, `8161` | 2 × 10 labels, 1" × 4" |
+| `avery5162` | `5162`, `8162` | 2 × 7 labels, 1-1/3" × 4" |
+| `avery5163` | `5163`, `8163` | 2 × 5 labels, 2" × 4" |
+| `avery5164` | `5164`, `8164` | 2 × 3 labels, 3-1/3" × 4" |
+| `avery5167` | `5167`, `8167` | 4 × 20 labels, 1/2" × 1-3/4" |
+| `avery5366` | `5366` | 2 × 15 labels, 2/3" × 3-7/16" |
+| `avery5395` | `5395` | 2 × 4 badges, 2-1/3" × 3-3/8" |
+
+`<avery:labelsheet>` attributes:
+
+| Attribute | Description |
+|-----------|-------------|
+| `stock` | Built-in stock id or alias. Required. |
+| `order` | Fill order for child labels: `rows` (default) or `cols`. |
+| `show-metrics` | When `true`, prints a compact appendix caption with the canonical stock id, label size, and grid count. |
+| `show-outline` | When `true`, draws the full stock grid as an overlay, which is useful for samples and calibration. |
+| `border`, `font.*`, `font`, positioning attrs | Standard widget styling/positioning attrs still apply. |
+
+`<avery:labelsheet>` behaves like a stock-backed label table:
+
+- Each direct `<avery:label>` child occupies one label slot.
+- Slot width, height, row count, column count, and gutter spacing come from the selected stock.
+- Children are filled across rows by default, or down columns when `order="cols"`.
+- Printing fails with a clear error if the number of child labels exceeds the stock capacity.
+
+`<avery:label>` is the author-facing label cell tag. It behaves like a small
+container, so standard widget styling such as `padding`, `border`, `fill`, and
+nested content like `<p>` and `<label>` can be used inside each label.
 
 ---
 

--- a/ltml/avery_sample_external_test.go
+++ b/ltml/avery_sample_external_test.go
@@ -1,0 +1,214 @@
+package ltml_test
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/rowland/leadtype/afm_fonts"
+	_ "github.com/rowland/leadtype/avery"
+	"github.com/rowland/leadtype/colors"
+	"github.com/rowland/leadtype/font"
+	"github.com/rowland/leadtype/ltml"
+	"github.com/rowland/leadtype/options"
+	"github.com/rowland/leadtype/pdf"
+	"github.com/rowland/leadtype/rich_text"
+)
+
+func TestSample_PaperCatalogsRender(t *testing.T) {
+	_, file, _, _ := runtime.Caller(0)
+	samples := []string{
+		"test_051_paper_sizes.ltml",
+		"test_052_large_paper_sizes.ltml",
+		"test_053_avery_labels.ltml",
+	}
+	for _, name := range samples {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			sample := filepath.Join(filepath.Dir(file), "samples", name)
+			doc, err := ltml.ParseFile(sample)
+			if err != nil {
+				t.Fatal(err)
+			}
+			w := &sampleTestWriter{t: t}
+			if err := doc.Print(w); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+type sampleTestWriter struct {
+	fonts    []*font.Font
+	fontSize float64
+	t        testing.TB
+}
+
+func (w *sampleTestWriter) ensureFonts() []*font.Font {
+	if len(w.fonts) != 0 {
+		return w.fonts
+	}
+	fontSource, err := afm_fonts.Default()
+	if err != nil {
+		w.t.Fatal(err)
+	}
+	face, err := font.New("Helvetica", options.Options{"size": 12.0}, font.FontSources{fontSource})
+	if err != nil {
+		w.t.Fatal(err)
+	}
+	w.fonts = []*font.Font{face}
+	return w.fonts
+}
+
+func (w *sampleTestWriter) Arch(x, y, r1, r2, startAngle, endAngle float64, border, fill, reverse bool) error {
+	return nil
+}
+func (w *sampleTestWriter) Arc(x, y, r, startAngle, endAngle float64, moveToStart bool) error {
+	return nil
+}
+func (w *sampleTestWriter) Clip(fn func()) error {
+	if fn != nil {
+		fn()
+	}
+	return nil
+}
+func (w *sampleTestWriter) ClipClosedShape(shape pdf.ClosedShape, fn func()) error {
+	if fn != nil {
+		fn()
+	}
+	return nil
+}
+func (w *sampleTestWriter) ClipRichText(text *rich_text.RichText, fn func()) error {
+	if fn != nil {
+		fn()
+	}
+	return nil
+}
+func (w *sampleTestWriter) ClipText(text string, fn func()) error {
+	if fn != nil {
+		fn()
+	}
+	return nil
+}
+func (w *sampleTestWriter) ClosedShapeBounds(shape pdf.ClosedShape) (pdf.Bounds, error) {
+	return shape.Bounds()
+}
+func (w *sampleTestWriter) DrawRichTextOnCircle(text *rich_text.RichText, x, y, r, startAngle float64, opts pdf.CurvedTextOptions) error {
+	return nil
+}
+func (w *sampleTestWriter) DrawTextOnCircle(text string, x, y, r, startAngle float64, opts pdf.CurvedTextOptions) error {
+	return nil
+}
+func (w *sampleTestWriter) DrawClosedShape(shape pdf.ClosedShape, border, fill bool) error {
+	return nil
+}
+func (w *sampleTestWriter) EnableTaggedPDF(bool)                                     {}
+func (w *sampleTestWriter) Circle(x, y, r float64, border, fill, reverse bool) error { return nil }
+func (w *sampleTestWriter) Ellipse(x, y, rx, ry float64, border, fill, reverse bool) error {
+	return nil
+}
+func (w *sampleTestWriter) FontColor() colors.Color { return colors.Black }
+func (w *sampleTestWriter) Fonts() []*font.Font     { return w.ensureFonts() }
+func (w *sampleTestWriter) FontSize() float64 {
+	if w.fontSize == 0 {
+		return 12
+	}
+	return w.fontSize
+}
+func (w *sampleTestWriter) ImageDimensions(data []byte) (width, height int, err error) {
+	return 0, 0, nil
+}
+func (w *sampleTestWriter) SVGDimensions(data []byte) (width, height int, err error) {
+	return 0, 0, nil
+}
+func (w *sampleTestWriter) SVGDimensionsFromFile(filename string) (width, height int, err error) {
+	return 0, 0, nil
+}
+func (w *sampleTestWriter) ImageDimensionsFromFile(filename string) (width, height int, err error) {
+	return 0, 0, nil
+}
+func (w *sampleTestWriter) LineSpacing() float64                       { return 1.0 }
+func (w *sampleTestWriter) SetLineCapStyle(style string) (prev string) { return "" }
+func (w *sampleTestWriter) Line(x, y, angle, length float64)           {}
+func (w *sampleTestWriter) LineTo(x, y float64)                        {}
+func (w *sampleTestWriter) Loc() (x, y float64)                        { return 0, 0 }
+func (w *sampleTestWriter) MoveTo(x, y float64)                        {}
+func (w *sampleTestWriter) NewPage()                                   {}
+func (w *sampleTestWriter) Print(text string) error                    { return nil }
+func (w *sampleTestWriter) PrintImage(data []byte, x, y float64, width, height *float64) (actualWidth, actualHeight float64, err error) {
+	return 0, 0, nil
+}
+func (w *sampleTestWriter) PrintSVG(data []byte, x, y float64, width, height *float64) (actualWidth, actualHeight float64, err error) {
+	return 0, 0, nil
+}
+func (w *sampleTestWriter) PrintSVGFile(filename string, x, y float64, width, height *float64) (actualWidth, actualHeight float64, err error) {
+	return 0, 0, nil
+}
+func (w *sampleTestWriter) PrintImageFile(filename string, x, y float64, width, height *float64) (actualWidth, actualHeight float64, err error) {
+	return 0, 0, nil
+}
+func (w *sampleTestWriter) PaintImageFile(filename string, x, y, width, height, opacity float64) error {
+	return nil
+}
+func (w *sampleTestWriter) PaintLinearGradient(lg *pdf.LinearGradient) error { return nil }
+func (w *sampleTestWriter) PaintRadialGradient(rg *pdf.RadialGradient) error { return nil }
+func (w *sampleTestWriter) PrintParagraph(para []*rich_text.RichText, options options.Options) {
+}
+func (w *sampleTestWriter) PrintRichText(text *rich_text.RichText) {}
+func (w *sampleTestWriter) Path(fn func()) error {
+	if fn != nil {
+		fn()
+	}
+	return nil
+}
+func (w *sampleTestWriter) Pie(x, y, r, startAngle, endAngle float64, border, fill, reverse bool) error {
+	return nil
+}
+func (w *sampleTestWriter) Polygon(x, y, r float64, sides int, border, fill, reverse bool, rotation float64) error {
+	return nil
+}
+func (w *sampleTestWriter) Rectangle(x, y, width, height float64, border bool, fill bool) {}
+func (w *sampleTestWriter) Rectangle2(x, y, width, height float64, border bool, fill bool, corners []float64, path, reverse bool) {
+}
+func (w *sampleTestWriter) Rotate(angle, x, y float64, fn func()) error {
+	if fn != nil {
+		fn()
+	}
+	return nil
+}
+func (w *sampleTestWriter) AddFont(family string, options options.Options) ([]*font.Font, error) {
+	return w.ensureFonts(), nil
+}
+func (w *sampleTestWriter) SetFont(name string, size float64, options options.Options) ([]*font.Font, error) {
+	w.fontSize = size
+	return w.ensureFonts(), nil
+}
+func (w *sampleTestWriter) SetFillColor(value any) (prev colors.Color)          { return colors.Black }
+func (w *sampleTestWriter) SetFillLinearGradient(lg *pdf.LinearGradient) error  { return nil }
+func (w *sampleTestWriter) SetFillRadialGradient(rg *pdf.RadialGradient) error  { return nil }
+func (w *sampleTestWriter) ClearFillGradient()                                  {}
+func (w *sampleTestWriter) SetLineColor(value colors.Color) (prev colors.Color) { return colors.Black }
+func (w *sampleTestWriter) SetLineDashPattern(pattern string) (prev string)     { return "" }
+func (w *sampleTestWriter) SetLineSpacing(lineSpacing float64) (prev float64)   { return 1.0 }
+func (w *sampleTestWriter) SetLineWidth(width float64)                          {}
+func (w *sampleTestWriter) SetStrikeout(strikeout bool) (prev bool)             { return false }
+func (w *sampleTestWriter) SetUnderline(underline bool) (prev bool)             { return false }
+func (w *sampleTestWriter) Star(x, y, r1, r2 float64, points int, border, fill, reverse bool, rotation float64) error {
+	return nil
+}
+func (w *sampleTestWriter) Stroke() error          { return nil }
+func (w *sampleTestWriter) Strikeout() bool        { return false }
+func (w *sampleTestWriter) TaggedPDFEnabled() bool { return false }
+func (w *sampleTestWriter) Underline() bool        { return false }
+func (w *sampleTestWriter) WithAccessibilityArtifact(fn func()) error {
+	if fn != nil {
+		fn()
+	}
+	return nil
+}
+func (w *sampleTestWriter) WithAccessibilityTag(tag string, opts pdf.AccessibilityOptions, fn func()) error {
+	if fn != nil {
+		fn()
+	}
+	return nil
+}

--- a/ltml/ltml_test.go
+++ b/ltml/ltml_test.go
@@ -241,6 +241,9 @@ func TestSamples(t *testing.T) {
 		"test_048_bullet_variants",
 		"test_049_rem_headings",
 		"test_050_lists",
+		"test_051_paper_sizes",
+		"test_052_large_paper_sizes",
+		"test_053_avery_labels",
 	}
 
 	for _, sample := range samples {

--- a/ltml/page_size_catalog.go
+++ b/ltml/page_size_catalog.go
@@ -1,0 +1,117 @@
+package ltml
+
+import "strings"
+
+type BuiltInPageSize struct {
+	ID     string
+	Family string
+	Width  float64
+	Height float64
+}
+
+var builtInPageSizes = []BuiltInPageSize{
+	{ID: "A0", Family: "ISO A", Width: mmToPoints(841), Height: mmToPoints(1189)},
+	{ID: "A1", Family: "ISO A", Width: mmToPoints(594), Height: mmToPoints(841)},
+	{ID: "A2", Family: "ISO A", Width: mmToPoints(420), Height: mmToPoints(594)},
+	{ID: "A3", Family: "ISO A", Width: mmToPoints(297), Height: mmToPoints(420)},
+	{ID: "A4", Family: "ISO A", Width: mmToPoints(210), Height: mmToPoints(297)},
+	{ID: "A5", Family: "ISO A", Width: mmToPoints(148), Height: mmToPoints(210)},
+	{ID: "A6", Family: "ISO A", Width: mmToPoints(105), Height: mmToPoints(148)},
+	{ID: "A7", Family: "ISO A", Width: mmToPoints(74), Height: mmToPoints(105)},
+	{ID: "A8", Family: "ISO A", Width: mmToPoints(52), Height: mmToPoints(74)},
+	{ID: "A9", Family: "ISO A", Width: mmToPoints(37), Height: mmToPoints(52)},
+	{ID: "A10", Family: "ISO A", Width: mmToPoints(26), Height: mmToPoints(37)},
+	{ID: "B0", Family: "ISO B", Width: mmToPoints(1000), Height: mmToPoints(1414)},
+	{ID: "B1", Family: "ISO B", Width: mmToPoints(707), Height: mmToPoints(1000)},
+	{ID: "B2", Family: "ISO B", Width: mmToPoints(500), Height: mmToPoints(707)},
+	{ID: "B3", Family: "ISO B", Width: mmToPoints(353), Height: mmToPoints(500)},
+	{ID: "B4", Family: "ISO B", Width: mmToPoints(250), Height: mmToPoints(353)},
+	{ID: "B5", Family: "ISO B", Width: mmToPoints(176), Height: mmToPoints(250)},
+	{ID: "B6", Family: "ISO B", Width: mmToPoints(125), Height: mmToPoints(176)},
+	{ID: "B7", Family: "ISO B", Width: mmToPoints(88), Height: mmToPoints(125)},
+	{ID: "B8", Family: "ISO B", Width: mmToPoints(62), Height: mmToPoints(88)},
+	{ID: "B9", Family: "ISO B", Width: mmToPoints(44), Height: mmToPoints(62)},
+	{ID: "B10", Family: "ISO B", Width: mmToPoints(31), Height: mmToPoints(44)},
+	{ID: "C0", Family: "ISO C", Width: mmToPoints(917), Height: mmToPoints(1297)},
+	{ID: "C1", Family: "ISO C", Width: mmToPoints(648), Height: mmToPoints(917)},
+	{ID: "C2", Family: "ISO C", Width: mmToPoints(458), Height: mmToPoints(648)},
+	{ID: "C3", Family: "ISO C", Width: mmToPoints(324), Height: mmToPoints(458)},
+	{ID: "C4", Family: "ISO C", Width: mmToPoints(229), Height: mmToPoints(324)},
+	{ID: "C5", Family: "ISO C", Width: mmToPoints(162), Height: mmToPoints(229)},
+	{ID: "C6", Family: "ISO C", Width: mmToPoints(114), Height: mmToPoints(162)},
+	{ID: "C7", Family: "ISO C", Width: mmToPoints(81), Height: mmToPoints(114)},
+	{ID: "C8", Family: "ISO C", Width: mmToPoints(57), Height: mmToPoints(81)},
+	{ID: "C9", Family: "ISO C", Width: mmToPoints(40), Height: mmToPoints(57)},
+	{ID: "C10", Family: "ISO C", Width: mmToPoints(28), Height: mmToPoints(40)},
+	{ID: "RA0", Family: "ISO RA", Width: mmToPoints(860), Height: mmToPoints(1220)},
+	{ID: "RA1", Family: "ISO RA", Width: mmToPoints(610), Height: mmToPoints(860)},
+	{ID: "RA2", Family: "ISO RA", Width: mmToPoints(430), Height: mmToPoints(610)},
+	{ID: "RA3", Family: "ISO RA", Width: mmToPoints(305), Height: mmToPoints(430)},
+	{ID: "RA4", Family: "ISO RA", Width: mmToPoints(215), Height: mmToPoints(305)},
+	{ID: "SRA0", Family: "ISO SRA", Width: mmToPoints(900), Height: mmToPoints(1280)},
+	{ID: "SRA1", Family: "ISO SRA", Width: mmToPoints(640), Height: mmToPoints(900)},
+	{ID: "SRA2", Family: "ISO SRA", Width: mmToPoints(450), Height: mmToPoints(640)},
+	{ID: "SRA3", Family: "ISO SRA", Width: mmToPoints(320), Height: mmToPoints(450)},
+	{ID: "SRA4", Family: "ISO SRA", Width: mmToPoints(225), Height: mmToPoints(320)},
+	{ID: "halfletter", Family: "North American", Width: inchesToPoints(5.5), Height: inchesToPoints(8.5)},
+	{ID: "statement", Family: "North American", Width: inchesToPoints(5.5), Height: inchesToPoints(8.5)},
+	{ID: "letter", Family: "North American", Width: inchesToPoints(8.5), Height: inchesToPoints(11)},
+	{ID: "legal", Family: "North American", Width: inchesToPoints(8.5), Height: inchesToPoints(14)},
+	{ID: "juniorlegal", Family: "North American", Width: inchesToPoints(5), Height: inchesToPoints(8)},
+	{ID: "tabloid", Family: "North American", Width: inchesToPoints(11), Height: inchesToPoints(17)},
+	{ID: "ledger", Family: "North American", Width: inchesToPoints(11), Height: inchesToPoints(17)},
+	{ID: "governmentletter", Family: "North American", Width: inchesToPoints(8), Height: inchesToPoints(10.5)},
+	{ID: "governmentlegal", Family: "North American", Width: inchesToPoints(8.5), Height: inchesToPoints(13)},
+	{ID: "executive", Family: "North American", Width: inchesToPoints(7.25), Height: inchesToPoints(10.5)},
+	{ID: "folio", Family: "North American", Width: inchesToPoints(8.5), Height: inchesToPoints(13)},
+	{ID: "quarto", Family: "North American", Width: inchesToPoints(8), Height: inchesToPoints(10)},
+	{ID: "ansia", Family: "ANSI", Width: inchesToPoints(8.5), Height: inchesToPoints(11)},
+	{ID: "ansib", Family: "ANSI", Width: inchesToPoints(11), Height: inchesToPoints(17)},
+	{ID: "ansic", Family: "ANSI", Width: inchesToPoints(17), Height: inchesToPoints(22)},
+	{ID: "ansid", Family: "ANSI", Width: inchesToPoints(22), Height: inchesToPoints(34)},
+	{ID: "ansie", Family: "ANSI", Width: inchesToPoints(34), Height: inchesToPoints(44)},
+	{ID: "archa", Family: "ARCH", Width: inchesToPoints(9), Height: inchesToPoints(12)},
+	{ID: "archb", Family: "ARCH", Width: inchesToPoints(12), Height: inchesToPoints(18)},
+	{ID: "archc", Family: "ARCH", Width: inchesToPoints(18), Height: inchesToPoints(24)},
+	{ID: "archd", Family: "ARCH", Width: inchesToPoints(24), Height: inchesToPoints(36)},
+	{ID: "arche", Family: "ARCH", Width: inchesToPoints(36), Height: inchesToPoints(48)},
+	{ID: "arche1", Family: "ARCH", Width: inchesToPoints(30), Height: inchesToPoints(42)},
+	{ID: "arche2", Family: "ARCH", Width: inchesToPoints(26), Height: inchesToPoints(38)},
+	{ID: "arche3", Family: "ARCH", Width: inchesToPoints(27), Height: inchesToPoints(39)},
+}
+
+var builtInPageSizesByID = initBuiltInPageSizes()
+var defaultPageStyles = initDefaultPageStyles()
+
+func inchesToPoints(inches float64) float64 {
+	return inches * 72.0
+}
+
+func mmToPoints(mm float64) float64 {
+	return mm * 72.0 / 25.4
+}
+
+func initBuiltInPageSizes() map[string]BuiltInPageSize {
+	byID := make(map[string]BuiltInPageSize, len(builtInPageSizes))
+	for _, spec := range builtInPageSizes {
+		byID[normalizeBuiltInPageSizeID(spec.ID)] = spec
+	}
+	return byID
+}
+
+func initDefaultPageStyles() map[string]*PageStyle {
+	styles := make(map[string]*PageStyle, len(builtInPageSizes))
+	for _, spec := range builtInPageSizes {
+		styles[spec.ID] = &PageStyle{id: spec.ID, width: spec.Width, height: spec.Height}
+	}
+	return styles
+}
+
+func normalizeBuiltInPageSizeID(id string) string {
+	return strings.ToLower(strings.TrimSpace(id))
+}
+
+func lookupBuiltInPageSize(id string) (BuiltInPageSize, bool) {
+	spec, ok := builtInPageSizesByID[normalizeBuiltInPageSizeID(id)]
+	return spec, ok
+}

--- a/ltml/page_style.go
+++ b/ltml/page_style.go
@@ -7,20 +7,20 @@ const (
 
 type PageSize [2]float64
 
-var PageSizes = map[string]PageSize{
-	"letter": {612, 792},
-	"legal":  {612, 1008},
-	"A4":     {595, 842},
-	"B5":     {499, 708},
-	"C5":     {459, 649},
-}
-
 type PageStyle struct {
 	id          string
 	size        string
 	height      float64
 	width       float64
 	orientation int
+}
+
+func (ps *PageStyle) Clone() *PageStyle {
+	if ps == nil {
+		return nil
+	}
+	clone := *ps
+	return &clone
 }
 
 func (ps *PageStyle) ID() string {
@@ -41,20 +41,26 @@ func (ps *PageStyle) SetAttrs(attrs map[string]string) {
 	}
 	var units Units = "pt"
 	units.SetAttrs(attrs)
+	prevOrientation := ps.orientation
+	orientationChanged := false
 	if orientation, ok := attrs["orientation"]; ok {
 		switch orientation {
 		case "portrait":
 			ps.orientation = Portrait
+			orientationChanged = ps.orientation != prevOrientation
 		case "landscape":
 			ps.orientation = Landscape
+			orientationChanged = ps.orientation != prevOrientation
 		}
 	}
+	hasSize := false
 	if size, ok := attrs["size"]; ok {
-		if sz, ok := PageSizes[size]; ok {
+		hasSize = true
+		if sz, ok := lookupBuiltInPageSize(size); ok {
 			if ps.orientation == Portrait {
-				ps.width, ps.height = sz[0], sz[1]
+				ps.width, ps.height = sz.Width, sz.Height
 			} else {
-				ps.width, ps.height = sz[1], sz[0]
+				ps.width, ps.height = sz.Height, sz.Width
 			}
 		}
 	}
@@ -64,6 +70,13 @@ func (ps *PageStyle) SetAttrs(attrs map[string]string) {
 	if width, ok := attrs["width"]; ok {
 		ps.width = ParseMeasurement(width, units)
 	}
+	if orientationChanged && !hasSize {
+		_, hasWidth := attrs["width"]
+		_, hasHeight := attrs["height"]
+		if !hasWidth && !hasHeight && ps.width != 0 && ps.height != 0 {
+			ps.width, ps.height = ps.height, ps.width
+		}
+	}
 }
 
 func (ps *PageStyle) Width() float64 {
@@ -71,17 +84,19 @@ func (ps *PageStyle) Width() float64 {
 }
 
 func PageStyleFor(id string, scope HasScope) *PageStyle {
-	ps, _ := scope.PageStyleFor(id)
-	return ps
+	if scope != nil {
+		if ps, ok := scope.PageStyleFor(id); ok {
+			return ps
+		}
+	}
+	if spec, ok := lookupBuiltInPageSize(id); ok {
+		return &PageStyle{id: spec.ID, width: spec.Width, height: spec.Height}
+	}
+	return nil
 }
 
 var _ HasAttrs = (*PageStyle)(nil)
 
-var defaultPageStyles = map[string]*PageStyle{}
-
 func init() {
-	for id, sz := range PageSizes {
-		defaultPageStyles[id] = &PageStyle{id: id, width: sz[0], height: sz[1]}
-	}
 	registerTag(DefaultSpace, "pagestyle", func() any { return &PageStyle{} })
 }

--- a/ltml/page_style_test.go
+++ b/ltml/page_style_test.go
@@ -1,6 +1,7 @@
 package ltml
 
 import (
+	"math"
 	"testing"
 )
 
@@ -91,5 +92,76 @@ func TestParsePageStyleTag_BuiltinStylesUnaffected(t *testing.T) {
 	}
 	if page.Height() != 792 {
 		t.Errorf("expected letter height 792, got %v", page.Height())
+	}
+}
+
+func TestParsePageStyleTag_PageStyleOverridesBuiltinOrientation(t *testing.T) {
+	doc, err := Parse([]byte(`
+<ltml>
+  <page style="tabloid" style.orientation="landscape"></page>
+</ltml>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	page := doc.Root().Page(0)
+	if page == nil {
+		t.Fatal("expected a page, got nil")
+	}
+	if page.Width() != inchesToPoints(17) {
+		t.Errorf("expected landscape tabloid width %v, got %v", inchesToPoints(17), page.Width())
+	}
+	if page.Height() != inchesToPoints(11) {
+		t.Errorf("expected landscape tabloid height %v, got %v", inchesToPoints(11), page.Height())
+	}
+}
+
+func TestPageStyleFor_BuiltinsAreCaseInsensitive(t *testing.T) {
+	ps := PageStyleFor("a4", &defaultScope)
+	if ps == nil {
+		t.Fatal("a4 page style not found")
+	}
+	wantWidth := mmToPoints(210)
+	wantHeight := mmToPoints(297)
+	if math.Abs(ps.Width()-wantWidth) > 0.001 {
+		t.Fatalf("a4 width = %v, want %v", ps.Width(), wantWidth)
+	}
+	if math.Abs(ps.Height()-wantHeight) > 0.001 {
+		t.Fatalf("a4 height = %v, want %v", ps.Height(), wantHeight)
+	}
+}
+
+func TestPageStyleFor_BuiltinsCoverRepresentativeFamilies(t *testing.T) {
+	tests := []struct {
+		id         string
+		wantWidth  float64
+		wantHeight float64
+	}{
+		{id: "A0", wantWidth: mmToPoints(841), wantHeight: mmToPoints(1189)},
+		{id: "governmentlegal", wantWidth: inchesToPoints(8.5), wantHeight: inchesToPoints(13)},
+		{id: "ansic", wantWidth: inchesToPoints(17), wantHeight: inchesToPoints(22)},
+		{id: "archd", wantWidth: inchesToPoints(24), wantHeight: inchesToPoints(36)},
+	}
+	for _, tt := range tests {
+		ps := PageStyleFor(tt.id, &defaultScope)
+		if ps == nil {
+			t.Fatalf("%s page style not found", tt.id)
+		}
+		if math.Abs(ps.Width()-tt.wantWidth) > 0.001 {
+			t.Fatalf("%s width = %v, want %v", tt.id, ps.Width(), tt.wantWidth)
+		}
+		if math.Abs(ps.Height()-tt.wantHeight) > 0.001 {
+			t.Fatalf("%s height = %v, want %v", tt.id, ps.Height(), tt.wantHeight)
+		}
+	}
+}
+
+func TestPageStyle_SetAttrs_OrientationSwapsBuiltInDimensions(t *testing.T) {
+	ps := &PageStyle{}
+	ps.SetAttrs(map[string]string{"size": "a4", "orientation": "landscape"})
+	if math.Abs(ps.Width()-mmToPoints(297)) > 0.001 {
+		t.Fatalf("landscape a4 width = %v, want %v", ps.Width(), mmToPoints(297))
+	}
+	if math.Abs(ps.Height()-mmToPoints(210)) > 0.001 {
+		t.Fatalf("landscape a4 height = %v, want %v", ps.Height(), mmToPoints(210))
 	}
 }

--- a/ltml/samples/test_051_paper_sizes.ltml
+++ b/ltml/samples/test_051_paper_sizes.ltml
@@ -1,0 +1,298 @@
+<ltml units="in" margin="0.5" font.name="Helvetica" font.size="12">
+  <pen id="thin" width="0.5pt" color="SlateGray" />
+  <layout id="vbox" padding="6pt" />
+  <style>
+    label.size-title { font.size: 22; font.weight: Bold; }
+    p.meta-line { font.name: Helvetica; font.size: 7; color: DimGray; width: 100%; font.line-height: 1.5; }
+    rect.calibration-box { width: 1in; height: 1in; border: thin; fill: AliceBlue; }
+    rect.calibration-box-2 { width: 0.5in; height: 0.5in; border: thin; fill: AliceBlue; }
+  </style>
+  <page style="A4">
+    <label class="size-title">A4</label>
+    <p class="meta-line">Family: ISO A</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 8.268in × 11.693in | 210 × 297 mm | 595.276 × 841.89 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="A4".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="A5">
+    <label class="size-title">A5</label>
+    <p class="meta-line">Family: ISO A</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 5.827in × 8.268in | 148 × 210 mm | 419.528 × 595.276 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="A5".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="A6" margin="0.25">
+    <label class="size-title">A6</label>
+    <p class="meta-line">Family: ISO A</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 4.134in × 5.827in | 105 × 148 mm | 297.638 × 419.528 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="A6".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="A7" margin="0.25">
+    <label class="size-title">A7</label>
+    <p class="meta-line">Family: ISO A</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 2.913in × 4.134in | 74 × 105 mm | 209.764 × 297.638 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="A7".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="A8" margin="0.125">
+    <label class="size-title">A8</label>
+    <p class="meta-line">Family: ISO A</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 2.047in × 2.913in | 52 × 74 mm | 147.402 × 209.764 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="A8".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="A9" margin="0.125">
+    <label class="size-title">A9</label>
+    <p class="meta-line">Family: ISO A</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 1.457in × 2.047in | 37 × 52 mm | 104.882 × 147.402 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="A9".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="A10" margin="0.125">
+    <label class="size-title">A10</label>
+    <p class="meta-line">Family: ISO A</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 1.024in × 1.457in | 26 × 37 mm | 73.701 × 104.882 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="A10".</p>
+    <rect class="calibration-box-2" />
+    <p class="meta-line">Calibration square: 0.5in × 0.5in</p>
+  </page>
+  <page style="B5">
+    <label class="size-title">B5</label>
+    <p class="meta-line">Family: ISO B</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 6.929in × 9.843in | 176 × 250 mm | 498.898 × 708.661 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="B5".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="B6">
+    <label class="size-title">B6</label>
+    <p class="meta-line">Family: ISO B</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 4.921in × 6.929in | 125 × 176 mm | 354.331 × 498.898 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="B6".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="B7">
+    <label class="size-title">B7</label>
+    <p class="meta-line">Family: ISO B</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 3.465in × 4.921in | 88 × 125 mm | 249.449 × 354.331 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="B7".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="B8" margin="0.25">
+    <label class="size-title">B8</label>
+    <p class="meta-line">Family: ISO B</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 2.441in × 3.465in | 62 × 88 mm | 175.748 × 249.449 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="B8".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="B9" margin="0.25">
+    <label class="size-title">B9</label>
+    <p class="meta-line">Family: ISO B</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 1.732in × 2.441in | 44 × 62 mm | 124.724 × 175.748 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="B9".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="B10" margin="0.125">
+    <label class="size-title">B10</label>
+    <p class="meta-line">Family: ISO B</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 1.22in × 1.732in | 31 × 44 mm | 87.874 × 124.724 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="B10".</p>
+    <rect class="calibration-box-2" />
+    <p class="meta-line">Calibration square: 0.5in × 0.5in</p>
+  </page>
+  <page style="C5">
+    <label class="size-title">C5</label>
+    <p class="meta-line">Family: ISO C</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 6.378in × 9.016in | 162 × 229 mm | 459.213 × 649.134 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="C5".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="C6">
+    <label class="size-title">C6</label>
+    <p class="meta-line">Family: ISO C</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 4.488in × 6.378in | 114 × 162 mm | 323.15 × 459.213 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="C6".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="C7">
+    <label class="size-title">C7</label>
+    <p class="meta-line">Family: ISO C</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 3.189in × 4.488in | 81 × 114 mm | 229.606 × 323.15 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="C7".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="C8" margin="0.25">
+    <label class="size-title">C8</label>
+    <p class="meta-line">Family: ISO C</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 2.244in × 3.189in | 57 × 81 mm | 161.575 × 229.606 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="C8".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="C9" margin="0.25">
+    <label class="size-title">C9</label>
+    <p class="meta-line">Family: ISO C</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 1.575in × 2.244in | 40 × 57 mm | 113.386 × 161.575 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="C9".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="C10" margin="0.125">
+    <label class="size-title">C10</label>
+    <p class="meta-line">Family: ISO C</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 1.102in × 1.575in | 28 × 40 mm | 79.37 × 113.386 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="C10".</p>
+    <rect class="calibration-box-2" />
+    <p class="meta-line">Calibration square: 0.5in × 0.5in</p>
+  </page>
+  <page style="RA4">
+    <label class="size-title">RA4</label>
+    <p class="meta-line">Family: ISO RA</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 8.465in × 12.008in | 215 × 305 mm | 609.449 × 864.567 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="RA4".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="SRA4">
+    <label class="size-title">SRA4</label>
+    <p class="meta-line">Family: ISO SRA</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 8.858in × 12.598in | 225 × 320 mm | 637.795 × 907.087 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="SRA4".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="halfletter">
+    <label class="size-title">halfletter</label>
+    <p class="meta-line">Family: North American</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 5.5in × 8.5in | 139.7 × 215.9 mm | 396 × 612 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="halfletter".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="statement">
+    <label class="size-title">statement</label>
+    <p class="meta-line">Family: North American</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 5.5in × 8.5in | 139.7 × 215.9 mm | 396 × 612 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="statement".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="letter">
+    <label class="size-title">letter</label>
+    <p class="meta-line">Family: North American</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 8.5in × 11in | 215.9 × 279.4 mm | 612 × 792 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="letter".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="legal">
+    <label class="size-title">legal</label>
+    <p class="meta-line">Family: North American</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 8.5in × 14in | 215.9 × 355.6 mm | 612 × 1008 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="legal".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="juniorlegal">
+    <label class="size-title">juniorlegal</label>
+    <p class="meta-line">Family: North American</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 5in × 8in | 127 × 203.2 mm | 360 × 576 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="juniorlegal".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="governmentletter">
+    <label class="size-title">governmentletter</label>
+    <p class="meta-line">Family: North American</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 8in × 10.5in | 203.2 × 266.7 mm | 576 × 756 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="governmentletter".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="governmentlegal">
+    <label class="size-title">governmentlegal</label>
+    <p class="meta-line">Family: North American</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 8.5in × 13in | 215.9 × 330.2 mm | 612 × 936 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="governmentlegal".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="executive">
+    <label class="size-title">executive</label>
+    <p class="meta-line">Family: North American</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 7.25in × 10.5in | 184.15 × 266.7 mm | 522 × 756 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="executive".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="folio">
+    <label class="size-title">folio</label>
+    <p class="meta-line">Family: North American</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 8.5in × 13in | 215.9 × 330.2 mm | 612 × 936 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="folio".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="quarto">
+    <label class="size-title">quarto</label>
+    <p class="meta-line">Family: North American</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 8in × 10in | 203.2 × 254 mm | 576 × 720 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="quarto".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="ansia">
+    <label class="size-title">ansia</label>
+    <p class="meta-line">Family: ANSI</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 8.5in × 11in | 215.9 × 279.4 mm | 612 × 792 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="ansia".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+</ltml>

--- a/ltml/samples/test_051_paper_sizes.pdf
+++ b/ltml/samples/test_051_paper_sizes.pdf
@@ -1,0 +1,7888 @@
+%PDF-1.7
+1 0 obj
+<<
+/Count 41 
+/Kids [7 0 R 20 0 R 27 0 R 34 0 R 41 0 R 48 0 R 54 0 R 56 0 R 61 0 R 63 0 R 65 0 R 72 0 R 79 0 R 86 0 R 93 0 R 99 0 R 101 0 R 106 0 R 109 0 R 116 0 R 123 0 R 130 0 R 137 0 R 142 0 R 144 0 R 146 0 R 150 0 R 153 0 R 155 0 R 162 0 R 169 0 R 176 0 R 183 0 R 190 0 R 197 0 R 204 0 R 211 0 R 218 0 R 225 0 R 232 0 R 239 0 R ] 
+/Type /Pages 
+>>
+endobj
+2 0 obj
+<<
+/Count 0 
+/Type /Outlines 
+>>
+endobj
+3 0 obj
+<<
+/MarkInfo <<
+/Marked true 
+>>
+
+/Outlines 2 0 R 
+/PageMode /UseNone 
+/Pages 1 0 R 
+/StructTreeRoot 6 0 R 
+/Type /Catalog 
+>>
+endobj
+4 0 obj
+<<
+/Font <<
+/F0 11 0 R 
+/F1 15 0 R 
+>>
+
+/ProcSet [/PDF /Text /ImageB /ImageC ] 
+>>
+endobj
+5 0 obj
+<<
+/Nums [0 [8 0 R 12 0 R 16 0 R 17 0 R 18 0 R 19 0 R ] 1 [21 0 R 22 0 R 23 0 R 24 0 R 25 0 R 26 0 R ] 2 [28 0 R 29 0 R 30 0 R 31 0 R 32 0 R 33 0 R ] 3 [35 0 R 36 0 R 37 0 R 38 0 R 38 0 R 39 0 R 39 0 R 40 0 R ] 4 [42 0 R 43 0 R 44 0 R 45 0 R 45 0 R 46 0 R 46 0 R 47 0 R ] 5 [49 0 R 50 0 R 51 0 R 51 0 R 52 0 R 52 0 R 52 0 R 53 0 R 53 0 R 53 0 R ] 6 [55 0 R ] 7 [57 0 R 58 0 R 59 0 R 59 0 R 60 0 R 60 0 R ] 8 [60 0 R 60 0 R 62 0 R 62 0 R 62 0 R 62 0 R 62 0 R ] 9 [64 0 R 64 0 R 64 0 R ] 10 [66 0 R 67 0 R 68 0 R 69 0 R 70 0 R 71 0 R ] 11 [73 0 R 74 0 R 75 0 R 76 0 R 77 0 R 78 0 R ] 12 [80 0 R 81 0 R 82 0 R 83 0 R 83 0 R 84 0 R 84 0 R 85 0 R ] 13 [87 0 R 88 0 R 89 0 R 90 0 R 90 0 R 91 0 R 91 0 R 92 0 R ] 14 [94 0 R 95 0 R 96 0 R 96 0 R 97 0 R 97 0 R 97 0 R 98 0 R 98 0 R 98 0 R ] 15 [100 0 R ] 16 [102 0 R 103 0 R 104 0 R 104 0 R 105 0 R 105 0 R 105 0 R ] 17 [107 0 R 107 0 R 107 0 R 107 0 R 108 0 R 108 0 R ] 18 [110 0 R 111 0 R 112 0 R 113 0 R 114 0 R 115 0 R ] 19 [117 0 R 118 0 R 119 0 R 120 0 R 121 0 R 122 0 R ] 20 [124 0 R 125 0 R 126 0 R 127 0 R 127 0 R 128 0 R 128 0 R 129 0 R ] 21 [131 0 R 132 0 R 133 0 R 134 0 R 134 0 R 135 0 R 135 0 R 136 0 R ] 22 [138 0 R 139 0 R 140 0 R 140 0 R 141 0 R 141 0 R 141 0 R ] 23 [143 0 R 143 0 R 143 0 R ] 24 [145 0 R 145 0 R ] 25 [147 0 R 148 0 R 149 0 R 149 0 R ] 26 [151 0 R 151 0 R 151 0 R 151 0 R 152 0 R 152 0 R 152 0 R 152 0 R ] 27 [154 0 R 154 0 R ] 28 [156 0 R 157 0 R 158 0 R 159 0 R 160 0 R 161 0 R ] 29 [163 0 R 164 0 R 165 0 R 166 0 R 167 0 R 168 0 R ] 30 [170 0 R 171 0 R 172 0 R 173 0 R 174 0 R 175 0 R ] 31 [177 0 R 178 0 R 179 0 R 180 0 R 181 0 R 182 0 R ] 32 [184 0 R 185 0 R 186 0 R 187 0 R 188 0 R 189 0 R ] 33 [191 0 R 192 0 R 193 0 R 194 0 R 195 0 R 196 0 R ] 34 [198 0 R 199 0 R 200 0 R 201 0 R 202 0 R 203 0 R ] 35 [205 0 R 206 0 R 207 0 R 208 0 R 209 0 R 210 0 R ] 36 [212 0 R 213 0 R 214 0 R 215 0 R 216 0 R 217 0 R ] 37 [219 0 R 220 0 R 221 0 R 222 0 R 223 0 R 224 0 R ] 38 [226 0 R 227 0 R 228 0 R 229 0 R 230 0 R 231 0 R ] 39 [233 0 R 234 0 R 235 0 R 236 0 R 237 0 R 238 0 R ] 40 [240 0 R 241 0 R 242 0 R 243 0 R 244 0 R 245 0 R ] ] 
+>>
+endobj
+6 0 obj
+<<
+/K [8 0 R 12 0 R 16 0 R 17 0 R 18 0 R 19 0 R 21 0 R 22 0 R 23 0 R 24 0 R 25 0 R 26 0 R 28 0 R 29 0 R 30 0 R 31 0 R 32 0 R 33 0 R 35 0 R 36 0 R 37 0 R 38 0 R 39 0 R 40 0 R 42 0 R 43 0 R 44 0 R 45 0 R 46 0 R 47 0 R 49 0 R 50 0 R 51 0 R 52 0 R 53 0 R 55 0 R 57 0 R 58 0 R 59 0 R 60 0 R 62 0 R 64 0 R 66 0 R 67 0 R 68 0 R 69 0 R 70 0 R 71 0 R 73 0 R 74 0 R 75 0 R 76 0 R 77 0 R 78 0 R 80 0 R 81 0 R 82 0 R 83 0 R 84 0 R 85 0 R 87 0 R 88 0 R 89 0 R 90 0 R 91 0 R 92 0 R 94 0 R 95 0 R 96 0 R 97 0 R 98 0 R 100 0 R 102 0 R 103 0 R 104 0 R 105 0 R 107 0 R 108 0 R 110 0 R 111 0 R 112 0 R 113 0 R 114 0 R 115 0 R 117 0 R 118 0 R 119 0 R 120 0 R 121 0 R 122 0 R 124 0 R 125 0 R 126 0 R 127 0 R 128 0 R 129 0 R 131 0 R 132 0 R 133 0 R 134 0 R 135 0 R 136 0 R 138 0 R 139 0 R 140 0 R 141 0 R 143 0 R 145 0 R 147 0 R 148 0 R 149 0 R 151 0 R 152 0 R 154 0 R 156 0 R 157 0 R 158 0 R 159 0 R 160 0 R 161 0 R 163 0 R 164 0 R 165 0 R 166 0 R 167 0 R 168 0 R 170 0 R 171 0 R 172 0 R 173 0 R 174 0 R 175 0 R 177 0 R 178 0 R 179 0 R 180 0 R 181 0 R 182 0 R 184 0 R 185 0 R 186 0 R 187 0 R 188 0 R 189 0 R 191 0 R 192 0 R 193 0 R 194 0 R 195 0 R 196 0 R 198 0 R 199 0 R 200 0 R 201 0 R 202 0 R 203 0 R 205 0 R 206 0 R 207 0 R 208 0 R 209 0 R 210 0 R 212 0 R 213 0 R 214 0 R 215 0 R 216 0 R 217 0 R 219 0 R 220 0 R 221 0 R 222 0 R 223 0 R 224 0 R 226 0 R 227 0 R 228 0 R 229 0 R 230 0 R 231 0 R 233 0 R 234 0 R 235 0 R 236 0 R 237 0 R 238 0 R 240 0 R 241 0 R 242 0 R 243 0 R 244 0 R 245 0 R ] 
+/ParentTree 5 0 R 
+/ParentTreeNextKey 41 
+/Type /StructTreeRoot 
+>>
+endobj
+7 0 obj
+<<
+/Contents 246 0 R 
+/CropBox [0 0 595.2755905511812 841.8897637795276 ] 
+/Length 1529 
+/MediaBox [0 0 595.2755905511812 841.8897637795276 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 0 
+/Type /Page 
+>>
+endobj
+8 0 obj
+<<
+/ActualText (A4) 
+/K <<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+9 0 obj
+<<
+/Ascent 1577 
+/AvgWidth 0 
+/CapHeight 1474 
+/Descent -471 
+/Flags 262144 
+/FontBBox [-2084 -985 2810 1971 ] 
+/FontFamily (Helvetica) 
+/FontFile2 292 0 R 
+/FontName /JMKLFY+Helvetica-Bold 
+/ItalicAngle 0 
+/Leading 2048 
+/MaxWidth 0 
+/MissingWidth 0 
+/StemH 0 
+/StemV 165 
+/Type /FontDescriptor 
+/XHeight 1090 
+>>
+endobj
+10 0 obj
+<<
+/BaseFont /JMKLFY+Helvetica-Bold 
+/CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> 
+/CIDToGIDMap 291 0 R 
+/DW 556 
+/FontDescriptor 9 0 R 
+/Subtype /CIDFontType2 
+/Type /Font 
+/W [1 [722 ] 10 [722 722 722 666 610 ] 16 [277 333 ] 19 [333 389 ] 22 [889 610 610 277 610 277 610 ] 32 [610 ] ] 
+>>
+endobj
+11 0 obj
+<<
+/BaseFont /JMKLFY+Helvetica-Bold 
+/DescendantFonts [10 0 R ] 
+/Encoding /Identity-H 
+/Subtype /Type0 
+/ToUnicode 290 0 R 
+/Type /Font 
+>>
+endobj
+12 0 obj
+<<
+/ActualText (Family: ISO A) 
+/K <<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+13 0 obj
+<<
+/Ascent 1577 
+/AvgWidth 0 
+/CapHeight 1469 
+/Descent -471 
+/Flags 0 
+/FontBBox [-1947 -985 2961 2297 ] 
+/FontFamily (Helvetica) 
+/FontFile2 289 0 R 
+/FontName /LQQFAH+Helvetica 
+/ItalicAngle 0 
+/Leading 2048 
+/MaxWidth 0 
+/MissingWidth 0 
+/StemH 0 
+/StemV 87 
+/Type /FontDescriptor 
+/XHeight 1071 
+>>
+endobj
+14 0 obj
+<<
+/BaseFont /LQQFAH+Helvetica 
+/CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> 
+/CIDToGIDMap 288 0 R 
+/DW 556 
+/FontDescriptor 13 0 R 
+/Subtype /CIDFontType2 
+/Type /Font 
+/W [1 [610 ] 3 [833 222 222 500 277 277 277 666 777 666 333 ] 16 [277 ] 18 [500 ] 20 [500 ] 22 [277 ] 25 [583 ] 29 [259 ] 34 [666 ] 36 [333 500 500 500 277 ] 43 [583 354 722 ] 48 [722 722 277 222 500 ] ] 
+>>
+endobj
+15 0 obj
+<<
+/BaseFont /LQQFAH+Helvetica 
+/DescendantFonts [14 0 R ] 
+/Encoding /Identity-H 
+/Subtype /Type0 
+/ToUnicode 287 0 R 
+/Type /Font 
+>>
+endobj
+16 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+17 0 obj
+<<
+/ActualText <feff00530069007a0065003a00200038002e0032003600380069006e002000d7002000310031002e0036003900330069006e0020007c0020003200310030002000d700200032003900370020006d006d0020007c0020003500390035002e003200370036002000d70020003800340031002e00380039002000700074> 
+/K <<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+18 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="A4".) 
+/K <<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+19 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+20 0 obj
+<<
+/Contents 247 0 R 
+/CropBox [0 0 419.52755905511816 595.2755905511812 ] 
+/Length 1529 
+/MediaBox [0 0 419.52755905511816 595.2755905511812 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 1 
+/Type /Page 
+>>
+endobj
+21 0 obj
+<<
+/ActualText (A5) 
+/K <<
+/Type /MCR 
+/Pg 20 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+22 0 obj
+<<
+/ActualText (Family: ISO A) 
+/K <<
+/Type /MCR 
+/Pg 20 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+23 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 20 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+24 0 obj
+<<
+/ActualText <feff00530069007a0065003a00200035002e0038003200370069006e002000d700200038002e0032003600380069006e0020007c0020003100340038002000d700200032003100300020006d006d0020007c0020003400310039002e003500320038002000d70020003500390035002e003200370036002000700074> 
+/K <<
+/Type /MCR 
+/Pg 20 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+25 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="A5".) 
+/K <<
+/Type /MCR 
+/Pg 20 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+26 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 20 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+27 0 obj
+<<
+/Contents 248 0 R 
+/CropBox [0 0 297.6377952755906 419.52755905511816 ] 
+/Length 1529 
+/MediaBox [0 0 297.6377952755906 419.52755905511816 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 2 
+/Type /Page 
+>>
+endobj
+28 0 obj
+<<
+/ActualText (A6) 
+/K <<
+/Type /MCR 
+/Pg 27 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+29 0 obj
+<<
+/ActualText (Family: ISO A) 
+/K <<
+/Type /MCR 
+/Pg 27 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+30 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 27 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+31 0 obj
+<<
+/ActualText <feff00530069007a0065003a00200034002e0031003300340069006e002000d700200035002e0038003200370069006e0020007c0020003100300035002000d700200031003400380020006d006d0020007c0020003200390037002e003600330038002000d70020003400310039002e003500320038002000700074> 
+/K <<
+/Type /MCR 
+/Pg 27 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+32 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="A6".) 
+/K <<
+/Type /MCR 
+/Pg 27 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+33 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 27 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+34 0 obj
+<<
+/Contents 249 0 R 
+/CropBox [0 0 209.76377952755908 297.6377952755906 ] 
+/Length 1602 
+/MediaBox [0 0 209.76377952755908 297.6377952755906 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 3 
+/Type /Page 
+>>
+endobj
+35 0 obj
+<<
+/ActualText (A7) 
+/K <<
+/Type /MCR 
+/Pg 34 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+36 0 obj
+<<
+/ActualText (Family: ISO A) 
+/K <<
+/Type /MCR 
+/Pg 34 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+37 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 34 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+38 0 obj
+<<
+/ActualText <feff00530069007a0065003a00200032002e0039003100330069006e002000d700200034002e0031003300340069006e0020007c002000370034002000d700200031003000350020006d006d0020007c0020003200300039002e003700360034002000d70020003200390037002e003600330038002000700074> 
+/K [<<
+/Type /MCR 
+/Pg 34 0 R 
+/MCID 3 
+>>
+<<
+/Type /MCR 
+/Pg 34 0 R 
+/MCID 4 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+39 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="A7".) 
+/K [<<
+/Type /MCR 
+/Pg 34 0 R 
+/MCID 5 
+>>
+<<
+/Type /MCR 
+/Pg 34 0 R 
+/MCID 6 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+40 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 34 0 R 
+/MCID 7 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+41 0 obj
+<<
+/Contents 250 0 R 
+/CropBox [0 0 147.40157480314963 209.76377952755908 ] 
+/Length 1592 
+/MediaBox [0 0 147.40157480314963 209.76377952755908 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 4 
+/Type /Page 
+>>
+endobj
+42 0 obj
+<<
+/ActualText (A8) 
+/K <<
+/Type /MCR 
+/Pg 41 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+43 0 obj
+<<
+/ActualText (Family: ISO A) 
+/K <<
+/Type /MCR 
+/Pg 41 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+44 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 41 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+45 0 obj
+<<
+/ActualText <feff00530069007a0065003a00200032002e0030003400370069006e002000d700200032002e0039003100330069006e0020007c002000350032002000d70020003700340020006d006d0020007c0020003100340037002e003400300032002000d70020003200300039002e003700360034002000700074> 
+/K [<<
+/Type /MCR 
+/Pg 41 0 R 
+/MCID 3 
+>>
+<<
+/Type /MCR 
+/Pg 41 0 R 
+/MCID 4 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+46 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="A8".) 
+/K [<<
+/Type /MCR 
+/Pg 41 0 R 
+/MCID 5 
+>>
+<<
+/Type /MCR 
+/Pg 41 0 R 
+/MCID 6 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+47 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 41 0 R 
+/MCID 7 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+48 0 obj
+<<
+/Contents 251 0 R 
+/CropBox [0 0 104.88188976377954 147.40157480314963 ] 
+/Length 1361 
+/MediaBox [0 0 104.88188976377954 147.40157480314963 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 5 
+/Type /Page 
+>>
+endobj
+49 0 obj
+<<
+/ActualText (A9) 
+/K <<
+/Type /MCR 
+/Pg 48 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+50 0 obj
+<<
+/ActualText (Family: ISO A) 
+/K <<
+/Type /MCR 
+/Pg 48 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+51 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K [<<
+/Type /MCR 
+/Pg 48 0 R 
+/MCID 2 
+>>
+<<
+/Type /MCR 
+/Pg 48 0 R 
+/MCID 3 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+52 0 obj
+<<
+/ActualText <feff00530069007a0065003a00200031002e0034003500370069006e002000d700200032002e0030003400370069006e0020007c002000330037002000d70020003500320020006d006d0020007c0020003100300034002e003800380032002000d70020003100340037002e003400300032002000700074> 
+/K [<<
+/Type /MCR 
+/Pg 48 0 R 
+/MCID 4 
+>>
+<<
+/Type /MCR 
+/Pg 48 0 R 
+/MCID 5 
+>>
+<<
+/Type /MCR 
+/Pg 48 0 R 
+/MCID 6 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+53 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="A9".) 
+/K [<<
+/Type /MCR 
+/Pg 48 0 R 
+/MCID 7 
+>>
+<<
+/Type /MCR 
+/Pg 48 0 R 
+/MCID 8 
+>>
+<<
+/Type /MCR 
+/Pg 48 0 R 
+/MCID 9 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+54 0 obj
+<<
+/Contents 252 0 R 
+/CropBox [0 0 104.88188976377954 147.40157480314963 ] 
+/Length 352 
+/MediaBox [0 0 104.88188976377954 147.40157480314963 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 6 
+/Type /Page 
+>>
+endobj
+55 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 54 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+56 0 obj
+<<
+/Contents 253 0 R 
+/CropBox [0 0 73.70078740157481 104.88188976377954 ] 
+/Length 786 
+/MediaBox [0 0 73.70078740157481 104.88188976377954 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 7 
+/Type /Page 
+>>
+endobj
+57 0 obj
+<<
+/ActualText (A10) 
+/K <<
+/Type /MCR 
+/Pg 56 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+58 0 obj
+<<
+/ActualText (Family: ISO A) 
+/K <<
+/Type /MCR 
+/Pg 56 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+59 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K [<<
+/Type /MCR 
+/Pg 56 0 R 
+/MCID 2 
+>>
+<<
+/Type /MCR 
+/Pg 56 0 R 
+/MCID 3 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+60 0 obj
+<<
+/ActualText <feff00530069007a0065003a00200031002e0030003200340069006e002000d700200031002e0034003500370069006e0020007c002000320036002000d70020003300370020006d006d0020007c002000370033002e003700300031002000d70020003100300034002e003800380032002000700074> 
+/K [<<
+/Type /MCR 
+/Pg 56 0 R 
+/MCID 4 
+>>
+<<
+/Type /MCR 
+/Pg 56 0 R 
+/MCID 5 
+>>
+<<
+/Type /MCR 
+/Pg 61 0 R 
+/MCID 0 
+>>
+<<
+/Type /MCR 
+/Pg 61 0 R 
+/MCID 1 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+61 0 obj
+<<
+/Contents 254 0 R 
+/CropBox [0 0 73.70078740157481 104.88188976377954 ] 
+/Length 750 
+/MediaBox [0 0 73.70078740157481 104.88188976377954 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 8 
+/Type /Page 
+>>
+endobj
+62 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="A10".) 
+/K [<<
+/Type /MCR 
+/Pg 61 0 R 
+/MCID 2 
+>>
+<<
+/Type /MCR 
+/Pg 61 0 R 
+/MCID 3 
+>>
+<<
+/Type /MCR 
+/Pg 61 0 R 
+/MCID 4 
+>>
+<<
+/Type /MCR 
+/Pg 61 0 R 
+/MCID 5 
+>>
+<<
+/Type /MCR 
+/Pg 61 0 R 
+/MCID 6 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+63 0 obj
+<<
+/Contents 255 0 R 
+/CropBox [0 0 73.70078740157481 104.88188976377954 ] 
+/Length 446 
+/MediaBox [0 0 73.70078740157481 104.88188976377954 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 9 
+/Type /Page 
+>>
+endobj
+64 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a00200030002e00350069006e002000d700200030002e00350069006e> 
+/K [<<
+/Type /MCR 
+/Pg 63 0 R 
+/MCID 0 
+>>
+<<
+/Type /MCR 
+/Pg 63 0 R 
+/MCID 1 
+>>
+<<
+/Type /MCR 
+/Pg 63 0 R 
+/MCID 2 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+65 0 obj
+<<
+/Contents 256 0 R 
+/CropBox [0 0 498.8976377952756 708.6614173228347 ] 
+/Length 1528 
+/MediaBox [0 0 498.8976377952756 708.6614173228347 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 10 
+/Type /Page 
+>>
+endobj
+66 0 obj
+<<
+/ActualText (B5) 
+/K <<
+/Type /MCR 
+/Pg 65 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+67 0 obj
+<<
+/ActualText (Family: ISO B) 
+/K <<
+/Type /MCR 
+/Pg 65 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+68 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 65 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+69 0 obj
+<<
+/ActualText <feff00530069007a0065003a00200036002e0039003200390069006e002000d700200039002e0038003400330069006e0020007c0020003100370036002000d700200032003500300020006d006d0020007c0020003400390038002e003800390038002000d70020003700300038002e003600360031002000700074> 
+/K <<
+/Type /MCR 
+/Pg 65 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+70 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="B5".) 
+/K <<
+/Type /MCR 
+/Pg 65 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+71 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 65 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+72 0 obj
+<<
+/Contents 257 0 R 
+/CropBox [0 0 354.33070866141736 498.8976377952756 ] 
+/Length 1529 
+/MediaBox [0 0 354.33070866141736 498.8976377952756 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 11 
+/Type /Page 
+>>
+endobj
+73 0 obj
+<<
+/ActualText (B6) 
+/K <<
+/Type /MCR 
+/Pg 72 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+74 0 obj
+<<
+/ActualText (Family: ISO B) 
+/K <<
+/Type /MCR 
+/Pg 72 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+75 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 72 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+76 0 obj
+<<
+/ActualText <feff00530069007a0065003a00200034002e0039003200310069006e002000d700200036002e0039003200390069006e0020007c0020003100320035002000d700200031003700360020006d006d0020007c0020003300350034002e003300330031002000d70020003400390038002e003800390038002000700074> 
+/K <<
+/Type /MCR 
+/Pg 72 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+77 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="B6".) 
+/K <<
+/Type /MCR 
+/Pg 72 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+78 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 72 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+79 0 obj
+<<
+/Contents 258 0 R 
+/CropBox [0 0 249.4488188976378 354.33070866141736 ] 
+/Length 1603 
+/MediaBox [0 0 249.4488188976378 354.33070866141736 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 12 
+/Type /Page 
+>>
+endobj
+80 0 obj
+<<
+/ActualText (B7) 
+/K <<
+/Type /MCR 
+/Pg 79 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+81 0 obj
+<<
+/ActualText (Family: ISO B) 
+/K <<
+/Type /MCR 
+/Pg 79 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+82 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 79 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+83 0 obj
+<<
+/ActualText <feff00530069007a0065003a00200033002e0034003600350069006e002000d700200034002e0039003200310069006e0020007c002000380038002000d700200031003200350020006d006d0020007c0020003200340039002e003400340039002000d70020003300350034002e003300330031002000700074> 
+/K [<<
+/Type /MCR 
+/Pg 79 0 R 
+/MCID 3 
+>>
+<<
+/Type /MCR 
+/Pg 79 0 R 
+/MCID 4 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+84 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="B7".) 
+/K [<<
+/Type /MCR 
+/Pg 79 0 R 
+/MCID 5 
+>>
+<<
+/Type /MCR 
+/Pg 79 0 R 
+/MCID 6 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+85 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 79 0 R 
+/MCID 7 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+86 0 obj
+<<
+/Contents 259 0 R 
+/CropBox [0 0 175.748031496063 249.4488188976378 ] 
+/Length 1596 
+/MediaBox [0 0 175.748031496063 249.4488188976378 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 13 
+/Type /Page 
+>>
+endobj
+87 0 obj
+<<
+/ActualText (B8) 
+/K <<
+/Type /MCR 
+/Pg 86 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+88 0 obj
+<<
+/ActualText (Family: ISO B) 
+/K <<
+/Type /MCR 
+/Pg 86 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+89 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 86 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+90 0 obj
+<<
+/ActualText <feff00530069007a0065003a00200032002e0034003400310069006e002000d700200033002e0034003600350069006e0020007c002000360032002000d70020003800380020006d006d0020007c0020003100370035002e003700340038002000d70020003200340039002e003400340039002000700074> 
+/K [<<
+/Type /MCR 
+/Pg 86 0 R 
+/MCID 3 
+>>
+<<
+/Type /MCR 
+/Pg 86 0 R 
+/MCID 4 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+91 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="B8".) 
+/K [<<
+/Type /MCR 
+/Pg 86 0 R 
+/MCID 5 
+>>
+<<
+/Type /MCR 
+/Pg 86 0 R 
+/MCID 6 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+92 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 86 0 R 
+/MCID 7 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+93 0 obj
+<<
+/Contents 260 0 R 
+/CropBox [0 0 124.7244094488189 175.748031496063 ] 
+/Length 1362 
+/MediaBox [0 0 124.7244094488189 175.748031496063 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 14 
+/Type /Page 
+>>
+endobj
+94 0 obj
+<<
+/ActualText (B9) 
+/K <<
+/Type /MCR 
+/Pg 93 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+95 0 obj
+<<
+/ActualText (Family: ISO B) 
+/K <<
+/Type /MCR 
+/Pg 93 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+96 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K [<<
+/Type /MCR 
+/Pg 93 0 R 
+/MCID 2 
+>>
+<<
+/Type /MCR 
+/Pg 93 0 R 
+/MCID 3 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+97 0 obj
+<<
+/ActualText <feff00530069007a0065003a00200031002e0037003300320069006e002000d700200032002e0034003400310069006e0020007c002000340034002000d70020003600320020006d006d0020007c0020003100320034002e003700320034002000d70020003100370035002e003700340038002000700074> 
+/K [<<
+/Type /MCR 
+/Pg 93 0 R 
+/MCID 4 
+>>
+<<
+/Type /MCR 
+/Pg 93 0 R 
+/MCID 5 
+>>
+<<
+/Type /MCR 
+/Pg 93 0 R 
+/MCID 6 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+98 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="B9".) 
+/K [<<
+/Type /MCR 
+/Pg 93 0 R 
+/MCID 7 
+>>
+<<
+/Type /MCR 
+/Pg 93 0 R 
+/MCID 8 
+>>
+<<
+/Type /MCR 
+/Pg 93 0 R 
+/MCID 9 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+99 0 obj
+<<
+/Contents 261 0 R 
+/CropBox [0 0 124.7244094488189 175.748031496063 ] 
+/Length 353 
+/MediaBox [0 0 124.7244094488189 175.748031496063 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 15 
+/Type /Page 
+>>
+endobj
+100 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 99 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+101 0 obj
+<<
+/Contents 262 0 R 
+/CropBox [0 0 87.8740157480315 124.7244094488189 ] 
+/Length 920 
+/MediaBox [0 0 87.8740157480315 124.7244094488189 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 16 
+/Type /Page 
+>>
+endobj
+102 0 obj
+<<
+/ActualText (B10) 
+/K <<
+/Type /MCR 
+/Pg 101 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+103 0 obj
+<<
+/ActualText (Family: ISO B) 
+/K <<
+/Type /MCR 
+/Pg 101 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+104 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K [<<
+/Type /MCR 
+/Pg 101 0 R 
+/MCID 2 
+>>
+<<
+/Type /MCR 
+/Pg 101 0 R 
+/MCID 3 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+105 0 obj
+<<
+/ActualText <feff00530069007a0065003a00200031002e003200320069006e002000d700200031002e0037003300320069006e0020007c002000330031002000d70020003400340020006d006d0020007c002000380037002e003800370034002000d70020003100320034002e003700320034002000700074> 
+/K [<<
+/Type /MCR 
+/Pg 101 0 R 
+/MCID 4 
+>>
+<<
+/Type /MCR 
+/Pg 101 0 R 
+/MCID 5 
+>>
+<<
+/Type /MCR 
+/Pg 101 0 R 
+/MCID 6 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+106 0 obj
+<<
+/Contents 263 0 R 
+/CropBox [0 0 87.8740157480315 124.7244094488189 ] 
+/Length 906 
+/MediaBox [0 0 87.8740157480315 124.7244094488189 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 17 
+/Type /Page 
+>>
+endobj
+107 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="B10".) 
+/K [<<
+/Type /MCR 
+/Pg 106 0 R 
+/MCID 0 
+>>
+<<
+/Type /MCR 
+/Pg 106 0 R 
+/MCID 1 
+>>
+<<
+/Type /MCR 
+/Pg 106 0 R 
+/MCID 2 
+>>
+<<
+/Type /MCR 
+/Pg 106 0 R 
+/MCID 3 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+108 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a00200030002e00350069006e002000d700200030002e00350069006e> 
+/K [<<
+/Type /MCR 
+/Pg 106 0 R 
+/MCID 4 
+>>
+<<
+/Type /MCR 
+/Pg 106 0 R 
+/MCID 5 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+109 0 obj
+<<
+/Contents 264 0 R 
+/CropBox [0 0 459.21259842519686 649.1338582677166 ] 
+/Length 1529 
+/MediaBox [0 0 459.21259842519686 649.1338582677166 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 18 
+/Type /Page 
+>>
+endobj
+110 0 obj
+<<
+/ActualText (C5) 
+/K <<
+/Type /MCR 
+/Pg 109 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+111 0 obj
+<<
+/ActualText (Family: ISO C) 
+/K <<
+/Type /MCR 
+/Pg 109 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+112 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 109 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+113 0 obj
+<<
+/ActualText <feff00530069007a0065003a00200036002e0033003700380069006e002000d700200039002e0030003100360069006e0020007c0020003100360032002000d700200032003200390020006d006d0020007c0020003400350039002e003200310033002000d70020003600340039002e003100330034002000700074> 
+/K <<
+/Type /MCR 
+/Pg 109 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+114 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="C5".) 
+/K <<
+/Type /MCR 
+/Pg 109 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+115 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 109 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+116 0 obj
+<<
+/Contents 265 0 R 
+/CropBox [0 0 323.1496062992126 459.21259842519686 ] 
+/Length 1525 
+/MediaBox [0 0 323.1496062992126 459.21259842519686 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 19 
+/Type /Page 
+>>
+endobj
+117 0 obj
+<<
+/ActualText (C6) 
+/K <<
+/Type /MCR 
+/Pg 116 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+118 0 obj
+<<
+/ActualText (Family: ISO C) 
+/K <<
+/Type /MCR 
+/Pg 116 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+119 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 116 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+120 0 obj
+<<
+/ActualText <feff00530069007a0065003a00200034002e0034003800380069006e002000d700200036002e0033003700380069006e0020007c0020003100310034002000d700200031003600320020006d006d0020007c0020003300320033002e00310035002000d70020003400350039002e003200310033002000700074> 
+/K <<
+/Type /MCR 
+/Pg 116 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+121 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="C6".) 
+/K <<
+/Type /MCR 
+/Pg 116 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+122 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 116 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+123 0 obj
+<<
+/Contents 266 0 R 
+/CropBox [0 0 229.60629921259843 323.1496062992126 ] 
+/Length 1599 
+/MediaBox [0 0 229.60629921259843 323.1496062992126 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 20 
+/Type /Page 
+>>
+endobj
+124 0 obj
+<<
+/ActualText (C7) 
+/K <<
+/Type /MCR 
+/Pg 123 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+125 0 obj
+<<
+/ActualText (Family: ISO C) 
+/K <<
+/Type /MCR 
+/Pg 123 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+126 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 123 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+127 0 obj
+<<
+/ActualText <feff00530069007a0065003a00200033002e0031003800390069006e002000d700200034002e0034003800380069006e0020007c002000380031002000d700200031003100340020006d006d0020007c0020003200320039002e003600300036002000d70020003300320033002e00310035002000700074> 
+/K [<<
+/Type /MCR 
+/Pg 123 0 R 
+/MCID 3 
+>>
+<<
+/Type /MCR 
+/Pg 123 0 R 
+/MCID 4 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+128 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="C7".) 
+/K [<<
+/Type /MCR 
+/Pg 123 0 R 
+/MCID 5 
+>>
+<<
+/Type /MCR 
+/Pg 123 0 R 
+/MCID 6 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+129 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 123 0 R 
+/MCID 7 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+130 0 obj
+<<
+/Contents 267 0 R 
+/CropBox [0 0 161.5748031496063 229.60629921259843 ] 
+/Length 1596 
+/MediaBox [0 0 161.5748031496063 229.60629921259843 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 21 
+/Type /Page 
+>>
+endobj
+131 0 obj
+<<
+/ActualText (C8) 
+/K <<
+/Type /MCR 
+/Pg 130 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+132 0 obj
+<<
+/ActualText (Family: ISO C) 
+/K <<
+/Type /MCR 
+/Pg 130 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+133 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 130 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+134 0 obj
+<<
+/ActualText <feff00530069007a0065003a00200032002e0032003400340069006e002000d700200033002e0031003800390069006e0020007c002000350037002000d70020003800310020006d006d0020007c0020003100360031002e003500370035002000d70020003200320039002e003600300036002000700074> 
+/K [<<
+/Type /MCR 
+/Pg 130 0 R 
+/MCID 3 
+>>
+<<
+/Type /MCR 
+/Pg 130 0 R 
+/MCID 4 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+135 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="C8".) 
+/K [<<
+/Type /MCR 
+/Pg 130 0 R 
+/MCID 5 
+>>
+<<
+/Type /MCR 
+/Pg 130 0 R 
+/MCID 6 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+136 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 130 0 R 
+/MCID 7 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+137 0 obj
+<<
+/Contents 268 0 R 
+/CropBox [0 0 113.38582677165356 161.5748031496063 ] 
+/Length 927 
+/MediaBox [0 0 113.38582677165356 161.5748031496063 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 22 
+/Type /Page 
+>>
+endobj
+138 0 obj
+<<
+/ActualText (C9) 
+/K <<
+/Type /MCR 
+/Pg 137 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+139 0 obj
+<<
+/ActualText (Family: ISO C) 
+/K <<
+/Type /MCR 
+/Pg 137 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+140 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K [<<
+/Type /MCR 
+/Pg 137 0 R 
+/MCID 2 
+>>
+<<
+/Type /MCR 
+/Pg 137 0 R 
+/MCID 3 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+141 0 obj
+<<
+/ActualText <feff00530069007a0065003a00200031002e0035003700350069006e002000d700200032002e0032003400340069006e0020007c002000340030002000d70020003500370020006d006d0020007c0020003100310033002e003300380036002000d70020003100360031002e003500370035002000700074> 
+/K [<<
+/Type /MCR 
+/Pg 137 0 R 
+/MCID 4 
+>>
+<<
+/Type /MCR 
+/Pg 137 0 R 
+/MCID 5 
+>>
+<<
+/Type /MCR 
+/Pg 137 0 R 
+/MCID 6 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+142 0 obj
+<<
+/Contents 269 0 R 
+/CropBox [0 0 113.38582677165356 161.5748031496063 ] 
+/Length 585 
+/MediaBox [0 0 113.38582677165356 161.5748031496063 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 23 
+/Type /Page 
+>>
+endobj
+143 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="C9".) 
+/K [<<
+/Type /MCR 
+/Pg 142 0 R 
+/MCID 0 
+>>
+<<
+/Type /MCR 
+/Pg 142 0 R 
+/MCID 1 
+>>
+<<
+/Type /MCR 
+/Pg 142 0 R 
+/MCID 2 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+144 0 obj
+<<
+/Contents 270 0 R 
+/CropBox [0 0 113.38582677165356 161.5748031496063 ] 
+/Length 258 
+/MediaBox [0 0 113.38582677165356 161.5748031496063 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 24 
+/Type /Page 
+>>
+endobj
+145 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K [<<
+/Type /MCR 
+/Pg 144 0 R 
+/MCID 0 
+>>
+<<
+/Type /MCR 
+/Pg 144 0 R 
+/MCID 1 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+146 0 obj
+<<
+/Contents 271 0 R 
+/CropBox [0 0 79.37007874015748 113.38582677165356 ] 
+/Length 538 
+/MediaBox [0 0 79.37007874015748 113.38582677165356 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 25 
+/Type /Page 
+>>
+endobj
+147 0 obj
+<<
+/ActualText (C10) 
+/K <<
+/Type /MCR 
+/Pg 146 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+148 0 obj
+<<
+/ActualText (Family: ISO C) 
+/K <<
+/Type /MCR 
+/Pg 146 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+149 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K [<<
+/Type /MCR 
+/Pg 146 0 R 
+/MCID 2 
+>>
+<<
+/Type /MCR 
+/Pg 146 0 R 
+/MCID 3 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+150 0 obj
+<<
+/Contents 272 0 R 
+/CropBox [0 0 79.37007874015748 113.38582677165356 ] 
+/Length 920 
+/MediaBox [0 0 79.37007874015748 113.38582677165356 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 26 
+/Type /Page 
+>>
+endobj
+151 0 obj
+<<
+/ActualText <feff00530069007a0065003a00200031002e0031003000320069006e002000d700200031002e0035003700350069006e0020007c002000320038002000d70020003400300020006d006d0020007c002000370039002e00330037002000d70020003100310033002e003300380036002000700074> 
+/K [<<
+/Type /MCR 
+/Pg 150 0 R 
+/MCID 0 
+>>
+<<
+/Type /MCR 
+/Pg 150 0 R 
+/MCID 1 
+>>
+<<
+/Type /MCR 
+/Pg 150 0 R 
+/MCID 2 
+>>
+<<
+/Type /MCR 
+/Pg 150 0 R 
+/MCID 3 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+152 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="C10".) 
+/K [<<
+/Type /MCR 
+/Pg 150 0 R 
+/MCID 4 
+>>
+<<
+/Type /MCR 
+/Pg 150 0 R 
+/MCID 5 
+>>
+<<
+/Type /MCR 
+/Pg 150 0 R 
+/MCID 6 
+>>
+<<
+/Type /MCR 
+/Pg 150 0 R 
+/MCID 7 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+153 0 obj
+<<
+/Contents 273 0 R 
+/CropBox [0 0 79.37007874015748 113.38582677165356 ] 
+/Length 407 
+/MediaBox [0 0 79.37007874015748 113.38582677165356 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 27 
+/Type /Page 
+>>
+endobj
+154 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a00200030002e00350069006e002000d700200030002e00350069006e> 
+/K [<<
+/Type /MCR 
+/Pg 153 0 R 
+/MCID 0 
+>>
+<<
+/Type /MCR 
+/Pg 153 0 R 
+/MCID 1 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+155 0 obj
+<<
+/Contents 274 0 R 
+/CropBox [0 0 609.4488188976378 864.5669291338584 ] 
+/Length 1545 
+/MediaBox [0 0 609.4488188976378 864.5669291338584 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 28 
+/Type /Page 
+>>
+endobj
+156 0 obj
+<<
+/ActualText (RA4) 
+/K <<
+/Type /MCR 
+/Pg 155 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+157 0 obj
+<<
+/ActualText (Family: ISO RA) 
+/K <<
+/Type /MCR 
+/Pg 155 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+158 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 155 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+159 0 obj
+<<
+/ActualText <feff00530069007a0065003a00200038002e0034003600350069006e002000d7002000310032002e0030003000380069006e0020007c0020003200310035002000d700200033003000350020006d006d0020007c0020003600300039002e003400340039002000d70020003800360034002e003500360037002000700074> 
+/K <<
+/Type /MCR 
+/Pg 155 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+160 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="RA4".) 
+/K <<
+/Type /MCR 
+/Pg 155 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+161 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 155 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+162 0 obj
+<<
+/Contents 275 0 R 
+/CropBox [0 0 637.7952755905512 907.0866141732284 ] 
+/Length 1557 
+/MediaBox [0 0 637.7952755905512 907.0866141732284 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 29 
+/Type /Page 
+>>
+endobj
+163 0 obj
+<<
+/ActualText (SRA4) 
+/K <<
+/Type /MCR 
+/Pg 162 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+164 0 obj
+<<
+/ActualText (Family: ISO SRA) 
+/K <<
+/Type /MCR 
+/Pg 162 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+165 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 162 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+166 0 obj
+<<
+/ActualText <feff00530069007a0065003a00200038002e0038003500380069006e002000d7002000310032002e0035003900380069006e0020007c0020003200320035002000d700200033003200300020006d006d0020007c0020003600330037002e003700390035002000d70020003900300037002e003000380037002000700074> 
+/K <<
+/Type /MCR 
+/Pg 162 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+167 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="SRA4".) 
+/K <<
+/Type /MCR 
+/Pg 162 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+168 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 162 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+169 0 obj
+<<
+/Contents 276 0 R 
+/CropBox [0 0 396 612 ] 
+/Length 1587 
+/MediaBox [0 0 396 612 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 30 
+/Type /Page 
+>>
+endobj
+170 0 obj
+<<
+/ActualText (halfletter) 
+/K <<
+/Type /MCR 
+/Pg 169 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+171 0 obj
+<<
+/ActualText (Family: North American) 
+/K <<
+/Type /MCR 
+/Pg 169 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+172 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 169 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+173 0 obj
+<<
+/ActualText <feff00530069007a0065003a00200035002e00350069006e002000d700200038002e00350069006e0020007c0020003100330039002e0037002000d70020003200310035002e00390020006d006d0020007c0020003300390036002000d70020003600310032002000700074> 
+/K <<
+/Type /MCR 
+/Pg 169 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+174 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="halfletter".) 
+/K <<
+/Type /MCR 
+/Pg 169 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+175 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 169 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+176 0 obj
+<<
+/Contents 277 0 R 
+/CropBox [0 0 396 612 ] 
+/Length 1579 
+/MediaBox [0 0 396 612 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 31 
+/Type /Page 
+>>
+endobj
+177 0 obj
+<<
+/ActualText (statement) 
+/K <<
+/Type /MCR 
+/Pg 176 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+178 0 obj
+<<
+/ActualText (Family: North American) 
+/K <<
+/Type /MCR 
+/Pg 176 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+179 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 176 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+180 0 obj
+<<
+/ActualText <feff00530069007a0065003a00200035002e00350069006e002000d700200038002e00350069006e0020007c0020003100330039002e0037002000d70020003200310035002e00390020006d006d0020007c0020003300390036002000d70020003600310032002000700074> 
+/K <<
+/Type /MCR 
+/Pg 176 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+181 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="statement".) 
+/K <<
+/Type /MCR 
+/Pg 176 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+182 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 176 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+183 0 obj
+<<
+/Contents 278 0 R 
+/CropBox [0 0 612 792 ] 
+/Length 1551 
+/MediaBox [0 0 612 792 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 32 
+/Type /Page 
+>>
+endobj
+184 0 obj
+<<
+/ActualText (letter) 
+/K <<
+/Type /MCR 
+/Pg 183 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+185 0 obj
+<<
+/ActualText (Family: North American) 
+/K <<
+/Type /MCR 
+/Pg 183 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+186 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 183 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+187 0 obj
+<<
+/ActualText <feff00530069007a0065003a00200038002e00350069006e002000d70020003100310069006e0020007c0020003200310035002e0039002000d70020003200370039002e00340020006d006d0020007c0020003600310032002000d70020003700390032002000700074> 
+/K <<
+/Type /MCR 
+/Pg 183 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+188 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="letter".) 
+/K <<
+/Type /MCR 
+/Pg 183 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+189 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 183 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+190 0 obj
+<<
+/Contents 279 0 R 
+/CropBox [0 0 612 1008 ] 
+/Length 1547 
+/MediaBox [0 0 612 1008 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 33 
+/Type /Page 
+>>
+endobj
+191 0 obj
+<<
+/ActualText (legal) 
+/K <<
+/Type /MCR 
+/Pg 190 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+192 0 obj
+<<
+/ActualText (Family: North American) 
+/K <<
+/Type /MCR 
+/Pg 190 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+193 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 190 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+194 0 obj
+<<
+/ActualText <feff00530069007a0065003a00200038002e00350069006e002000d70020003100340069006e0020007c0020003200310035002e0039002000d70020003300350035002e00360020006d006d0020007c0020003600310032002000d700200031003000300038002000700074> 
+/K <<
+/Type /MCR 
+/Pg 190 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+195 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="legal".) 
+/K <<
+/Type /MCR 
+/Pg 190 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+196 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 190 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+197 0 obj
+<<
+/Contents 280 0 R 
+/CropBox [0 0 360 576 ] 
+/Length 1571 
+/MediaBox [0 0 360 576 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 34 
+/Type /Page 
+>>
+endobj
+198 0 obj
+<<
+/ActualText (juniorlegal) 
+/K <<
+/Type /MCR 
+/Pg 197 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+199 0 obj
+<<
+/ActualText (Family: North American) 
+/K <<
+/Type /MCR 
+/Pg 197 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+200 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 197 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+201 0 obj
+<<
+/ActualText <feff00530069007a0065003a002000350069006e002000d7002000380069006e0020007c0020003100320037002000d70020003200300033002e00320020006d006d0020007c0020003300360030002000d70020003500370036002000700074> 
+/K <<
+/Type /MCR 
+/Pg 197 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+202 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="juniorlegal".) 
+/K <<
+/Type /MCR 
+/Pg 197 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+203 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 197 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+204 0 obj
+<<
+/Contents 281 0 R 
+/CropBox [0 0 576 756 ] 
+/Length 1631 
+/MediaBox [0 0 576 756 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 35 
+/Type /Page 
+>>
+endobj
+205 0 obj
+<<
+/ActualText (governmentletter) 
+/K <<
+/Type /MCR 
+/Pg 204 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+206 0 obj
+<<
+/ActualText (Family: North American) 
+/K <<
+/Type /MCR 
+/Pg 204 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+207 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 204 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+208 0 obj
+<<
+/ActualText <feff00530069007a0065003a002000380069006e002000d7002000310030002e00350069006e0020007c0020003200300033002e0032002000d70020003200360036002e00370020006d006d0020007c0020003500370036002000d70020003700350036002000700074> 
+/K <<
+/Type /MCR 
+/Pg 204 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+209 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="governmentletter".) 
+/K <<
+/Type /MCR 
+/Pg 204 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+210 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 204 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+211 0 obj
+<<
+/Contents 282 0 R 
+/CropBox [0 0 612 936 ] 
+/Length 1623 
+/MediaBox [0 0 612 936 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 36 
+/Type /Page 
+>>
+endobj
+212 0 obj
+<<
+/ActualText (governmentlegal) 
+/K <<
+/Type /MCR 
+/Pg 211 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+213 0 obj
+<<
+/ActualText (Family: North American) 
+/K <<
+/Type /MCR 
+/Pg 211 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+214 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 211 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+215 0 obj
+<<
+/ActualText <feff00530069007a0065003a00200038002e00350069006e002000d70020003100330069006e0020007c0020003200310035002e0039002000d70020003300330030002e00320020006d006d0020007c0020003600310032002000d70020003900330036002000700074> 
+/K <<
+/Type /MCR 
+/Pg 211 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+216 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="governmentlegal".) 
+/K <<
+/Type /MCR 
+/Pg 211 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+217 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 211 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+218 0 obj
+<<
+/Contents 283 0 R 
+/CropBox [0 0 522 756 ] 
+/Length 1591 
+/MediaBox [0 0 522 756 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 37 
+/Type /Page 
+>>
+endobj
+219 0 obj
+<<
+/ActualText (executive) 
+/K <<
+/Type /MCR 
+/Pg 218 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+220 0 obj
+<<
+/ActualText (Family: North American) 
+/K <<
+/Type /MCR 
+/Pg 218 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+221 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 218 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+222 0 obj
+<<
+/ActualText <feff00530069007a0065003a00200037002e003200350069006e002000d7002000310030002e00350069006e0020007c0020003100380034002e00310035002000d70020003200360036002e00370020006d006d0020007c0020003500320032002000d70020003700350036002000700074> 
+/K <<
+/Type /MCR 
+/Pg 218 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+223 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="executive".) 
+/K <<
+/Type /MCR 
+/Pg 218 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+224 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 218 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+225 0 obj
+<<
+/Contents 284 0 R 
+/CropBox [0 0 612 936 ] 
+/Length 1543 
+/MediaBox [0 0 612 936 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 38 
+/Type /Page 
+>>
+endobj
+226 0 obj
+<<
+/ActualText (folio) 
+/K <<
+/Type /MCR 
+/Pg 225 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+227 0 obj
+<<
+/ActualText (Family: North American) 
+/K <<
+/Type /MCR 
+/Pg 225 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+228 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 225 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+229 0 obj
+<<
+/ActualText <feff00530069007a0065003a00200038002e00350069006e002000d70020003100330069006e0020007c0020003200310035002e0039002000d70020003300330030002e00320020006d006d0020007c0020003600310032002000d70020003900330036002000700074> 
+/K <<
+/Type /MCR 
+/Pg 225 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+230 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="folio".) 
+/K <<
+/Type /MCR 
+/Pg 225 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+231 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 225 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+232 0 obj
+<<
+/Contents 285 0 R 
+/CropBox [0 0 576 720 ] 
+/Length 1535 
+/MediaBox [0 0 576 720 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 39 
+/Type /Page 
+>>
+endobj
+233 0 obj
+<<
+/ActualText (quarto) 
+/K <<
+/Type /MCR 
+/Pg 232 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+234 0 obj
+<<
+/ActualText (Family: North American) 
+/K <<
+/Type /MCR 
+/Pg 232 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+235 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 232 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+236 0 obj
+<<
+/ActualText <feff00530069007a0065003a002000380069006e002000d70020003100300069006e0020007c0020003200300033002e0032002000d700200032003500340020006d006d0020007c0020003500370036002000d70020003700320030002000700074> 
+/K <<
+/Type /MCR 
+/Pg 232 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+237 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="quarto".) 
+/K <<
+/Type /MCR 
+/Pg 232 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+238 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 232 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+239 0 obj
+<<
+/Contents 286 0 R 
+/CropBox [0 0 612 792 ] 
+/Length 1503 
+/MediaBox [0 0 612 792 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 40 
+/Type /Page 
+>>
+endobj
+240 0 obj
+<<
+/ActualText (ansia) 
+/K <<
+/Type /MCR 
+/Pg 239 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+241 0 obj
+<<
+/ActualText (Family: ANSI) 
+/K <<
+/Type /MCR 
+/Pg 239 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+242 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 239 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+243 0 obj
+<<
+/ActualText <feff00530069007a0065003a00200038002e00350069006e002000d70020003100310069006e0020007c0020003200310035002e0039002000d70020003200370039002e00340020006d006d0020007c0020003600310032002000d70020003700390032002000700074> 
+/K <<
+/Type /MCR 
+/Pg 239 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+244 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="ansia".) 
+/K <<
+/Type /MCR 
+/Pg 239 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+245 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 239 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+246 0 obj
+<<
+/Length 1529 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 788.9493 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<00010002> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b0008000c> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e00070008001500160017001800150004000f000800190008001a001a00160018001b001c0004000f0008001d00080017001a001e0008001900080017001b001f0008000300030008001d00080020001b002000160017001f001800080019000800150021001a00160015001b000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0022002300040005001000240004000f00080012001000060005000e00080005001100110025002300130008000400120008002600020012000e00240004000f0012000e000f00120004001000040027000e002800080010002900040012000800130002002a000e000800230012000e001200080012001000060005000e002b002c000c0021002c0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 653.8898 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 653.8898 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 642.4996 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002d000200050004002e000d0002001000040011000f00080012002f00230002000d000e00070008001a0004000f000800190008001a0004000f> Tj
+EMC
+ET
+endstream
+endobj
+247 0 obj
+<<
+/Length 1529 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 542.3352 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<00010003> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b0008000c> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e000700080020001600150017001f0004000f000800190008001500160017001800150004000f0008001d0008001a002100150008001900080017001a001e0008000300030008001d00080021001a001b00160020001700150008001900080020001b002000160017001f0018000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0022002300040005001000240004000f00080012001000060005000e00080005001100110025002300130008000400120008002600020012000e00240004000f0012000e000f00120004001000040027000e002800080010002900040012000800130002002a000e000800230012000e001200080012001000060005000e002b002c000c0020002c0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 407.2756 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 407.2756 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 395.8855 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002d000200050004002e000d0002001000040011000f00080012002f00230002000d000e00070008001a0004000f000800190008001a0004000f> Tj
+EMC
+ET
+endstream
+endobj
+248 0 obj
+<<
+/Length 1529 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+18 384.5871 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<00010004> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b0008000c> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e0007000800210016001a001c00210004000f0008001900080020001600150017001f0004000f0008001d0008001a001e0020000800190008001a002100150008000300030008001d00080017001b001f00160018001c00150008001900080021001a001b0016002000170015000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0022002300040005001000240004000f00080012001000060005000e00080005001100110025002300130008000400120008002600020012000e00240004000f0012000e000f00120004001000040027000e002800080010002900040012000800130002002a000e000800230012000e001200080012001000060005000e002b002c000c0018002c0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+18 249.5276 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+18 249.5276 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+18 238.1374 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002d000200050004002e000d0002001000040011000f00080012002f00230002000d000e00070008001a0004000f000800190008001a0004000f> Tj
+EMC
+ET
+endstream
+endobj
+249 0 obj
+<<
+/Length 1602 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+18 262.6974 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<00010005> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b0008000c> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e0007000800170016001b001a001c0004000f00080019000800210016001a001c00210004000f0008001d0008001f0021000800190008001a001e00200008000300030008001d00080017001e001b0016001f0018002100080019> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0017001b001f00160018001c0015000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 5 
+>>
+BDC
+<0022002300040005001000240004000f00080012001000060005000e00080005001100110025002300130008000400120008002600020012000e00240004000f0012000e000f00120004001000040027000e002800080010002900040012000800130002002a000e000800230012000e0012> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 6 
+>>
+BDC
+<0012001000060005000e002b002c000c001f002c0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+18 106.6378 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+18 106.6378 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+18 95.2477 Td
+/P <<
+/MCID 7 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002d000200050004002e000d0002001000040011000f00080012002f00230002000d000e00070008001a0004000f000800190008001a0004000f> Tj
+EMC
+ET
+endstream
+endobj
+250 0 obj
+<<
+/Length 1592 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+9 183.8233 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<00010006> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b0008000c> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e0007000800170016001e0021001f0004000f00080019000800170016001b001a001c0004000f0008001d000800200017000800190008001f00210008000300030008001d> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<001a0021001f00160021001e00170008001900080017001e001b0016001f00180021000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 5 
+>>
+BDC
+<0022002300040005001000240004000f00080012001000060005000e00080005001100110025002300130008000400120008002600020012000e00240004000f0012000e000f00120004001000040027000e0028> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 6 
+>>
+BDC
+<0010002900040012000800130002002a000e000800230012000e001200080012001000060005000e002b002c000c0015002c0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+9 27.7638 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+9 27.7638 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+9 16.3736 Td
+/P <<
+/MCID 7 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002d000200050004002e000d0002001000040011000f00080012002f00230002000d000e00070008001a0004000f000800190008001a0004000f> Tj
+EMC
+ET
+endstream
+endobj
+251 0 obj
+<<
+/Length 1361 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+9 121.4611 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<00010007> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b0008000c> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<00130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<000a00040014000e00070008001a001600210020001f0004000f00080019000800170016001e0021001f0004000f0008001d0008001c001f> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 5 
+>>
+BDC
+<00190008002000170008000300030008001d0008001a001e0021001600150015001700080019> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 6 
+>>
+BDC
+<001a0021001f00160021001e0017000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 7 
+>>
+BDC
+<0022002300040005001000240004000f00080012001000060005000e00080005001100110025002300130008000400120008002600020012000e0024> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 8 
+>>
+BDC
+<0004000f0012000e000f00120004001000040027000e002800080010002900040012000800130002002a000e000800230012000e0012> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 9 
+>>
+BDC
+<0012001000060005000e002b002c000c001b002c0016> Tj
+EMC
+ET
+endstream
+endobj
+252 0 obj
+<<
+/Length 352 
+>>
+stream
+/Artifact BMC
+0.9412 0.9725 1 rg
+9 66.4016 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+9 66.4016 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+9 55.0114 Td
+/P <<
+/MCID 0 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002d000200050004002e000d0002001000040011000f00080012002f00230002000d000e00070008001a0004000f000800190008001a0004000f> Tj
+EMC
+ET
+endstream
+endobj
+253 0 obj
+<<
+/Length 786 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+9 78.9415 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<000100080009> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b0008000c> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<00120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<000a00040014000e00070008001a0016001e001700210004000f00080019> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 5 
+>>
+BDC
+<001a001600210020001f0004000f0008001d000800170018000800190008001c001f> Tj
+EMC
+ET
+endstream
+endobj
+254 0 obj
+<<
+/Length 750 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+9 90.4918 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000300030008001d0008001f001c0016001f001e001a00080019> Tj
+EMC
+0 -7 Td
+/P <<
+/MCID 1 
+>>
+BDC
+<001a001e00210016001500150017000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<0022002300040005001000240004000f00080012001000060005000e> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<0005001100110025002300130008000400120008002600020012000e0024> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0004000f0012000e000f00120004001000040027000e002800080010002900040012> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 5 
+>>
+BDC
+<00130002002a000e000800230012000e0012> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 6 
+>>
+BDC
+<0012001000060005000e002b002c000c001a001e002c0016> Tj
+EMC
+ET
+endstream
+endobj
+255 0 obj
+<<
+/Length 446 
+>>
+stream
+/Artifact BMC
+0.9412 0.9725 1 rg
+9 59.8819 36 36 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+9 59.8819 36 36 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+9 48.4918 Td
+/P <<
+/MCID 0 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002d000200050004002e000d0002001000040011000f> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 1 
+>>
+BDC
+<0012002f00230002000d000e00070008001e001600200004000f00080019> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<001e001600200004000f> Tj
+EMC
+ET
+endstream
+endobj
+256 0 obj
+<<
+/Length 1528 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 655.721 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<000a0003> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b00080022> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e0007000800180016001b0017001b0004000f000800190008001b001600150021001c0004000f0008001d0008001a001f001800080019000800170020001e0008000300030008001d00080021001b001500160015001b0015000800190008001f001e0015001600180018001a000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0022002300040005001000240004000f00080012001000060005000e00080005001100110025002300130008000400120008002600020012000e00240004000f0012000e000f00120004001000040027000e002800080010002900040012000800130002002a000e000800230012000e001200080012001000060005000e002b002c00220020002c0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 520.6614 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 520.6614 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 509.2713 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002d000200050004002e000d0002001000040011000f00080012002f00230002000d000e00070008001a0004000f000800190008001a0004000f> Tj
+EMC
+ET
+endstream
+endobj
+257 0 obj
+<<
+/Length 1529 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 445.9572 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<000a0004> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b00080022> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e0007000800210016001b0017001a0004000f00080019000800180016001b0017001b0004000f0008001d0008001a00170020000800190008001a001f00180008000300030008001d0008001c002000210016001c001c001a0008001900080021001b001500160015001b0015000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0022002300040005001000240004000f00080012001000060005000e00080005001100110025002300130008000400120008002600020012000e00240004000f0012000e000f00120004001000040027000e002800080010002900040012000800130002002a000e000800230012000e001200080012001000060005000e002b002c00220018002c0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 310.8976 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 310.8976 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 299.5075 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002d000200050004002e000d0002001000040011000f00080012002f00230002000d000e00070008001a0004000f000800190008001a0004000f> Tj
+EMC
+ET
+endstream
+endobj
+258 0 obj
+<<
+/Length 1603 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 301.3903 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<000a0005> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b00080022> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e00070008001c00160021001800200004000f00080019000800210016001b0017001a0004000f0008001d000800150015000800190008001a001700200008000300030008001d000800170021001b001600210021001b00080019> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<001c002000210016001c001c001a000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 5 
+>>
+BDC
+<0022002300040005001000240004000f00080012001000060005000e00080005001100110025002300130008000400120008002600020012000e00240004000f0012000e000f00120004001000040027000e002800080010002900040012000800130002002a000e000800230012000e0012> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 6 
+>>
+BDC
+<0012001000060005000e002b002c0022001f002c0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 145.3307 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 145.3307 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 133.9406 Td
+/P <<
+/MCID 7 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002d000200050004002e000d0002001000040011000f00080012002f00230002000d000e00070008001a0004000f000800190008001a0004000f> Tj
+EMC
+ET
+endstream
+endobj
+259 0 obj
+<<
+/Length 1596 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+18 214.5084 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<000a0006> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b00080022> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e000700080017001600210021001a0004000f000800190008001c00160021001800200004000f0008001d000800180017000800190008001500150008000300030008001d> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<001a001f00200016001f0021001500080019000800170021001b001600210021001b000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 5 
+>>
+BDC
+<0022002300040005001000240004000f00080012001000060005000e00080005001100110025002300130008000400120008002600020012000e00240004000f0012000e000f00120004001000040027000e002800080010002900040012> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 6 
+>>
+BDC
+<00130002002a000e000800230012000e001200080012001000060005000e002b002c00220015002c0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+18 58.4488 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+18 58.4488 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+18 47.0587 Td
+/P <<
+/MCID 7 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002d000200050004002e000d0002001000040011000f00080012002f00230002000d000e00070008001a0004000f000800190008001a0004000f> Tj
+EMC
+ET
+endstream
+endobj
+260 0 obj
+<<
+/Length 1362 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+18 140.8076 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<000a0007> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b00080022> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<00130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<000a00040014000e00070008001a0016001f001c00170004000f0008001900080017001600210021001a0004000f0008001d000800210021> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 5 
+>>
+BDC
+<00190008001800170008000300030008001d0008001a001700210016001f0017002100080019> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 6 
+>>
+BDC
+<001a001f00200016001f00210015000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 7 
+>>
+BDC
+<0022002300040005001000240004000f00080012001000060005000e00080005001100110025002300130008000400120008002600020012000e0024> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 8 
+>>
+BDC
+<0004000f0012000e000f00120004001000040027000e002800080010002900040012000800130002002a000e000800230012000e0012> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 9 
+>>
+BDC
+<0012001000060005000e002b002c0022001b002c0016> Tj
+EMC
+ET
+endstream
+endobj
+261 0 obj
+<<
+/Length 353 
+>>
+stream
+/Artifact BMC
+0.9412 0.9725 1 rg
+18 85.748 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+18 85.748 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+18 74.3579 Td
+/P <<
+/MCID 0 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002d000200050004002e000d0002001000040011000f00080012002f00230002000d000e00070008001a0004000f000800190008001a0004000f> Tj
+EMC
+ET
+endstream
+endobj
+262 0 obj
+<<
+/Length 920 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+9 98.784 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<000a00080009> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b00080022> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<00130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<000a00040014000e00070008001a0016001700170004000f000800190008001a0016001f001c00170004000f> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 5 
+>>
+BDC
+<001d0008001c001a000800190008002100210008000300030008001d00080015001f00160015001f0021> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 6 
+>>
+BDC
+<00190008001a001700210016001f00170021000800130010> Tj
+EMC
+ET
+endstream
+endobj
+263 0 obj
+<<
+/Length 906 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+9 110.3343 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<0022002300040005001000240004000f00080012001000060005000e0008000500110011002500230013000800040012> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 1 
+>>
+BDC
+<002600020012000e00240004000f0012000e000f00120004001000040027000e002800080010002900040012> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<00130002002a000e000800230012000e0012> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<0012001000060005000e002b002c0022001a001e002c0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+9 35.2244 36 36 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+9 35.2244 36 36 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+9 23.8343 Td
+/P <<
+/MCID 4 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002d000200050004002e000d0002001000040011000f00080012002f00230002000d000e0007> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 5 
+>>
+BDC
+<001e001600200004000f000800190008001e001600200004000f> Tj
+EMC
+ET
+endstream
+endobj
+264 0 obj
+<<
+/Length 1529 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 596.1934 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<000b0003> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b0008002d> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e0007000800180016001c001f00150004000f000800190008001b0016001e001a00180004000f0008001d0008001a0018001700080019000800170017001b0008000300030008001d000800210020001b00160017001a001c00080019000800180021001b0016001a001c0021000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0022002300040005001000240004000f00080012001000060005000e00080005001100110025002300130008000400120008002600020012000e00240004000f0012000e000f00120004001000040027000e002800080010002900040012000800130002002a000e000800230012000e001200080012001000060005000e002b002c002d0020002c0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 461.1339 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 461.1339 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 449.7437 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002d000200050004002e000d0002001000040011000f00080012002f00230002000d000e00070008001a0004000f000800190008001a0004000f> Tj
+EMC
+ET
+endstream
+endobj
+265 0 obj
+<<
+/Length 1525 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 406.2722 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<000b0004> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b0008002d> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e00070008002100160021001500150004000f00080019000800180016001c001f00150004000f0008001d0008001a001a0021000800190008001a001800170008000300030008001d0008001c0017001c0016001a002000080019000800210020001b00160017001a001c000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0022002300040005001000240004000f00080012001000060005000e00080005001100110025002300130008000400120008002600020012000e00240004000f0012000e000f00120004001000040027000e002800080010002900040012000800130002002a000e000800230012000e001200080012001000060005000e002b002c002d0018002c0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 271.2126 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 271.2126 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 259.8225 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002d000200050004002e000d0002001000040011000f00080012002f00230002000d000e00070008001a0004000f000800190008001a0004000f> Tj
+EMC
+ET
+endstream
+endobj
+266 0 obj
+<<
+/Length 1599 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 270.2092 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<000b0005> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b0008002d> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e00070008001c0016001a0015001b0004000f000800190008002100160021001500150004000f0008001d00080015001a000800190008001a001a00210008000300030008001d000800170017001b00160018001e001800080019> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<001c0017001c0016001a0020000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 5 
+>>
+BDC
+<0022002300040005001000240004000f00080012001000060005000e00080005001100110025002300130008000400120008002600020012000e00240004000f0012000e000f00120004001000040027000e002800080010002900040012000800130002002a000e> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 6 
+>>
+BDC
+<00230012000e001200080012001000060005000e002b002c002d001f002c0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 114.1496 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 114.1496 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 102.7595 Td
+/P <<
+/MCID 7 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002d000200050004002e000d0002001000040011000f00080012002f00230002000d000e00070008001a0004000f000800190008001a0004000f> Tj
+EMC
+ET
+endstream
+endobj
+267 0 obj
+<<
+/Length 1596 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+18 194.6659 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<000b0006> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b0008002d> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e00070008001700160017002100210004000f000800190008001c0016001a0015001b0004000f0008001d00080020001f0008001900080015001a0008000300030008001d> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<001a0018001a00160020001f002000080019000800170017001b00160018001e0018000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 5 
+>>
+BDC
+<0022002300040005001000240004000f00080012001000060005000e00080005001100110025002300130008000400120008002600020012000e00240004000f0012000e000f00120004001000040027000e0028> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 6 
+>>
+BDC
+<0010002900040012000800130002002a000e000800230012000e001200080012001000060005000e002b002c002d0015002c0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+18 38.6063 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+18 38.6063 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+18 27.2162 Td
+/P <<
+/MCID 7 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002d000200050004002e000d0002001000040011000f00080012002f00230002000d000e00070008001a0004000f000800190008001a0004000f> Tj
+EMC
+ET
+endstream
+endobj
+268 0 obj
+<<
+/Length 927 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+18 126.6344 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<000b0007> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b0008002d> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<00130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<000a00040014000e00070008001a00160020001f00200004000f000800190008001700160017002100210004000f0008001d> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 5 
+>>
+BDC
+<0021001e0008001900080020001f0008000300030008001d0008001a001a001c0016001c0015001800080019> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 6 
+>>
+BDC
+<001a0018001a00160020001f0020000800130010> Tj
+EMC
+ET
+endstream
+endobj
+269 0 obj
+<<
+/Length 585 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+18 138.1847 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<0022002300040005001000240004000f00080012001000060005000e0008000500110011002500230013000800040012> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 1 
+>>
+BDC
+<002600020012000e00240004000f0012000e000f00120004001000040027000e002800080010002900040012> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<00130002002a000e000800230012000e001200080012001000060005000e002b002c002d001b002c0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+18 37.5748 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+18 37.5748 72 72 re
+S
+EMC
+endstream
+endobj
+270 0 obj
+<<
+/Length 258 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+18 138.1847 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<002d000200050004002e000d0002001000040011000f00080012002f00230002000d000e00070008001a0004000f00080019> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 1 
+>>
+BDC
+<001a0004000f> Tj
+EMC
+ET
+endstream
+endobj
+271 0 obj
+<<
+/Length 538 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+9 87.4454 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<000b00080009> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b0008002d> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<00120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+ET
+endstream
+endobj
+272 0 obj
+<<
+/Length 920 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+9 98.9957 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000a00040014000e00070008001a0016001a001e00170004000f00080019> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 1 
+>>
+BDC
+<001a00160020001f00200004000f0008001d0008001700150008001900080021001e> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000300030008001d0008001f001b0016001c001f00080019> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<001a001a001c0016001c00150018000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0022002300040005001000240004000f00080012001000060005000e0008000500110011002500230013> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 5 
+>>
+BDC
+<000400120008002600020012000e00240004000f0012000e000f00120004001000040027000e0028> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 6 
+>>
+BDC
+<0010002900040012000800130002002a000e000800230012000e0012> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 7 
+>>
+BDC
+<0012001000060005000e002b002c002d001a001e002c0016> Tj
+EMC
+ET
+endstream
+endobj
+273 0 obj
+<<
+/Length 407 
+>>
+stream
+/Artifact BMC
+0.9412 0.9725 1 rg
+9 68.3858 36 36 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+9 68.3858 36 36 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+9 56.9957 Td
+/P <<
+/MCID 0 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002d000200050004002e000d0002001000040011000f00080012002f00230002000d000e0007> Tj
+EMC
+0 -10.5 Td
+/P <<
+/MCID 1 
+>>
+BDC
+<001e001600200004000f000800190008001e001600200004000f> Tj
+EMC
+ET
+endstream
+endobj
+274 0 obj
+<<
+/Length 1545 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 811.6265 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<000c00010002> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b00080030000c> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e00070008001500160021001800200004000f000800190008001a00170016001e001e00150004000f0008001d00080017001a0020000800190008001c001e00200008000300030008001d00080018001e001b001600210021001b000800190008001500180021001600200018001f000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0022002300040005001000240004000f00080012001000060005000e00080005001100110025002300130008000400120008002600020012000e00240004000f0012000e000f00120004001000040027000e002800080010002900040012000800130002002a000e000800230012000e001200080012001000060005000e002b002c0030000c0021002c0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 676.5669 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 676.5669 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 665.1768 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002d000200050004002e000d0002001000040011000f00080012002f00230002000d000e00070008001a0004000f000800190008001a0004000f> Tj
+EMC
+ET
+endstream
+endobj
+275 0 obj
+<<
+/Length 1557 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 854.1462 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<000d000c00010002> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b0008000a0030000c> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e00070008001500160015002000150004000f000800190008001a001700160020001b00150004000f0008001d0008001700170020000800190008001c0017001e0008000300030008001d00080018001c001f0016001f001b0020000800190008001b001e001f0016001e0015001f000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0022002300040005001000240004000f00080012001000060005000e00080005001100110025002300130008000400120008002600020012000e00240004000f0012000e000f00120004001000040027000e002800080010002900040012000800130002002a000e000800230012000e001200080012001000060005000e002b002c000a0030000c0021002c0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 719.0866 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 719.0866 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 707.6965 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002d000200050004002e000d0002001000040011000f00080012002f00230002000d000e00070008001a0004000f000800190008001a0004000f> Tj
+EMC
+ET
+endstream
+endobj
+276 0 obj
+<<
+/Length 1587 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 559.0596 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<000e000f00100011001000120013001300120014> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<0001000200030004000500060007000800310011000d001000290008000c0003000e000d000400260002000f> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e000700080020001600200004000f0008001900080015001600200004000f0008001d0008001a001c001b0016001f0008001900080017001a00200016001b0008000300030008001d0008001c001b00180008001900080018001a0017000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0022002300040005001000240004000f00080012001000060005000e00080005001100110025002300130008000400120008002600020012000e00240004000f0012000e000f00120004001000040027000e002800080010002900040012000800130002002a000e000800230012000e001200080012001000060005000e002b002c00290002000500320005000e00100010000e000d002c0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 424 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 424 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 412.6099 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002d000200050004002e000d0002001000040011000f00080012002f00230002000d000e00070008001a0004000f000800190008001a0004000f> Tj
+EMC
+ET
+endstream
+endobj
+277 0 obj
+<<
+/Length 1579 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 559.0596 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<00150013000f001300120016001200170013> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<0001000200030004000500060007000800310011000d001000290008000c0003000e000d000400260002000f> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e000700080020001600200004000f0008001900080015001600200004000f0008001d0008001a001c001b0016001f0008001900080017001a00200016001b0008000300030008001d0008001c001b00180008001900080018001a0017000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0022002300040005001000240004000f00080012001000060005000e00080005001100110025002300130008000400120008002600020012000e00240004000f0012000e000f00120004001000040027000e002800080010002900040012000800130002002a000e000800230012000e001200080012001000060005000e002b002c0012001000020010000e0003000e000f0010002c0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 424 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 424 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 412.6099 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002d000200050004002e000d0002001000040011000f00080012002f00230002000d000e00070008001a0004000f000800190008001a0004000f> Tj
+EMC
+ET
+endstream
+endobj
+278 0 obj
+<<
+/Length 1551 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 739.0596 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<001000120013001300120014> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<0001000200030004000500060007000800310011000d001000290008000c0003000e000d000400260002000f> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e000700080015001600200004000f000800190008001a001a0004000f0008001d00080017001a00200016001b0008001900080017001f001b001600210008000300030008001d00080018001a0017000800190008001f001b0017000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0022002300040005001000240004000f00080012001000060005000e00080005001100110025002300130008000400120008002600020012000e00240004000f0012000e000f00120004001000040027000e002800080010002900040012000800130002002a000e000800230012000e001200080012001000060005000e002b002c0005000e00100010000e000d002c0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 604 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 604 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 592.6099 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002d000200050004002e000d0002001000040011000f00080012002f00230002000d000e00070008001a0004000f000800190008001a0004000f> Tj
+EMC
+ET
+endstream
+endobj
+279 0 obj
+<<
+/Length 1547 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 955.0596 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<001000120018000f0010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<0001000200030004000500060007000800310011000d001000290008000c0003000e000d000400260002000f> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e000700080015001600200004000f000800190008001a00210004000f0008001d00080017001a00200016001b000800190008001c00200020001600180008000300030008001d00080018001a0017000800190008001a001e001e0015000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0022002300040005001000240004000f00080012001000060005000e00080005001100110025002300130008000400120008002600020012000e00240004000f0012000e000f00120004001000040027000e002800080010002900040012000800130002002a000e000800230012000e001200080012001000060005000e002b002c0005000e002a00020005002c0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 820 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 820 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 808.6099 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002d000200050004002e000d0002001000040011000f00080012002f00230002000d000e00070008001a0004000f000800190008001a0004000f> Tj
+EMC
+ET
+endstream
+endobj
+280 0 obj
+<<
+/Length 1571 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 523.0596 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<0019001a0017001b001c0014001000120018000f0010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<0001000200030004000500060007000800310011000d001000290008000c0003000e000d000400260002000f> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e0007000800200004000f00080019000800150004000f0008001d0008001a0017001f0008001900080017001e001c001600170008000300030008001d0008001c0018001e0008001900080020001f0018000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0022002300040005001000240004000f00080012001000060005000e00080005001100110025002300130008000400120008002600020012000e00240004000f0012000e000f00120004001000040027000e002800080010002900040012000800130002002a000e000800230012000e001200080012001000060005000e002b002c00330023000f00040011000d0005000e002a00020005002c0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 388 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 388 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 376.6099 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002d000200050004002e000d0002001000040011000f00080012002f00230002000d000e00070008001a0004000f000800190008001a0004000f> Tj
+EMC
+ET
+endstream
+endobj
+281 0 obj
+<<
+/Length 1631 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 703.0596 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<0018001c001d0012001400170016001200170013001000120013001300120014> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<0001000200030004000500060007000800310011000d001000290008000c0003000e000d000400260002000f> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e0007000800150004000f000800190008001a001e001600200004000f0008001d00080017001e001c001600170008001900080017001800180016001f0008000300030008001d00080020001f0018000800190008001f00200018000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0022002300040005001000240004000f00080012001000060005000e00080005001100110025002300130008000400120008002600020012000e00240004000f0012000e000f00120004001000040027000e002800080010002900040012000800130002002a000e000800230012000e001200080012001000060005000e002b002c002a00110027000e000d000f0003000e000f00100005000e00100010000e000d002c0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 568 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 568 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 556.6099 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002d000200050004002e000d0002001000040011000f00080012002f00230002000d000e00070008001a0004000f000800190008001a0004000f> Tj
+EMC
+ET
+endstream
+endobj
+282 0 obj
+<<
+/Length 1623 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 883.0596 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<0018001c001d0012001400170016001200170013001000120018000f0010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<0001000200030004000500060007000800310011000d001000290008000c0003000e000d000400260002000f> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e000700080015001600200004000f000800190008001a001c0004000f0008001d00080017001a00200016001b000800190008001c001c001e001600170008000300030008001d00080018001a0017000800190008001b001c0018000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0022002300040005001000240004000f00080012001000060005000e00080005001100110025002300130008000400120008002600020012000e00240004000f0012000e000f00120004001000040027000e002800080010002900040012000800130002002a000e000800230012000e001200080012001000060005000e002b002c002a00110027000e000d000f0003000e000f00100005000e002a00020005002c0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 748 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 748 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 736.6099 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002d000200050004002e000d0002001000040011000f00080012002f00230002000d000e00070008001a0004000f000800190008001a0004000f> Tj
+EMC
+ET
+endstream
+endobj
+283 0 obj
+<<
+/Length 1591 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 703.0596 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<0012001e0012001f001a0013001b001d0012> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<0001000200030004000500060007000800310011000d001000290008000c0003000e000d000400260002000f> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e00070008001f0016001700200004000f000800190008001a001e001600200004000f0008001d0008001a001500210016001a00200008001900080017001800180016001f0008000300030008001d0008002000170017000800190008001f00200018000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0022002300040005001000240004000f00080012001000060005000e00080005001100110025002300130008000400120008002600020012000e00240004000f0012000e000f00120004001000040027000e002800080010002900040012000800130002002a000e000800230012000e001200080012001000060005000e002b002c000e0034000e00260023001000040027000e002c0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 568 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 568 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 556.6099 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002d000200050004002e000d0002001000040011000f00080012002f00230002000d000e00070008001a0004000f000800190008001a0004000f> Tj
+EMC
+ET
+endstream
+endobj
+284 0 obj
+<<
+/Length 1543 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 883.0596 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<0011001c0010001b001c> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<0001000200030004000500060007000800310011000d001000290008000c0003000e000d000400260002000f> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e000700080015001600200004000f000800190008001a001c0004000f0008001d00080017001a00200016001b000800190008001c001c001e001600170008000300030008001d00080018001a0017000800190008001b001c0018000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0022002300040005001000240004000f00080012001000060005000e00080005001100110025002300130008000400120008002600020012000e00240004000f0012000e000f00120004001000040027000e002800080010002900040012000800130002002a000e000800230012000e001200080012001000060005000e002b002c00320011000500040011002c0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 748 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 748 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 736.6099 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002d000200050004002e000d0002001000040011000f00080012002f00230002000d000e00070008001a0004000f000800190008001a0004000f> Tj
+EMC
+ET
+endstream
+endobj
+285 0 obj
+<<
+/Length 1535 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 667.0596 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<0020001a000f00140013001c> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<0001000200030004000500060007000800310011000d001000290008000c0003000e000d000400260002000f> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e0007000800150004000f000800190008001a001e0004000f0008001d00080017001e001c001600170008001900080017002000210008000300030008001d00080020001f0018000800190008001f0017001e000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0022002300040005001000240004000f00080012001000060005000e00080005001100110025002300130008000400120008002600020012000e00240004000f0012000e000f00120004001000040027000e002800080010002900040012000800130002002a000e000800230012000e001200080012001000060005000e002b002c002f00230002000d00100011002c0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 532 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 532 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 520.6099 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002d000200050004002e000d0002001000040011000f00080012002f00230002000d000e00070008001a0004000f000800190008001a0004000f> Tj
+EMC
+ET
+endstream
+endobj
+286 0 obj
+<<
+/Length 1503 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 739.0596 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<000f00170015001b000f> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<00010002000300040005000600070008000c0031000a0009> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e000700080015001600200004000f000800190008001a001a0004000f0008001d00080017001a00200016001b0008001900080017001f001b001600210008000300030008001d00080018001a0017000800190008001f001b0017000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0022002300040005001000240004000f00080012001000060005000e00080005001100110025002300130008000400120008002600020012000e00240004000f0012000e000f00120004001000040027000e002800080010002900040012000800130002002a000e000800230012000e001200080012001000060005000e002b002c0002000f001200040002002c0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 604 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 604 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 592.6099 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002d000200050004002e000d0002001000040011000f00080012002f00230002000d000e00070008001a0004000f000800190008001a0004000f> Tj
+EMC
+ET
+endstream
+endobj
+287 0 obj
+<<
+/Length 1012 
+>>
+stream
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo << /Registry (Adobe) /Ordering (UCS) /Supplement 0 >> def
+/CMapName /Adobe-Identity-UCS def
+/CMapType 2 def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+52 beginbfchar
+<0001> <0046>
+<0002> <0061>
+<0003> <006D>
+<0004> <0069>
+<0005> <006C>
+<0006> <0079>
+<0007> <003A>
+<0008> <0020>
+<0009> <0049>
+<000A> <0053>
+<000B> <004F>
+<000C> <0041>
+<000D> <0072>
+<000E> <0065>
+<000F> <006E>
+<0010> <0074>
+<0011> <006F>
+<0012> <0073>
+<0013> <0070>
+<0014> <007A>
+<0015> <0038>
+<0016> <002E>
+<0017> <0032>
+<0018> <0036>
+<0019> <00D7>
+<001A> <0031>
+<001B> <0039>
+<001C> <0033>
+<001D> <007C>
+<001E> <0030>
+<001F> <0037>
+<0020> <0035>
+<0021> <0034>
+<0022> <0042>
+<0023> <0075>
+<0024> <002D>
+<0025> <006B>
+<0026> <0063>
+<0027> <0076>
+<0028> <003B>
+<0029> <0068>
+<002A> <0067>
+<002B> <003D>
+<002C> <0022>
+<002D> <0043>
+<002E> <0062>
+<002F> <0071>
+<0030> <0052>
+<0031> <004E>
+<0032> <0066>
+<0033> <006A>
+<0034> <0078>
+endbfchar
+endcmap
+CMap end
+end
+endstream
+endobj
+288 0 obj
+<<
+/Length 106 
+>>
+stream
+   ) D P L O \   , 6 2 $ U H Q W R V S ]         _     % X  N F Y  K J    & E T 5 1 I M [endstream
+endobj
+289 0 obj
+<<
+/Length 20712 
+/Length1 20712 
+>>
+stream
+     Ä  POS/2G$N   ‹   `cmap∏  <  cvt ò"A€  H  åfpgmR≈≠'  ‘  êglyf·ﬁÙ€  d  )phead°Gı  :‘   6hhea
+"	  ;   $hmtx	fNÜ  ;0  ƒloca I@  >Ù  »maxp	e}  Bº    nameqFSy  B‹  post[cN¨  IÙ  Åprepƒqä  Lx  n àê   ô3  ô3  – f             ‡ ˇP x[        pyrs @ 	˚ ˛§ =öÕ  üO  /Ω                      ¯            " . ; = C F I O S c v z | ◊ˇˇ     " - 0 = A F I N R a e x | ◊ˇˇ                                       " 8 8 < < < > @ D f j j                     $ % & ) , 1 2 5 6 D E F H I J K L M N O P Q R S T U V W X Y [ \ ] _ ¿ Ω (Ä /   ˇŸ  ˇ⁄  ˇŸ˛UˇÊ« ˛mˇÒ;   π   π˛?< ¿ ç õ Ø  ® ¿ ( ^ ò …j π\ ¥ ÷ . Ä  ∏ L Ãˇˇ— f § Ø t ¬ ï ±  ( m  L é%ˇz  @ L b Ñˇ¢ $ 8 Ü Ω 9 ^ é Ìˇ©ˇ≥ @ R U ™ ´ ¬ À#±ˇÆˇ‰  Q t Ñ ™ —ˇLˇØ  , B P Q Ñ æ%⁄ˇh  ; ò ú ü ° ¡ ÏÇ¥ˇhˇvˇ–ˇ·    S S }¥·ØÜˇúˇÍˇ˛  ( * R ` ì £ ™ Ø Ø ¿ Ektìï@Ç¥Ö˛˝  ) G G H o à ¥ π ƒ Ú ˘Ôt≈ˇ5ˇÛ  K L R U e v v á á é ´ ª0CP}îï”*UXwxÊN\y”s≤åò˛ıˇªˇ«ˇ’   [ r ~ ú ¬ – Ù ˙%;B^^Äõπ°πP¿–™ﬂ„Ô˚+tì´¬Œiïôﬂı>°Â%€˛b˛â˛Œˇ;ˇ·ˇ¯   ! 9 B N _ a o p 4  é ≠ ≠ Ø Ω ƒ ≈ … … … „ Ì ¯ ˘ 2MMNOfiû∫∫æ„Ôˆ  	SbmÄ’Ä*JZØØ»÷˚˚GI åmöö¶®≤œ9>NVÄâåc—÷~é≤Ô(Loå ¥ … ¿ ¡             $ Ø 2 n cDb ñC°a ä t dàÔp (ˇ]~G0 ™ æ { b ö } â\ °ˇÿ™ ◊ ì l   Ä ßB ó  Ç 0 * * * * * * ì v † ¨ ∏ ´ ≈   +˛U / !æ '@)*)('&%$#"! 
+	 ,E#F` ∞&`∞&#HH-,E#F#a ∞&a∞&#HH-,E#F`∞ a ∞F`∞&#HH-,E#F#a∞ ` ∞&a∞ a∞&#HH-,E#F`∞@a ∞f`∞&#HH-,E#F#a∞@` ∞&a∞@a∞&#HH-, < <-, E# ∞ÕD# ∏ZQX# ∞çD#Y ∞ÌQX# ∞MD#Y ∞êQX# ∞D#Y!!-,  EhD ∞` E∞FvhäE`D-,π@   
+-, π  @ -, E∞ Ca}h∞ C`D-,E∞#DE∞#D-, E∞%Ead∞PQXED!!Y-, ∞%RX#Y!-,i∞@a∞ ãd#dã∏@ b`d#da\X∞aY∞`-,E∞+∞#D∞zÂ-,E∞+∞#D-,E∞+∞Eå∞#D∞zÂ-,∞%FaeäF∞@`ãH-,∞%F`äF∞@aåH-,KS \X∞ÖYX∞ÖY-, ∞%E∞#jDE∞#DEe#E ∞%`j ∞	#B#häj`a ∞ RX≤@E#aDY∞ PX≤@E#aDY-,π~;!-,π-A-A-,π;!~-,π;!ÁÉ-,π-A“¿-,π~ƒ‡-,KRXED!!Y-, ∞%#I∞@`∞ c ∞ RX#∞%8#∞%e8 äc8!!!!!Y-,Ei ∞	C∞&`∞%∞%Ia∞ÄSX≤@E#ahD≤@E#`jD≤	Ee#E`BY∞	C`ä:-,∞%# äı ∞`#ÌÏ-,∞%# äı ∞a#ÌÏ-,∞%ı ÌÏ-, ∞` < <-, ∞a < <-,vE ∞%E#ah#h`D-,vE∞%E#ah#Eh`D-,vE∞%Eah#E#aD-,Ei∞∞2KPX!∞ YaD-∏ +,K∏ 	PX±éY∏ˇÖ∏ Dπ 	 _^-∏ ,,  EiD∞`-∏ -,∏ ,*!-∏ ., F∞%FRX#Y ä äIdä F had∞%F hadRX#eäY/ ∞ SXi ∞ TX!∞@Yi ∞ TX!∞@eYY:-∏ /, F∞%FRX#äY F jad∞%F jadRX#äY/˝-∏ 0,K ∞&PXQX∞ÄD∞@DY!! E∞¿PX∞¿D!YY-∏ 1,  EiD∞`  E}iD∞`-∏ 2,∏ 1*-∏ 3,K ∞&SX∞Ä∞@Yää ∞&SX#!∞¿äää#Y ∞&SX#!∏ äää#Y ∞&SX#!∏@äää#Y ∏ &SX∞%E∏ÄPX#!∏Ä#!∞%E#!#!Y!YD-∏ 4,KSXED!!Y-∏ 5,K∏ 	PX±éY∏ˇÖ∏ Dπ 	 _^-∏ 6,  EiD∞`-∏ 7,∏ 6*!-∏ 8, F∞%FRX#Y ä äIdä F had∞%F hadRX#eäY/ ∞ SXi ∞ TX!∞@Yi ∞ TX!∞@eYY:-∏ 9, F∞%FRX#äY F jad∞%F jadRX#äY/˝-∏ :,K ∞&PXQX∞ÄD∞@DY!! E∞¿PX∞¿D!YY-∏ ;,  EiD∞`  E}iD∞`-∏ <,∏ ;*-∏ =,K ∞&SX∞Ä∞@Yää ∞&SX#!∞¿äää#Y ∞&SX#!∏ äää#Y ∞&SX#!∏@äää#Y ∏ &SX∞%E∏ÄPX#!∏Ä#!∞%E#!#!Y!YD-∏ >,KSXED!!Y-∏ ?,K∏ 	PX±éY∏ˇÖ∏ Dπ 	 _^-∏ @,  EiD∞`-∏ A,∏ @*!-∏ B, F∞%FRX#Y ä äIdä F had∞%F hadRX#eäY/ ∞ SXi ∞ TX!∞@Yi ∞ TX!∞@eYY:-∏ C, F∞%FRX#äY F jad∞%F jadRX#äY/˝-∏ D,K ∞&PXQX∞ÄD∞@DY!! E∞¿PX∞¿D!YY-∏ E,  EiD∞`  E}iD∞`-∏ F,∏ E*-∏ G,K ∞&SX∞Ä∞@Yää ∞&SX#!∞¿äää#Y ∞&SX#!∏ äää#Y ∞&SX#!∏@äää#Y ∏ &SX∞%E∏ÄPX#!∏Ä#!∞%E#!#!Y!YD-∏ H,KSXED!!Y-∏ I,K∏ 	PX±éY∏ˇÖ∏ Dπ 	 _^-∏ J,  EiD∞`-∏ K,∏ J*!-∏ L, F∞%FRX#Y ä äIdä F had∞%F hadRX#eäY/ ∞ SXi ∞ TX!∞@Yi ∞ TX!∞@eYY:-∏ M, F∞%FRX#äY F jad∞%F jadRX#äY/˝-∏ N,K ∞&PXQX∞ÄD∞@DY!! E∞¿PX∞¿D!YY-∏ O,  EiD∞`  E}iD∞`-∏ P,∏ O*-∏ Q,K ∞&SX∞Ä∞@Yää ∞&SX#!∞¿äää#Y ∞&SX#!∏ äää#Y ∞&SX#!∏@äää#Y ∏ &SX∞%E∏ÄPX#!∏Ä#!∞%E#!#!Y!YD-∏ R,KSXED!!Y-∏ S,K∏ 	PX±éY∏ˇÖ∏ Dπ 	 _^-∏ T,  EiD∞`-∏ U,∏ T*!-∏ V, F∞%FRX#Y ä äIdä F had∞%F hadRX#eäY/ ∞ SXi ∞ TX!∞@Yi ∞ TX!∞@eYY:-∏ W, F∞%FRX#äY F jad∞%F jadRX#äY/˝-∏ X,K ∞&PXQX∞ÄD∞@DY!! E∞¿PX∞¿D!YY-∏ Y,  EiD∞`  E}iD∞`-∏ Z,∏ Y*-∏ [,K ∞&SX∞@∞ Yää ∞&SX#!∞Ääää#Y ∞&SX#!∏ ¿äää#Y ∞&SX#!∏ äää#Y ∞&SX#!∏@äää#Y ∏ &SX∞%E∏ÄPX#!∏Ä#!∞%E#!#!Y!YD-∏ \,KSXED!!Y-∏ ],K∏ 	PX±éY∏ˇÖ∏ Dπ 	 _^-∏ ^,  EiD∞`-∏ _,∏ ^*!-∏ `, F∞%FRX#Y ä äIdä F had∞%F hadRX#eäY/ ∞ SXi ∞ TX!∞@Yi ∞ TX!∞@eYY:-∏ a, F∞%FRX#äY F jad∞%F jadRX#äY/˝-∏ b,K ∞&PXQX∞ÄD∞@DY!! E∞¿PX∞¿D!YY-∏ c,  EiD∞`  E}iD∞`-∏ d,∏ c*-∏ e,K ∞&SX∞@∞ Yää ∞&SX#!∞Ääää#Y ∞&SX#!∏ ¿äää#Y ∞&SX#!∏ äää#Y ∞&SX#!∏@äää#Y ∏ &SX∞%E∏ÄPX#!∏Ä#!∞%E#!#!Y!YD-∏ f,KSXED!!Y-  B  –Ω   C∏ S+∏ /∏ /∏ ∏  –∏  /∏ ∏ ‹∏  ∏ ‹∏ ∏ 	‹ ∫    V+∫   V+013!'!Bé∏¸‚Ω˙C∏M˚≥    Rq^Ω   %@ù  ))	˛!ªH++NÙMÌ÷˝ ?<˝<10###^y°yΩ˝¥L˝¥L  UﬁKó   @
+ / ∏B≥!∫H++N‰Ê /MÌ10!!Uˆ˛
+óπ    Ø  Ä ⁄  &@*
+d d!ce++NÙM˝NEeDÊ ?MÌ1073#Ø——⁄⁄     @ˇŸò   q@áF558o8Gvƒ‘Ì˝Ì ?Ì?Ì10Cy@4 &%&	%&(  (( (((
+( ( +++++++++++++Å ] ! '&47!64#"3@|`W~˛‚˛˛~i?v5ä¶x≠üì/HÆòÂ±˛Ã˛‹ø˛Ó‡ª;ÙØF˙Â¯RÙ;˛’˛›€ÖÀ     ƒ  ’í  #±∏3@ñ 
+G	vƒƒ’˝9 ??ÙÕ105>73#ƒ√ö&é¿ˆäY¶˙nˆ    @  ù " ¶@N6FWknzÑá*Zk||µ "! "
+5 u!"!8o"'Å8"$G#vƒ‘ÌÙÌıÌ‰ ?<˝<?Ì9/999999 ]10Cy@%&( 	(
+(
+( ++++++Å ]6?67654&#"#676!2!!JÖ¡¿Å4Rñ}πG&∑Bu(ˆ„yFµâb8d¸)πpoK5Sk}ìåKÖªv–˛ˆ£¨zGeL61Wj™    1ˇŸö 1 ƒ@IS-e)c-u)u-ñ&K+
++˘15 ∏#@515$51ñ'D∏J@
+8.o) Å'3G2vƒ‘ÌÙÌıÌÌÙÌ ?Ì?Ì9/Ù˝ÊÌÌ9910Cy@6/0& 	&%"& ( 0
+(#( %(( 	/( !(&( +++++++<++++ÅÅÅ ]]5332654&#"5327654&#"#476!2 #Âº(F∑é¨µ°%&eAròe¥E&≤@n€G,Fq˛Ú¯'»ã?qòxîvü 8êktxBz†p»√πÑR3±ÄÕ˛˛     4  /ú   \@"	
+æ
+uÔ∏µñ¨
+∏X≥Gvƒ‘ıÙ<˝‰ ??Ù<˝<99999á.+}≈10	!533#•˛5Œ˝åêò””˚â˝w˛^∞é¸_ù˛¢     Bˇ‹Ä   ª@+Hà9FWg: 
+u  
+5
+∏"@:5 «8o 8 "G!vƒ‘ÌıÌƒ ?ÌÌ?˝9/‰ÙÌ99999á.+}≈ 99910Cy@(	& (   (	(( ( 
+( +++++<<++ÅÅ ]]32654&#"'!!67632!"$'˝}@T†ö∑Ä]Ö/úmË˝ü=2-Pi≈˚˛ÌØ˛Ûmö;Ã|ñ§H@	Æ˛r&!˛√À˛ ≈Ã    Mˇ€#û  ' ©@9w%'XÜ áà	G
+!'!5«5'5)Å8o
+<
+$1)G(vƒ‘˝9|KRxz/ıÌÙÌ ?Ì?ÌÌ9/Ì910Cy@4%&  & (&$( ( (!(%'( '( (++++<+++++ÅÅÅÅ] ] #&'&#"67632#" 7!654&#"3GΩ≤#AÑó≤
+>^Vj¥˛Î…˛‹A}LÅç~¶tØüçû˘ÑU0Z˛È˛¸[-(Ê‰√˛”1i∫d˙›øÇn«öõàπ    K  /Ä  S@68:9JUVb∑
+|¥≈	: 	  o8	¨Gvƒ‘ÙÌÂ99 ??<˝<99]10]#67!5/EÂXW-.«DËâó¸ËÄùC˛¥¿ªöc‹öñÓ≠µ   Bˇ◊ú   2 À@GVW	ZYde	kiw%	I{v#r%s'|1|2àá á'à.à1òG2%%25,55,8!∏Ü∑8)o/8∏Üµ8/4G3vƒ‘ÌÙÌıÌÙÌ ?Ì?Ì9/Ì999910Cy@5*. -( +(
+( ( (.( *( ( ( +++++++++ÅÅÅÅ] ] 654&#"3654&#"3 '&54632#"$5467§ÜÄÉÇtñfà•™ÖÅ£ïú˛µ*OË’ŒÍD&PY3_˛Ë—˛ﬂ|z@Ö\PÜÜZer˝;áÜãêìÇp£†+PÄ†ÊŸëÜS/-)5d†Ω˛˘„ÿπ1   Iˇÿö  ' ´@.+(HXhâàò	F!''5
+
+!55«<1∏U@ )Å$8)G(vƒ‘ÌÙÌı˝9}KRxz/ ?ÌÌ?Ì9/Ì910Cy@4&%&"$(  ( ( &$( #!(!(( %'( ++++++++++ÅÅÅÅ]326#"543 !"&5 654&#"3k7EÅ∂&<±fœÒÓË9wBOÉ˛«“⁄2±ü{ÑõàïZï9◊I_MÀ√(˛ÊõÈ˛˘À˛Æ‹¶&ç∞ûõ±îå•   „  ¥!   2@** 
+	d 	d!x|++NÙM<˝<NEeDÊ ??MÌÌ103#3#„————!⁄˝ì⁄     „˛–∏!   9@ #
+d*
+4
+d x|+NÙM<<˝<ÌNEeDÊ ??MÌÌ‘Ì1067654&'#533#„Fm’4Ç’’—P*2⁄ kHvQ⁄   \ ﬁo6   '@  Õ  		\!?R++NÙ<ˆ< /MÌ˝˝10!5!5o˚Ì˚Ì6®®˛S´´     =Ω  
+ D∏ ]+ ∏∂EX∏ /π ƒ>Y∏∂EX∏ /π æ>Y∏∂EX∏ 	/π 	æ>Yª  π  a+013#!#éﬂÌÖ·⁄ï˝ªüÃZâ˝wc˙C∏˛H   ó  Ω 
+  ( Ç@8ZZjjjzw!IH  ''1i1#*	%()*∏_≥!vf++NÙ<M˝<NˆMÌÙÌ ?˝?Ì9/˝9910Cy@%&++ ++++ÅÅ]]27654'&#!27654'&#!! )ƒ~FnuBÇ˛ù≠∑N1èL}˛u√wm@O)Mq8cYÖ˛ﬁ˝ìP#7èê2˛9˝ZjC_†:˝˚ö[wãY/'+6`©és¨  Zˇ⁄qÂ   ±@;óñÇáâSÜ::	1;1 	1 °!jf++NÙMÌNˆMÌÙÌ9/ ??Ì?Ì9/Ì10Cy@: %&%&	2 2	2  2
+2 2 22++++<<++<<++++++Å]]#.#" 327673! '&76!#4¬!≈≤Ÿ˛ıÒÔ‹s=¬íØ˛◊ˇ ÆÂ¨∫G(Â˛⁄ªé¶˛œ˛≈˛˛˛ø©YëËùΩõÕ¨E–‚    Ø  ™Ω 	 9@	 	k% 
+∏W≥!ï‹++NÙM˝<NˆM‰ ??<Ì9/˝10!!!!#Ø˚¸Ã—˝/«Ω¥˛BØ˝d   …  íΩ  ∏ ++∫    .+ ∏  /∏ /013#………Ω˙C  ú  *Ω 	 
+ v@78'GX∏õ@
+
+
+∏õµ∏õ@
+	 †!vp++NÙ<M˝<Nˆ<M˝<999/ ??<?<99á.+á}≈10 ]]33##úÎÊΩﬂ˝æ:Ω˚Z¶˙C•˚[Ω    Pˇ’ËÂ    ä@,á« «√»…
+C::	11ÿ!jf++NÙMÌNˆMÌ9/ ??Ì?Ì10Cy@2 &%	%&2  22 222
+2 2 ++++++++++++Å ] ! '&7! 5 #" !õªíßƒ˛ï˛≠¬≠îætÎ˛ÒÎ‰˛‡˜Â˙√˛–˛∑⁄ˇ ‡ÿJ*‘˙¢yı<˛«˛œÙ˛±^  ¥  xΩ 	 ' î@IHYXidxª0 @B#! &`qu!&$% 		& %%1i)&%'
+()÷!ïf++NÙ<M˝<NˆMÙÌ‘Ì‘Ì ?<<?˝9/<˝<999999]9+10]2654'&#!!2#./&'&#!#Gå£r=f˛«®®mœmbVW.Ù
+d9z˛;«píù9˛
+°1^˝Ñ®3#rÄ≈T)F!<Vıê1˝ä  `ˇ’ˆÂ / 0 ˛@^)'#&&65!G&b&zw$	k%Yh™"
+:"$"
+Ü//+::+	0
+$"(00%I%(2%I %/12†!jâ++NÙMÌÙÌNˆMÌÙÌ9/9999 ??Ì?Ì9/Ì9.˝3]q10Cy@M(. &&-%%&, + -., + *++ +-+ 	'+%.+ )+ ++ ++++++<++++<++++++ÅÅÅ ]327654'&/&'&54$32#&'&#"# '&74c˙p\≤KL¢«√Qå˚ÁCª1[⁄∞öZ;–ŒïQå˛ùÎ˛ÓõõM⁄}Ní >†x32%-,5\∑∆˛ﬂıv?sîbl2 0/";gƒÙ“åãÓ   Rˇ‹GI  ; < ›@8*0
+'3Hi	j9	2$	;+.);∑;;2*%'"∏ä@#'.5<<<)*®$>)J'8=>ºó ! πñ ++NÙMÌÙÌNˆM‰˝ƒ9/ ??Ì?Ì?ÌÌ99]9.Ì.Ì9910Cy@(67" %6! !  !!" 7! !!! +++<++++ÅÅÅ ]]$3276=67654&#"#>323267#"'&'#"&5467rN_Yñ!h2mb1S¥>Ézç;!
+®˜£Ωvu%*,&]*	7Œ|ïΩ∫óäœZ,I¶ë/gl,-\SL*S∆õHHò˝ó"ÖB#@Hjµàï§‰   vˇﬁ%¬   p@.¶ß◊"  
+' ..)  á!Ω]++NÙ<M˝‰‰NˆMÌ ?Ì??Ì?9910Cy@
+&
+&&	& ++++ÅÅ ]3>32#"'&'#$654&#"3vØ;§`»˘ˆ⁄zT29¶fëëç{π&G¬¬˝ÎMQ˛Ì˛Ù˛˛∞;#Mâ}Ëæ©ﬁ∂—ó^±    ;ˇ·–N   ß@/ßò®™Jõ''
+'∏≥!r}++NÙMÌNˆ<MÌ99Ì9/ ??Ì?Ì9/Ì10Cy@4 %
+& &
+&  !& & 	&!++++<<++<<+++Å ]] #.#"32673#"5 3÷„Ør~¨J0àípÉØª“˙‘N∞◊cÉ®m†°‹âw’≈3Ê:  Hˇ⁄I  $ %@yóôß@@)K∂«∆«ÿŸ	÷ÿ#ËË#««\!$ö$9!
+%óß∑◊%%
+'''$.'&'‘!¶]++NÙM˝‰NˆMÌ‘˝999999/] ??Ì?Ì9/<˝<Ì910Cy@F #&%"$&   &	& &#!&!&
+& 
+&  ++++<++<+++*+*Åq] q]] !327673#"  3&'&#"¥÷86¸ÔêóçT0±O1RyAR»˛Í‚(J≠|®#GkUQlJ¢£≈]6G;ë.P#B˛&uFÇ≥ä‹       “  M@+
+9
+)¸¸!g~++NÙM˝]9ƒ/<˝<NEeDÊ ??<M˝<?Ì‘Ì107632.#"3###535µ#?¥$R ≤¥≤ïïB4\§UÆé¸dúé®    =˛;ËI  - . ∑@M6II	XY	à©®©'¶+π@")ƒ
+")
+
+.....-)0'>&'/0á!rB++NÙMÌÙÌ9NˆM˝‰ı9/ ??Ì?Ì??ÌÌ9910Cy@,#($%&#&& (&& ! %"&')& !  +++<<+++++ÅÅÅ ] 53!"&'33276'#"$ 3 &#"32765|^35¶<p˛…≠Ï∑'=Éœ@&6ò}Æ˛˚∫D§æF%ì|¬O,˛—B>#Cá¸2Ãv⁄õ•H'<íV›RP˜.˛°¿≤_öµΩØcÑ-    Ñ  Ì¬  S@,''uu  
+)
+) ∏≥!bB++NÙ<M˝<NˆMÌ ?<?Ì?99910 ]367632#4'&#"#Ñ¥@3WÇÈS-π1áp∂¥¬˝‹Q!9£Yû˝Q£v7Xö÷˝»     Ñ  ;Ω   6@Â  
+	) 	™!bB++NÙ<Mƒ˝<ƒNEeDÊ ??<?MÌ103#3#Ñ∑∑∑∑*˚÷ΩÃ   ˇ⁄˛P8Ω   /∏ S+∫    V+∏ ∏ –∏  ∏ 	– ∏ /∏ /∫    V+01#53>53#"&'8¥¥˛¢y1¥&?∞Ì–˘4#\∂˚7u:b     Ä  ¯Ω  ß@dY:Wgyxáπ…⁄
+	Ñî§9		m	
+  
+
+	
+) ≤!bπ ++NÙ<M˝<<NÊ ?<<?<?99áM.+}¡á.+]}¿<<10] q]r33	##Ä≠ŒÊ˛f±Ê˛≤ó≠Ω¸´«˛o˝bä˛n    â  =Ω  )@  
+) ™!bB++NÙ<M˝<NEeDÊ ??103#â¥¥Ω˙C    Ñ  %G & Ö@;'''HVg#%
+#
+%! %
+()∏≤)∏@
+ .%)& '(∏≥!bB++NÙ<M˝‰ÙÌÙ˝NEeDÊ ?<??<MÌÌ99910 ]367632>32#4&#"#4'&#"#Ñ≤@4YqÄN,$<¢eÿN*ªkMjô∑)pfß¥/òO$=?$FVSúTé˝7ËkPé¶˝ëªm2Kûœ˝»   Ñ  ÌI   ^@1∑«'vt 
+ )	.) ∏≥!bB++NÙ<M˝‰NˆMÌ9/ ??<??Ì99910 ]]3>32#4'&#"#Ñ´L™h‰P,∑0~@)J8-¥ß/ò^RüW¢˝Q£b<dB5qi˝œI   ;ˇŸ!N    ê@3òñô•®¶©∏»◊ÂÈ:'	'∏	≥!r]++NÙMÌNˆMÌ9/ ??Ì?Ì10Cy@, &	&  &	& &
+& & &&+++++++++Å ]$54'&#"3 !" 5 3‡Ö0L∫•ññ£÷¸˛˜›˛¸Át¶ñ^î¸≤´‰⁄˛Ï˛Ù˛˝˛Æ+¸@  v˛U%I  " t@,©ß( "'$
+..!)"#$á!Ω]++NÙ<M˝‰‰NˆMÌ ??Ì??Ì9910Cy@ && &&& &++++++ÅÅ ]$654'&#"3367632#"'&'#∆ß%F∫ªE%%F∫˛.Ø6@[{∂˛∑töyR0;¥y”“Ä\±ªdö|W¶±éI(<˛È˛˝˛¢ñ_5I˝›   <˛UÌG    z@38HX®ß®( ..)"'!"á!rB++NÙMÌNˆ<M˝‰‰ ??Ì??Ì9910Cy@ && &  & &+++++ÅÅÅ ]327654'&#" 53##" 3¯'E≤ºG'+I∏ußè[2.´µ-üw´˛Ú˝…~^ß∞aóã]üÀ‘>C$Fï˙&&HUJ    â  íG  O@&'&7G		' 
+.) ∏E≥!b~++NÙ<M˝‰NÊ ??M?ƒ˝ƒ99910 ]3>32.#"#â´§kàí¥/π6õæØr˝ò   Bˇ◊∂K . /.@è8	òñôòò*($%'6!F!G$G'V$W'f$g&yyyv#t$t%t&¶®, -. -.(i&%6%%"
++∆.ö+/	 /!/'>(&'(1'> '.01≤!¶]++NÙMÌÙ˝9NˆM˝9Ù˝9999/999 ??ÌÌ?ÌÌ9q10Cy@L-&%&!! 	&!, ! *!! ! "! !"'
+!&%	
+-! )! !! ++++<<+<<++++++++++Å ]]]32654'&/&'&54632#&'&#"#"&'Ô%D®dò='sèâAt€πÚkC™&>ôfiE(Nw¬BiŸﬁÔ«∑PZ0WW[E$$"*IÅòºéZh=2GN@F*/,Eîè–Ÿ†˘  ˇÔ	Z  Rµ.
+¿∏?@%9
+) ¸¸!g}++NÙM˝]9ƒ/<˝<NEeDÊ /??<M˝<Ì˝‰1033#3267#"&5#53®∂´´&1C'~ZëëZ˛’ì˝E8é	Åg≈ì    Äˇ„ﬁI   ^@:∏»	(w◊ 
+ 
+.
+))“!bB++NÙMÌNˆ<M˝‰9/ ??Ì??<9910 ]]327653#7#"'&5%80ÉºD%¥™#4gìÂS-Ø/˝9R4`®Zù˚—û=*TôRâÿ     Í/ @.B≈ g hhgáàß ®G HEJÜâ«»I(s(∏	≥!g~++KRy∏ˇp¥ ∏É∑m∏É@m   
+Ø∫Ñ  Ñ≥ØNÙM˝‡‡˝NEeDÊ ?<?<999M.+N‰M.+N‰M+KQy@%) ) 
+Ø ØNÙM˝99˝99NEeDÊ ?<?<9++10q] ]q	3#‹+≈˛l¿˛u/¸òh˚—/    ·/  # ±
+?∞3± ?∞3∞/∞÷ ± 
+±99013	#	#Èˆ˘€˛óyÊ˛ˆ˛˛‰y/˛áy˝˚˝€í˛n%   ˛IËI    @näàß8HXgwwåò óòóó® ®H KG…D∆á¶ ¶ß®$(  ØØè‘!g~++NÙM‰˝99˝99NEeDÊ9/ ??M˝92/?<<<99KRy@ mm  á.+}ƒá.+}ƒ]q10q] ]3#"&'53267>73!«&ÉbBúÄú&)/*2/>˛tÃ/g˛ë˛ÏÆ˛f¥§!î$N¸òÇ   4  ¥I 	 
+ l@B7H W XWg hgw	)  
+
+9 9	
+
+>J ≤!r]++NÙM‰NˆM‰ ??<˝<9?<˝<9999/á.+á}≈10]7!5!!!4{˝¥>˝âä¸Äœé °ì˝°I  ê  ;“  )@ 
+ ¡¡!we++NÙ<M˝<NEeDÊ ??10!#3;´´“     t Z˝  t@?wòò®®  		
+
+    		
+ 
+	 
+/<’< /<’<10á.+ƒá.+ƒ<<<<<<<< ]7			'tv{|y˛Ñ|y˛Ñ˛Öv{áv˛Ö{v˛Ñ˛Öy{˛Öy{          ˘í7˘_<ı      _Mè     ﬁ‡.÷¯e¸'ë˘   	         )˛)  ¯e¸Ìë                Ò B    9  9  9 Ì◊ Rs  s @ BV Yá ú™ é™ D N¨ \9 ™™ U9 Ø9  s @s ƒs @s 1s 4s Bs Ms Ks Bs I9 „9 „¨ ¨ \¨ s ú ·V V ó« Z« •V Ø„ Ø9 c« °9 …  #V ús ú™ ó« ú9 PV Ø9 P« ¥V `„ !« ™V 4ç %V *V *„ /9 Ä9ˇª9 /¡ xs  ™ &s Rs v  ;s 8s H9 s =s Ñ« Ñ«ˇ⁄  Ä« â™ Ñs Ñs ;s vs <™ â  B9 s Ä  «       4¨ˇ’ ê¨ *¨ V V « ZV Ø« ú9 P« ™s Rs Rs Rs Rs Rs R  ;s Hs Hs Hs H9 g9 9  9 %s Ñs ;s ;s ;s ;s ;s Äs Äs Äs Äs P3 os hs 8s KÕ ïLˇı„ «Â Â   Ì™ ä™ Rd \  9 B¥ *d \d Zd \sˇ·úˇ¥Ù j¥ (ñ d /1ˇyˆ ;Ï 1% ^ I„ \„ ∫™ Ë¨ \dˇÔs (d \Â qs ¬s ¬  Ì9  V V 9 P  Iç Gsˇ˚  Ò™ N™ N« Ñ« ™d \Ù B  V *V˛™Ù `™ ¥™ ™    s P9 ó« ™™ N  V V ØV V ØV Ø9 k9ˇ˘9  9 9 P9 PR i9 P« ™« ™« ™9 Ω™ *™ˇ˜™ ™ ™ ˜™ Ñ™ y™ˇˇ™ °™ *sˇË«ˇ◊V `  B„ /  4 ê« !s =V *  V Äs Ä¨ \¨ t       l   l   l   l   l   º   º   º   º   º   º   º   º   º   º   º   ¯  8  8    `  x  –  l  î  ¿  T  	∏  
+‰  <  ∏  ∏          Ñ  å  ¨  ¨  ¨        @  @  @  @  @  Ï  Ë  Ë  Ë  ¸  î  î  î  î  î  î  î  î  î  î  î  î  î  î  (  ¸        î  ,  |    x  Ï  Ã      ¿  ∞   î  !|  "  #»  $h  %  &H  &H  &®  '‘  (t  (t  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  (∏  )p    Ò o 	 k     g  Ëê     9≤        P         	 P        Y       "       	A       J       	R       2[       	       	            &      4      H      	Z      /ç      <º      0¯      :(      6b      0ò      <»    `     Ã    |     Ê     |    ò  	   `     ˙     n    ®    ∞     ™    
+ ä     ∫     ö    
+         ⁄    ⁄    2    n    Ê    @    L    T  !  ¬  "  Ù  *    9    >  
+–     î  	  ä    $     “  
+   ¿© 1990-2006 Apple Computer Inc. © 1981 Linotype AG © 1990-91 Type Solutions Inc.HelveticaRegular R e g u l a r C o u r a n t R e g u l a r0Ï0Æ0Â0È0¸^8âƒOS R e g u l i e r R e g o l a r e«|ºÃ¥ N o r m a ljnñö‘9'/J N o r m a l A l m i n d e l i g N o r m a a l i N o r m a l R e g u l a r R e g u l a r1KG=K9 N o r m a l4 N o r m a l R e g u l a r R e g u l a r R e g u l a r R e g u l a rö±ΩøΩπ∫¨Ë“Ÿ‹ S z a b · l y o s R e g u l e r B i a s a N o r m a l R e g u l a r28G09=89	0	G		M	/	A	2	0 T h∞› n gHelvetica; 17.0d1e1; 2020-09-21Helvetica17.0d1e1HelveticaHelvetica is a registered trademark of Linotype AGHelvetica est une marque déposée de Linotype AGHelvetica ist ein eingetragenes Warenzeichen der Linotype AGHelvetica è un marchio registrato di Linotype AGHelvetica is een geregistreerd handelsmerk van Linotype AGHelvetica är ett registrerat varumärke för Linotype AGHelvetica es una marca registrada de Linotype AGHelvetica er et registreret varemærke tilhørende Linotype AGHelveticaLigaturesCommon LigaturesNumber SpacingProportional NumbersMonospaced NumbersNo Change          ˇe e                     Ò           	 
+                        ! " # $ % & ' ( ) * + , - . / 0 1 2 3 4 5 6 7 8 9 : ; < = > ? @ A B C D E F G H I J K L M N O P Q R S T U V W X Y Z [ \ ] ^ _ ` a b c d e f g h i j k l m n o p q r s t u v w x y z { | } ~  Ä Å Ç É Ñ Ö Ü á à â ä ã å ç é ê ë í ì î ï ñ ó ö õ ù û ü † ° ¢ £ § ¶ ® © ™ ´ ¨ ≠ Æ Ø ∞ ± ≤ ≥ ¥ µ ∂ ∑ ∏ π ∫ ª º æ ø ¿ ¡ ¬ √	
+ ∆ « » …   À Ã Õ Œ œ – — “ ” ‘ ’ ÷ ◊ ÿ Ÿ ⁄ € ‹ › ﬁ ﬂ ‡ · ‚ „ ‰ Â Ê Á Ë È Í Î Ï Ì Ó Ô old_notequalold_partialdiffold_summationold_integralold_radicalold_approxequalEuroquotesinglbase.oldquotedblbase.old   ∏ ]+∫ π _+øª > 4 )     e+øº B 4 )     e+øΩ : 4 )     e+ ø∑ M = 7 (    e+ø∏ ` O 7 (    e+øπ G = )     e+ø∫ B 4 )     e+ ∫æ  d+∏∂ E}iD∏ S+∏ I+∏ ?+∏ 5+∏ ++A Ä¶ ê¶ †¶  iã yã âã ôã  âã ôã ©ã πã≤@∫y J@T
+“∏¥ûŸ„ª  ·≤ 	A
+†ü d • %z H (ö≥)l`A
+© p© Ä©  Ä© ©≤2æ, % & ∂Á1-Â1∏≤¬'∏≤¡∏@¿ûøgæg´'∏≤™)∏∂©lì∏ö≤í∏≤ë∏≤u∏∂m)ñd1∏ö≤Lñ∏´≤9∏V@68!5‰/'∏@-L*1Õ$∏´≤ ∏%@ì:LE':E'ª™õ *õ≤%J∫õ %z≥I)8ñ∏{≥H(1%∏z@6H(ñ)H'%)L%)F'')H'V»Ñ[A2+(&!
+∏¨≤?ª´ ? ´≥∏Æ≤?ª≠ ? ≠∑ ∏ˇ‡¥   ∏´¥   ∏´∂   ∏≠≥   ∏≠@               J ∞ç∏ Öv??>9FD>9FD>9FD>9FD>9FD>9F`D>9F`D>9F`D+++++++++++++++++++++++++++∞ñKSX∞™Y∞2KSX∞ˇY+++++++++++++++++++++++++++++++++++++++++tu+++eB++KRy≥vpjfEe#E`#Ee`#E`∞ãvh∞Äb  ±jpEe#E ∞&`bch ∞&ae∞p#eD∞j#D ±vfEe#E ∞&`bch ∞&ae∞f#eD∞v#D± fETX±f@eD≤v@vE#aDY≥bBr]Ee#E`#Ee`#E`∞âvh∞Äb  ±rBEe#E ∞&`bch ∞&ae∞B#eD∞r#D ±b]Ee#E ∞&`bch ∞&ae∞]#eD∞b#D± ]ETX±]@eD≤b@bE#aDY++++EiSBst∏ö EiK ∞(S∞IQZX∞ aYD∏¶ EiDu  endstream
+endobj
+290 0 obj
+<<
+/Length 732 
+>>
+stream
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo << /Registry (Adobe) /Ordering (UCS) /Supplement 0 >> def
+/CMapName /Adobe-Identity-UCS def
+/CMapType 2 def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+32 beginbfchar
+<0001> <0041>
+<0002> <0034>
+<0003> <0035>
+<0004> <0036>
+<0005> <0037>
+<0006> <0038>
+<0007> <0039>
+<0008> <0031>
+<0009> <0030>
+<000A> <0042>
+<000B> <0043>
+<000C> <0052>
+<000D> <0053>
+<000E> <0068>
+<000F> <0061>
+<0010> <006C>
+<0011> <0066>
+<0012> <0065>
+<0013> <0074>
+<0014> <0072>
+<0015> <0073>
+<0016> <006D>
+<0017> <006E>
+<0018> <0067>
+<0019> <006A>
+<001A> <0075>
+<001B> <0069>
+<001C> <006F>
+<001D> <0076>
+<001E> <0078>
+<001F> <0063>
+<0020> <0071>
+endbfchar
+endcmap
+CMap end
+end
+endstream
+endobj
+291 0 obj
+<<
+/Length 66 
+>>
+stream
+   $         % & 5 6 K D O I H W U V P Q J M X L R Y [ F Tendstream
+endobj
+292 0 obj
+<<
+/Length 13268 
+/Length1 13268 
+>>
+stream
+     Ä  POS/2á,√   ‹   `cmapHÂ  <   ºcvt 
+5„  ¯   fpgm”'õi    sglyf9b5  à  #êhead„˜≠  '   6hhea	Üb  'P   $hmtxï_0  't  ploca ¨¥  (‰  tmaxpŸã  *X    namemÒ$   *x  ¸post{  2t   ⁄prepRÀ‡o  3P   Ñ ˘º   ô3  ô3  – f             ‡ ˇR x[        pyrs   	ˇˇ ˛§ =Æ€  üO  B¬                      ®       1 9 C S a c j o v xˇˇ   0 4 A R a c e l q xˇˇ                         " & ( ( ( 2 8 B           $ % & 5 6 D F H I J K L M O P Q R T U V W X Y [ * ˛ ò*4   )˛P B #¬ -∏ f,K∏ 	PX±éY∏ˇÖ∏ Dπ 	 _^-∏ g,  EiD∞`-∏ h,∏ g*!-∏ i, F∞%FRX#Y ä äIdä F had∞%F hadRX#eäY/ ∞ SXi ∞ TX!∞@Yi ∞ TX!∞@eYY:-∏ j, F∞%FRX#äY F jad∞%F jadRX#äY/˝-∏ k,K ∞&PXQX∞ÄD∞@DY!! E∞¿PX∞¿D!YY-∏ l,  EiD∞`  E}iD∞`-∏ m,∏ l*-∏ n,K ∞&SX∞@∞ Yää ∞&SX#!∞Ääää#Y ∞&SX#!∏ ¿äää#Y ∞&SX#!∏ äää#Y ∞&SX#!∏@äää#Y ∏ &SX∞%E∏ÄPX#!∏Ä#!∞%E#!#!Y!YD-∏ o,KSXED!!Y-   ö  =¬   ^∏ f+ ∏  EX∏  /π   >Y∏  EX∏ /π  >Y∏ ‹∏  ∏ ‹∏ /∏ 	/∏ ∏  –∏  /∏ 	∏ ‹∏ ‹∏  ∏ ‹01!!%!ö£˚]Î¸Õ¬˙>∏R˚Æ  @ˇ‹(¥  #∏ f+ ∏  EX∏  /π   >Y∫   i+∏  ∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∏ /∏ /∏ ∏ –∏ /∏ ∏ 
+‹∏ ‹A ⁄  Í  ]A 	    )  9  I  Y  i  y  â  ô  ©  π  …  ]∏ ∏ ‹A     &  6  F  V  f  v  Ü  ñ  ¶  ∂  ∆  ]A ’  Â  ]01 ! 65&#"324˛Îﬂﬂpoﬂn'ORR$ÑggÜ√√˛ô˛ô˛|mÑ˙¸¸˛˙˙˛˜     é  ™  )∏ f+ ∏  EX∏  /π   >Y∫   i+∫    i+01)!5676767653˛‹˛´á6V6%ÌË¬9'A'    6  /° 
+  Q∏ f+ ∏  EX∏ /π  >Y∫    i+∏ ∏ –∏  ∏ –∫   i+∏ ∏ 	–∏ ∏ –∏ ∏ ‹01#!!5!)/§˛È˝¬@˝~kﬂ˛»8˘p¸vr  6ˇ⁄!ó   ◊∏ f+ ∏  EX∏ /π  >Y∫   i+∫    i+∫ 
+   9∏ ∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∫   i+A ⁄  Í  ]A 	    )  9  I  Y  i  y  â  ô  ©  π  …  ]∏ ∏ "‹01"%!!67632 !"$'!32654&"4&C"ˇ f˝Ø4B%>Y¥˛˛˛ˇœ˛ˆ`\joh–A!Ú˛√+ÚÁ…˛ƒﬁÃ]eïqoô    @ˇ⁄*∏  , ◊∏ f+ ∏  EX∏ /π  >Y∫   i+∫   + i+∫  +  9∏ ∏ %‹A  %  % ' % 7 % G % W % g % w % á % ó % ß % ∑ % « % ]A ÷ % Ê % ]∫  ( i+A ⁄ ( Í ( ]A 	 (  ( ) ( 9 ( I ( Y ( i ( y ( â ( ô ( © ( π ( … ( ]∏ ∏ .‹012# '&4767>32!4'&#">32654&#"r¡˜Úˇ˛ÓÇeH>…å ˛‰.]ã; 5åfT~a_m|ZI≠˛˙ÃÀ˛ Â≥¶hπ{iÄœ¨#*DúV®?:˛Aëuîèrá     4  8ó   ∏ f+ ∏  EX∏ /π  >Y∫  
+ i+01!7!!ÜrM=b˛ÿÛùj˝- @ÿ¢¨á˛z}Ü•g ﬂ?   6ˇ⁄%±  $ 1õ∏ f+ ∏  EX∏ /π  >Y∫  - i+∫ ' " i+∫  " '9∫  " '9∏ ∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∫   i+∫   i+A     &  6  F  V  f  v  Ü  ñ  ¶  ∂  ∆  ]A ’  Â  ]∫   9A ⁄  Í  ]A 	    )  9  I  Y  i  y  â  ô  ©  π  …  ]∫   9∏ /∫   9∏ *‹A ⁄ * Í * ]A 	 *  * ) * 9 * I * Y * i * y * â * ô * © * π * … * ]∏ ∏ 3‹017&5467.54632 #"32654&#"32654&#"≥}oki?ÓŸŸÓ?ikl˛ÒÛÛ.obboq``qK0VW__WVa[Ä∑z∆2F£GûﬂﬂûG£<<∆z∑˛ˇÀkvvkoss2dOVaaVO  =ˇ÷-∂  * œ∏ f+ ∏  EX∏  /π   >Y∫  ) i+∫ "  i+∏  ∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∫   "9∫   i+A     &  6  F  V  f  v  Ü  ñ  ¶  ∂  ∆  ]A ’  Â  ]01"$'!32767#"$54 3 327654&#"£˛¸
+XIç9',Pu≠˛Ù◊K{FCÄ˛FRim;4asdI*¡π@PúV•10Ô·È!˛€¶˛Ò˛˘∞˛±…@ôÅÅ">ô{ê     4  ®¬  
+ B∏ f+ ∏  EX∏ /π  >Y∏  EX∏ /π  >Y∏  EX∏ /π  >Y∫    i+01!!!!˚˝·f˛æ\
+˛≤µ∏æ/˛—¬˙>-D˝º  °  a¬   * \∏ f+ ∏  EX∏ /π  >Y∏  EX∏  /π   >Y∫ )  i+∫   )9∏  ∏ ‹∏ ∏ &‹∫   i+∏ ∏ '–01)!!!27654'&654'&#!!2=˝dÃqDD&JqsB*?G¡x˛ëja6b_59<PEk˛ºja¬ô^ÉáR.&)≤ÉhE/6(â˛w0às+$]g!˛ª   \ˇ◊{ﬁ ∏ f+ ∏  EX∏ 
+/π 
+ >Y∏  EX∏ /π  >Y∏ 
+∏ ‹A Ÿ  È  ]A     (  8  H  X  h  x  à  ò  ®  ∏  »  ]∏ ∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∫   i+A     &  6  F  V  f  v  Ü  ñ  ¶  ∂  ∆  ]A ’  Â  ]01%! '&76! !&'&#"32767!¨•˛ˇ˛¬∂∂œ¥t¨_˛Ã/T•®¬Õû¢U/1(nóÃÕeÇ—∂Ùâäj6`˛Ò¯¯˜j9rÒ    £  q¬  * £∏ f+ ∏  EX∏ /π  >Y∏  EX∏ /π  >Y∏  EX∏ /π  >Y∫ )   i+∫    )9∏ ∏ &‹∏ +/∏ ,/∏ +∏ –∏ /∏ ‹∏ ,∏ ‹∏ ‹∫   9∏ ∏ –∏ /∏ ∏ –∏ /∏ ∏ '–01!!!!&'&/.654'&#!!2˛¬˛””õß:08jzfU,˛≠c3\Y2d˛ö]hB˝æ¬FD8àWiÀ*)óõce$9%1>Aâç^*|Ü.˛t     Uˇ⁄Ì .∏ f+ ∏  EX∏ /π  >Y∏  EX∏ '/π ' >Y∏  ‹A       '   7   G   W   g   w   á   ó   ß   ∑   «   ]A ÷   Ê   ]∏ ∏ ‹A Ÿ  È  ]A     (  8  H  X  h  x  à  ò  ®  ∏  »  ]∫   i+A     &  6  F  V  f  v  Ü  ñ  ¶  ∂  ∆  ]A ’  Â  ]01%27654'&/&'&54 !2!&'&#" !  5!≥mDÅ@@âúÊXï ÈI˛ÿlHkwéF-ì˛ßUÑ˛À˛Ê˛‡˛∂&)K’.}I('#4=fŸ∆˜ÎÖ8%`VO'#=(Ch≈ ˛ıÊe2[    ;ˇﬁ8\ * : —∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∏  EX∏ /π  >Y∫   9∏ ∏ $‹A Ÿ $ È $ ]A  $  $ ( $ 8 $ H $ X $ h $ x $ à $ ò $ ® $ ∏ $ » $ ]∫ 1  9∫  0 i+∏ ∏ 	–∏ 	/∏ 0∏ –∏ /∏ 0∏ !–∏ !/∏ ∏ <‹016!2!.'#"&5476?67654&#"!632675Æq≥ãã˛ 
+;M\tî¡õU•aO"=]Ze*
+˛Ì	(:\õ70@Z'BÃêGG≈˛4J8(*!:%@-5©õ…Z1
+7C32%?è˝^!lèj	'RI  Gˇ⁄4\ ∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∏ ∏ ‹A Ÿ  È  ]A     (  8  H  X  h  x  à  ò  ®  ∏  »  ]∏ ∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∫ 	  i+A  	  	 & 	 6 	 F 	 V 	 f 	 v 	 Ü 	 ñ 	 ¶ 	 ∂ 	 ∆ 	 ]A ’ 	 Â 	 ]01!&'&#"3267!! 5 324˛‹!0eê53çdT	#
+TÜ˛˘˛˘¯ÒÕª=1BèL~xIàlVÇtª8˘8∏     /ˇ‹:_  ! Õ∏ f+ ∏  EX∏ 
+/π 
+ 
+>Y∏  EX∏ /π  >Y∫   i+∏ ∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∏ 
+∏ ‹A Ÿ  È  ]A     (  8  H  X  h  x  à  ò  ®  ∏  »  ]01#"  32!32767.#"*Zå¸–˛¬Âà⁄G@˝a;SX7	{[cm@adü..fnaÄKç§B)20Nqu|j      ã—  o∏ f+ ∏  EX∏  /π   >Y∏  EX∏ /π  >Y∏  EX∏ 
+/π 
+ >Y∫   i+∏ ∏ –∏ ∏ –∫ 
+  i+∏ 
+∏ –∏ ∏ –∏ /01.3#!#53547632Ñq+ªª˛‰üú;>Ì,ÀË5 \…¸ëo…FØBb   B˛B^\ ! /’∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏ /π  
+>Y∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∏  EX∏ /π  >Y∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∏ ∏ $‹A  $  $ ' $ 7 $ G $ W $ g $ w $ á $ ó $ ß $ ∑ $ « $ ]A ÷ $ Ê $ ]∫   $9∏ ∏ *‹A Ÿ * È * ]A  *  * ( * 8 * H * X * h * x * à * ò * ® * ∏ * » * ]∫   *9∏ 0/∏ 1/∏ ‹∏ ‹∏ –∏ /∏ 0∏ –∏ /∏ ∏ '–∏ '/∏ ∏ .‹A  .  . & . 6 . F . V . f . v . Ü . ñ . ¶ . ∂ . ∆ . ]A ’ . Â . ]013276=#"54325!!"$'!32654&#"π.mö4")/Uà“˚ÚﬁR=h@Gz˛¶—˛¯6:ñdäÉnñ9ø'gBúFF#A'¸ÛK+sù˚ˆ”k∏§£2äó•õ¢çKn_     á  ^Ω  ¡∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∏  EX∏ /π  >Y∏ ∏ ‹A Ÿ  È  ]A     (  8  H  X  h  x  à  ò  ®  ∏  »  ]∫   9∏ /∏ /∏ ‹∏ ‹∏ ∏ –∏ /∏ ‹∏ –∫   901!4'&#"!!>32^˛›'mqu˛‰>£Ze•5-Ä˝ÄóX6Lóå˝≤Ω˝˜_KFH=Å   â  ™À   [∏ f+ ∏  EX∏  /π   
+>Y∏  EX∏ /π  >Y∏  EX∏ /π  >Y∏ ∏ ‹∫   i+∏ ∏ –∏ ∏ –01!!™˛ﬂ!˛ﬂB˚æBâ˛˘   	˛HØÀ   k∏ f+ ∏  EX∏ /π  >Y∏  EX∏ /π  >Y∏  EX∏ /π  >Y∏ 	‹∏ –∏ ∏ ‹∫    i+∏  ∏ –∏ ∏ –∏ ∏ ‹01!#"&'53265!!íÇæ3&*+˛„=˚N•û‰);;˛˘     ã  ®¬  2∏ f+ ∏  EX∏  /π   >Y∏  EX∏ /π  >Y∫    i+01!!ã˛„¬˙>     Ä  úZ - ±∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∏  EX∏ /π  >Y∏  EX∏ */π * >Y∫   9∫   9∫   i+∫ * + i+∫  ! i+∏ ∏ 
+–∏ 
+/∫   9∫  + *9∏ ∏ /‹01&#"!!6763267632!4'&#"!4È$iz*˛ﬂ5/SÑ}M> 8SXlHå9.
+˛‹&fv-˛·OO-Y˝p@üU$@73P`--8F9S7j˝Q∂>(Lb4I˝wâa    á  a\  {∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∏  EX∏ /π  >Y∫ 	  9∏ /∏ /∏ ∏ –∏ /∏ ‹∏ –∏ /∫ 	  9∏ ∏ ‹∏ ‹01"!!67632!4'&Üë6˛‰71Xá©◊˛‹*o{Ae˝≤@üT%B±Õ˝"óV.T     Bˇ⁄úe  j∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∏ ∏ ‹A Ÿ  È  ]A     (  8  H  X  h  x  à  ò  ®  ∏  »  ]∏ ∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∫   i+∫   i+A     &  6  F  V  f  v  Ü  ñ  ¶  ∂  ∆  ]A ’  Â  ]A ⁄  Í  ]A 	    )  9  I  Y  i  y  â  ô  ©  π  …  ]∏ ∏ ‹01 !  54 ! "32654&ä˛Ï˛Á˛Á˛Ï˛Ê}áá}}ÜÜ∏≠Ï˛´UÏZÒ±§§≤≤§§±   <˛P^^   i∏ f+ ∏  EX∏ 
+/π 
+ 
+>Y∏  EX∏  /π   >Y∏  EX∏ /π  >Y∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∫   9∏ 
+∏ ‹A Ÿ  È  ]A     (  8  H  X  h  x  à  ò  ®  ∏  »  ]∫  
+ 9∏ !/∏ "/∏ ‹∏  ‹∏ !∏ –∏ /∏  ∏ –∏ /∏  ∏ –∏ /∏ ∏ ‹A     &  6  F  V  f  v  Ü  ñ  ¶  ∂  ∆  ]A ’  Â  ]01#" 5 325!327654'&#"D õÜΩ˛ˆƒàT13˝%8òì>("=ôlÉ˛P7Bg.¸FC&W¢˙â~SdOé¶©q    Ç  ˚\  h∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏ /π  
+>Y∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∫ 	  9∫   i+∫ 	  901"!!67632.©¨;!˛·B1PÄ*;p?É˝˜Bæm(C˛‹   Bˇ€%a , ≈∏ f+ ∏  EX∏ +/π + 
+>Y∏  EX∏ /π  >Y∏ +∏ ‹A Ÿ  È  ]A     (  8  H  X  h  x  à  ò  ®  ∏  »  ]∏ ∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]01!&'&#"# &5!32654'&%&'&54632tÄ˛„/q]O**ˇ™UTÒ¸˛ˇı!	5èTc((˛ˇπLLÌ◊ÃR»7 ::'18(QR{¢ÕŸ®L 9220=.EDÄóŸ     ˇÍxh  Y∏ f+ ∏  EX∏ /π  >Y∫ 
+  i+∏ ∏  ‹∏ 
+∏ –∏ ∏ –∏  ∏ –∫   i+∏ ∏ 
+–∏ ∏ –01%'&5#53!3#326xá J0òò±±"WÀ’M1füÀ0˛–À˝¿C!    }ˇËUB  »∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∏  EX∏ /π  >Y∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∫    9∏ /∏ /∏ ‹∏ ‹∏  –∏  /∏ ∏ 
+–∏ 
+/∏ ‹01%#"'&5!32765!!@ C}TÚT/$'rí6!˛Îö2<,Æ`ªë˝o]/Sv@iQ˚æ      WB  D∏ f+ ∏  EX∏  /π   
+>Y∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∫    901!!!@„Ë2˛w˛”B¸‹$˚æ    P@  )∏ f+ ∏  EX∏  /π   >Y∏  EX∏ /π  >Y01)!	!!P˛ùºΩ˛¶t˛ú]∂≤S˛öG˛π(˛ƒ<˝Ì         ùD∞©_<ı      ¢(Ä     ﬁ‡.◊˜‹¸'
+˙≥           )˛)  ˜‹¸€~                \« ö    9  9  ™ ·À ßs  s 8 /« oÁ c™ Y™  /¨ I9 v™ /9 Ä9ˇês @s és @s 6s 6s 6s @s 4s 6s =™ Ë™ Ë¨ ¨ I¨ „ {Õ «« 4« °« \« úV •„ ú9 U« ö9 Ñs -« °„ ú™ ó« ó9 eV £9 e« £V U„ !« úV /ç V !V #„ 4™ Ä9ˇê™ /¨ ãs  ™ˇŒs ;„ {s G„ ?s /™ „ B„ á9 â9 	s Ç9 ã Ä„ á„ B„ }„ < Çs B™ „ }s 9 s        à   à   à   à   à   à   à   à   à   à   à   à   à   à   à   à   à   à   à    l  l  l  ¯  @  §    4  	ê  	ê  	ê  	ê  	ê  	ê  	ê  	ê  
+  
+Ù  t  t  t  t  t  t  t  t  t  t  t  t  t  t  t  §  L  L  L  L  L  L  L  L  L  L  L  L  L  L  –  –  L  L  ê  H  ∞  ƒ  L        P  ê  \        ¯  ®   ¯  !ú  "º  #(  #(  #ê    \ k 	 k     p  Ë¢     EB        P         	 P        Y       $©       Õ       î       ú       2™       S       	a      j      z      à      ú      	Æ      €      /‹      È      <      ˜      0G      
+      :w            6±      $      0Á      <      5    	  H      Y     i     w   
+  á         ≠    
+3     «     m    E  	   ]     Õ     e    Q    W     á     u     ô     Å     ﬂ     Â     π    
+{     ˚    +    Ö            
+  !  
+g  "  ç  *  £  9  
+ô  >  
+q     }  	  =     Ì     ±  
+   ü© 1990-2006 Apple Computer Inc. © 1981 Linotype AG © 1990-91 Type Solutions Inc.HelveticaBold B o l d G r a s F e t t0‹0¸0Î0…|óOS V e t G r a s s e t t oº¸¥‹Ã¥ N e g r i t a|óö‘91J6 N e g r i t o F e d L i h a v o i t u F e t B o l d N e g r i t o8@=K9 F e t+2 K a l1 n N e g r e t a B o l d T u n È B o l dàΩƒøΩ±‚—‘ F È l k ˆ v È r T e b a l T e b a l A l d i n B o l d8@=89	,	K	2	M	!≠ mHelvetica Bold; 17.0d1e1; 2020-09-21Helvetica BoldHelvetica GrasHelvetica FettHelvetica grassettoHelvetica vetHelvetica FetHelvetica NegritaHelvetica CarregadoHelvetica HalvfetHelvetica lihavaHelvetica √”ËœHelvetica »—Ã” ÁHelvetica Ú·‰17.0d1e1Helvetica-BoldHelvetica is a registered trademark of Linotype AGHelvetica est une marque déposée de Linotype AGHelvetica ist ein eingetragenes Warenzeichen der Linotype AGHelvetica è un marchio registrato di Linotype AGHelvetica is een geregistreerd handelsmerk van Linotype AGHelvetica är ett registrerat varumärke för Linotype AGHelvetica es una marca registrada de Linotype AGHelvetica er et registreret varemærke tilhørende Linotype AGHelvetica BoldLigaturesCommon LigaturesNumber SpacingProportional NumbersMonospaced NumbersNo Change          ˇe e                     \           	 
+                        ! " # $ % & ' ( ) * + , - . / 0 1 2 3 4 5 6 7 8 9 : ; < = > ? @ A B C D E F G H I J K L M N O P Q R S T U V W X Y Z [  ∏ f+ ∫   h+∫   h+ø  (       n+ø  %       n+ ø  - %      n+ø  K = 0 "    n+ø  &       n+ ∫   m+∏   E}iDendstream
+endobj
+xref
+0 293
+0000000000 65535 f
+0000000009 00000 n
+0000000376 00000 n
+0000000424 00000 n
+0000000566 00000 n
+0000000664 00000 n
+0000002791 00000 n
+0000004348 00000 n
+0000004584 00000 n
+0000004701 00000 n
+0000005031 00000 n
+0000005367 00000 n
+0000005524 00000 n
+0000005653 00000 n
+0000005973 00000 n
+0000006396 00000 n
+0000006548 00000 n
+0000006695 00000 n
+0000007059 00000 n
+0000007244 00000 n
+0000007480 00000 n
+0000007719 00000 n
+0000007838 00000 n
+0000007968 00000 n
+0000008116 00000 n
+0000008481 00000 n
+0000008667 00000 n
+0000008904 00000 n
+0000009143 00000 n
+0000009262 00000 n
+0000009392 00000 n
+0000009540 00000 n
+0000009905 00000 n
+0000010091 00000 n
+0000010328 00000 n
+0000010567 00000 n
+0000010686 00000 n
+0000010816 00000 n
+0000010964 00000 n
+0000011367 00000 n
+0000011595 00000 n
+0000011832 00000 n
+0000012073 00000 n
+0000012192 00000 n
+0000012322 00000 n
+0000012470 00000 n
+0000012869 00000 n
+0000013097 00000 n
+0000013334 00000 n
+0000013575 00000 n
+0000013694 00000 n
+0000013824 00000 n
+0000014014 00000 n
+0000014452 00000 n
+0000014719 00000 n
+0000014959 00000 n
+0000015196 00000 n
+0000015434 00000 n
+0000015554 00000 n
+0000015684 00000 n
+0000015874 00000 n
+0000016347 00000 n
+0000016585 00000 n
+0000016931 00000 n
+0000017169 00000 n
+0000017503 00000 n
+0000017741 00000 n
+0000017860 00000 n
+0000017990 00000 n
+0000018138 00000 n
+0000018503 00000 n
+0000018689 00000 n
+0000018926 00000 n
+0000019166 00000 n
+0000019285 00000 n
+0000019415 00000 n
+0000019563 00000 n
+0000019928 00000 n
+0000020114 00000 n
+0000020351 00000 n
+0000020591 00000 n
+0000020710 00000 n
+0000020840 00000 n
+0000020988 00000 n
+0000021391 00000 n
+0000021619 00000 n
+0000021856 00000 n
+0000022092 00000 n
+0000022211 00000 n
+0000022341 00000 n
+0000022489 00000 n
+0000022888 00000 n
+0000023116 00000 n
+0000023353 00000 n
+0000023589 00000 n
+0000023708 00000 n
+0000023838 00000 n
+0000024028 00000 n
+0000024466 00000 n
+0000024733 00000 n
+0000024968 00000 n
+0000025206 00000 n
+0000025442 00000 n
+0000025564 00000 n
+0000025696 00000 n
+0000025889 00000 n
+0000026323 00000 n
+0000026559 00000 n
+0000026871 00000 n
+0000027169 00000 n
+0000027410 00000 n
+0000027531 00000 n
+0000027663 00000 n
+0000027813 00000 n
+0000028180 00000 n
+0000028368 00000 n
+0000028607 00000 n
+0000028848 00000 n
+0000028969 00000 n
+0000029101 00000 n
+0000029251 00000 n
+0000029614 00000 n
+0000029802 00000 n
+0000030041 00000 n
+0000030282 00000 n
+0000030403 00000 n
+0000030535 00000 n
+0000030685 00000 n
+0000031087 00000 n
+0000031318 00000 n
+0000031557 00000 n
+0000031798 00000 n
+0000031919 00000 n
+0000032051 00000 n
+0000032201 00000 n
+0000032603 00000 n
+0000032834 00000 n
+0000033073 00000 n
+0000033313 00000 n
+0000033434 00000 n
+0000033566 00000 n
+0000033759 00000 n
+0000034201 00000 n
+0000034441 00000 n
+0000034712 00000 n
+0000034952 00000 n
+0000035234 00000 n
+0000035474 00000 n
+0000035596 00000 n
+0000035728 00000 n
+0000035921 00000 n
+0000036161 00000 n
+0000036635 00000 n
+0000036947 00000 n
+0000037187 00000 n
+0000037485 00000 n
+0000037724 00000 n
+0000037846 00000 n
+0000037979 00000 n
+0000038129 00000 n
+0000038500 00000 n
+0000038689 00000 n
+0000038928 00000 n
+0000039167 00000 n
+0000039290 00000 n
+0000039424 00000 n
+0000039574 00000 n
+0000039945 00000 n
+0000040135 00000 n
+0000040374 00000 n
+0000040557 00000 n
+0000040686 00000 n
+0000040827 00000 n
+0000040977 00000 n
+0000041312 00000 n
+0000041508 00000 n
+0000041747 00000 n
+0000041930 00000 n
+0000042058 00000 n
+0000042199 00000 n
+0000042349 00000 n
+0000042684 00000 n
+0000042879 00000 n
+0000043118 00000 n
+0000043301 00000 n
+0000043426 00000 n
+0000043567 00000 n
+0000043717 00000 n
+0000044048 00000 n
+0000044240 00000 n
+0000044479 00000 n
+0000044664 00000 n
+0000044788 00000 n
+0000044929 00000 n
+0000045079 00000 n
+0000045414 00000 n
+0000045605 00000 n
+0000045844 00000 n
+0000046027 00000 n
+0000046157 00000 n
+0000046298 00000 n
+0000046448 00000 n
+0000046759 00000 n
+0000046956 00000 n
+0000047195 00000 n
+0000047378 00000 n
+0000047513 00000 n
+0000047654 00000 n
+0000047804 00000 n
+0000048135 00000 n
+0000048337 00000 n
+0000048576 00000 n
+0000048759 00000 n
+0000048893 00000 n
+0000049034 00000 n
+0000049184 00000 n
+0000049515 00000 n
+0000049716 00000 n
+0000049955 00000 n
+0000050138 00000 n
+0000050266 00000 n
+0000050407 00000 n
+0000050557 00000 n
+0000050904 00000 n
+0000051099 00000 n
+0000051338 00000 n
+0000051521 00000 n
+0000051645 00000 n
+0000051786 00000 n
+0000051936 00000 n
+0000052267 00000 n
+0000052458 00000 n
+0000052697 00000 n
+0000052880 00000 n
+0000053005 00000 n
+0000053146 00000 n
+0000053296 00000 n
+0000053611 00000 n
+0000053803 00000 n
+0000054042 00000 n
+0000054225 00000 n
+0000054349 00000 n
+0000054480 00000 n
+0000054630 00000 n
+0000054961 00000 n
+0000055152 00000 n
+0000055391 00000 n
+0000056974 00000 n
+0000058557 00000 n
+0000060140 00000 n
+0000061796 00000 n
+0000063442 00000 n
+0000064857 00000 n
+0000065262 00000 n
+0000066101 00000 n
+0000066904 00000 n
+0000067403 00000 n
+0000068985 00000 n
+0000070568 00000 n
+0000072225 00000 n
+0000073875 00000 n
+0000075291 00000 n
+0000075697 00000 n
+0000076670 00000 n
+0000077629 00000 n
+0000079212 00000 n
+0000080791 00000 n
+0000082444 00000 n
+0000084094 00000 n
+0000085074 00000 n
+0000085712 00000 n
+0000086023 00000 n
+0000086614 00000 n
+0000087587 00000 n
+0000088047 00000 n
+0000089646 00000 n
+0000091257 00000 n
+0000092898 00000 n
+0000094531 00000 n
+0000096136 00000 n
+0000097737 00000 n
+0000099362 00000 n
+0000101047 00000 n
+0000102724 00000 n
+0000104369 00000 n
+0000105966 00000 n
+0000107555 00000 n
+0000109112 00000 n
+0000110178 00000 n
+0000110337 00000 n
+0000131120 00000 n
+0000131905 00000 n
+0000132023 00000 n
+trailer
+<<
+/Root 3 0 R 
+/Size 293 
+>>
+startxref
+145362
+%%EOF

--- a/ltml/samples/test_052_large_paper_sizes.ltml
+++ b/ltml/samples/test_052_large_paper_sizes.ltml
@@ -1,0 +1,333 @@
+<ltml units="in" margin="0.5" font.name="Helvetica" font.size="12">
+  <pen id="thin" width="0.5pt" color="SlateGray" />
+  <layout id="vbox" padding="6pt" />
+  <style>
+    label.size-title { font.size: 22; font.weight: Bold; }
+    p.meta-line { font.name: Helvetica; font.size: 7; color: DimGray; width: 100%; font.line-height: 1.5; }
+    rect.calibration-box { width: 1in; height: 1in; border: thin; fill: AliceBlue; }
+  </style>
+  <page style="A0">
+    <label class="size-title">A0</label>
+    <p class="meta-line">Family: ISO A</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 33.11in × 46.811in | 841 × 1189 mm | 2383.937 × 3370.394 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="A0".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="A1">
+    <label class="size-title">A1</label>
+    <p class="meta-line">Family: ISO A</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 23.386in × 33.11in | 594 × 841 mm | 1683.78 × 2383.937 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="A1".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="A2">
+    <label class="size-title">A2</label>
+    <p class="meta-line">Family: ISO A</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 16.535in × 23.386in | 420 × 594 mm | 1190.551 × 1683.78 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="A2".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="A3">
+    <label class="size-title">A3</label>
+    <p class="meta-line">Family: ISO A</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 11.693in × 16.535in | 297 × 420 mm | 841.89 × 1190.551 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="A3".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="B0">
+    <label class="size-title">B0</label>
+    <p class="meta-line">Family: ISO B</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 39.37in × 55.669in | 1000 × 1414 mm | 2834.646 × 4008.189 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="B0".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="B1">
+    <label class="size-title">B1</label>
+    <p class="meta-line">Family: ISO B</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 27.835in × 39.37in | 707 × 1000 mm | 2004.094 × 2834.646 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="B1".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="B2">
+    <label class="size-title">B2</label>
+    <p class="meta-line">Family: ISO B</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 19.685in × 27.835in | 500 × 707 mm | 1417.323 × 2004.094 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="B2".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="B3">
+    <label class="size-title">B3</label>
+    <p class="meta-line">Family: ISO B</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 13.898in × 19.685in | 353 × 500 mm | 1000.63 × 1417.323 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="B3".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="B4">
+    <label class="size-title">B4</label>
+    <p class="meta-line">Family: ISO B</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 9.843in × 13.898in | 250 × 353 mm | 708.661 × 1000.63 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="B4".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="C0">
+    <label class="size-title">C0</label>
+    <p class="meta-line">Family: ISO C</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 36.102in × 51.063in | 917 × 1297 mm | 2599.37 × 3676.535 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="C0".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="C1">
+    <label class="size-title">C1</label>
+    <p class="meta-line">Family: ISO C</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 25.512in × 36.102in | 648 × 917 mm | 1836.85 × 2599.37 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="C1".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="C2">
+    <label class="size-title">C2</label>
+    <p class="meta-line">Family: ISO C</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 18.031in × 25.512in | 458 × 648 mm | 1298.268 × 1836.85 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="C2".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="C3">
+    <label class="size-title">C3</label>
+    <p class="meta-line">Family: ISO C</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 12.756in × 18.031in | 324 × 458 mm | 918.425 × 1298.268 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="C3".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="C4">
+    <label class="size-title">C4</label>
+    <p class="meta-line">Family: ISO C</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 9.016in × 12.756in | 229 × 324 mm | 649.134 × 918.425 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="C4".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="RA0">
+    <label class="size-title">RA0</label>
+    <p class="meta-line">Family: ISO RA</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 33.858in × 48.031in | 860 × 1220 mm | 2437.795 × 3458.268 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="RA0".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="RA1">
+    <label class="size-title">RA1</label>
+    <p class="meta-line">Family: ISO RA</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 24.016in × 33.858in | 610 × 860 mm | 1729.134 × 2437.795 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="RA1".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="RA2">
+    <label class="size-title">RA2</label>
+    <p class="meta-line">Family: ISO RA</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 16.929in × 24.016in | 430 × 610 mm | 1218.898 × 1729.134 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="RA2".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="RA3">
+    <label class="size-title">RA3</label>
+    <p class="meta-line">Family: ISO RA</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 12.008in × 16.929in | 305 × 430 mm | 864.567 × 1218.898 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="RA3".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="SRA0">
+    <label class="size-title">SRA0</label>
+    <p class="meta-line">Family: ISO SRA</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 35.433in × 50.394in | 900 × 1280 mm | 2551.181 × 3628.346 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="SRA0".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="SRA1">
+    <label class="size-title">SRA1</label>
+    <p class="meta-line">Family: ISO SRA</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 25.197in × 35.433in | 640 × 900 mm | 1814.173 × 2551.181 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="SRA1".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="SRA2">
+    <label class="size-title">SRA2</label>
+    <p class="meta-line">Family: ISO SRA</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 17.717in × 25.197in | 450 × 640 mm | 1275.591 × 1814.173 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="SRA2".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="SRA3">
+    <label class="size-title">SRA3</label>
+    <p class="meta-line">Family: ISO SRA</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 12.598in × 17.717in | 320 × 450 mm | 907.087 × 1275.591 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="SRA3".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="tabloid" style.orientation="landscape">
+    <label class="size-title">tabloid</label>
+    <p class="meta-line">Family: North American</p>
+    <p class="meta-line">Orientation in sample: landscape</p>
+    <p class="meta-line">Size: 11in × 17in | 279.4 × 431.8 mm | 792 × 1224 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="tabloid".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="ledger" style.orientation="landscape">
+    <label class="size-title">ledger</label>
+    <p class="meta-line">Family: North American</p>
+    <p class="meta-line">Orientation in sample: landscape</p>
+    <p class="meta-line">Size: 11in × 17in | 279.4 × 431.8 mm | 792 × 1224 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="ledger".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="ansib" style.orientation="landscape">
+    <label class="size-title">ansib</label>
+    <p class="meta-line">Family: ANSI</p>
+    <p class="meta-line">Orientation in sample: landscape</p>
+    <p class="meta-line">Size: 11in × 17in | 279.4 × 431.8 mm | 792 × 1224 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="ansib".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="ansic" style.orientation="landscape">
+    <label class="size-title">ansic</label>
+    <p class="meta-line">Family: ANSI</p>
+    <p class="meta-line">Orientation in sample: landscape</p>
+    <p class="meta-line">Size: 17in × 22in | 431.8 × 558.8 mm | 1224 × 1584 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="ansic".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="ansid" style.orientation="landscape">
+    <label class="size-title">ansid</label>
+    <p class="meta-line">Family: ANSI</p>
+    <p class="meta-line">Orientation in sample: landscape</p>
+    <p class="meta-line">Size: 22in × 34in | 558.8 × 863.6 mm | 1584 × 2448 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="ansid".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="ansie" style.orientation="landscape">
+    <label class="size-title">ansie</label>
+    <p class="meta-line">Family: ANSI</p>
+    <p class="meta-line">Orientation in sample: landscape</p>
+    <p class="meta-line">Size: 34in × 44in | 863.6 × 1117.6 mm | 2448 × 3168 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="ansie".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="archa">
+    <label class="size-title">archa</label>
+    <p class="meta-line">Family: ARCH</p>
+    <p class="meta-line">Orientation in sample: portrait</p>
+    <p class="meta-line">Size: 9in × 12in | 228.6 × 304.8 mm | 648 × 864 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="archa".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="archb" style.orientation="landscape">
+    <label class="size-title">archb</label>
+    <p class="meta-line">Family: ARCH</p>
+    <p class="meta-line">Orientation in sample: landscape</p>
+    <p class="meta-line">Size: 12in × 18in | 304.8 × 457.2 mm | 864 × 1296 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="archb".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="archc" style.orientation="landscape">
+    <label class="size-title">archc</label>
+    <p class="meta-line">Family: ARCH</p>
+    <p class="meta-line">Orientation in sample: landscape</p>
+    <p class="meta-line">Size: 18in × 24in | 457.2 × 609.6 mm | 1296 × 1728 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="archc".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="archd" style.orientation="landscape">
+    <label class="size-title">archd</label>
+    <p class="meta-line">Family: ARCH</p>
+    <p class="meta-line">Orientation in sample: landscape</p>
+    <p class="meta-line">Size: 24in × 36in | 609.6 × 914.4 mm | 1728 × 2592 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="archd".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="arche" style.orientation="landscape">
+    <label class="size-title">arche</label>
+    <p class="meta-line">Family: ARCH</p>
+    <p class="meta-line">Orientation in sample: landscape</p>
+    <p class="meta-line">Size: 36in × 48in | 914.4 × 1219.2 mm | 2592 × 3456 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="arche".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="arche1" style.orientation="landscape">
+    <label class="size-title">arche1</label>
+    <p class="meta-line">Family: ARCH</p>
+    <p class="meta-line">Orientation in sample: landscape</p>
+    <p class="meta-line">Size: 30in × 42in | 762 × 1066.8 mm | 2160 × 3024 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="arche1".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="arche2" style.orientation="landscape">
+    <label class="size-title">arche2</label>
+    <p class="meta-line">Family: ARCH</p>
+    <p class="meta-line">Orientation in sample: landscape</p>
+    <p class="meta-line">Size: 26in × 38in | 660.4 × 965.2 mm | 1872 × 2736 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="arche2".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+  <page style="arche3" style.orientation="landscape">
+    <label class="size-title">arche3</label>
+    <p class="meta-line">Family: ARCH</p>
+    <p class="meta-line">Orientation in sample: landscape</p>
+    <p class="meta-line">Size: 27in × 39in | 685.8 × 990.6 mm | 1944 × 2808 pt</p>
+    <p class="meta-line">Built-in style lookup is case-insensitive; this page uses style="arche3".</p>
+    <rect class="calibration-box" />
+    <p class="meta-line">Calibration square: 1in × 1in</p>
+  </page>
+</ltml>

--- a/ltml/samples/test_052_large_paper_sizes.pdf
+++ b/ltml/samples/test_052_large_paper_sizes.pdf
@@ -1,0 +1,7822 @@
+%PDF-1.7
+1 0 obj
+<<
+/Count 36 
+/Kids [7 0 R 20 0 R 27 0 R 34 0 R 41 0 R 48 0 R 55 0 R 62 0 R 69 0 R 76 0 R 83 0 R 90 0 R 97 0 R 104 0 R 111 0 R 118 0 R 125 0 R 132 0 R 139 0 R 146 0 R 153 0 R 160 0 R 167 0 R 174 0 R 181 0 R 188 0 R 195 0 R 202 0 R 209 0 R 216 0 R 223 0 R 230 0 R 237 0 R 244 0 R 251 0 R 258 0 R ] 
+/Type /Pages 
+>>
+endobj
+2 0 obj
+<<
+/Count 0 
+/Type /Outlines 
+>>
+endobj
+3 0 obj
+<<
+/MarkInfo <<
+/Marked true 
+>>
+
+/Outlines 2 0 R 
+/PageMode /UseNone 
+/Pages 1 0 R 
+/StructTreeRoot 6 0 R 
+/Type /Catalog 
+>>
+endobj
+4 0 obj
+<<
+/Font <<
+/F0 11 0 R 
+/F1 15 0 R 
+>>
+
+/ProcSet [/PDF /Text /ImageB /ImageC ] 
+>>
+endobj
+5 0 obj
+<<
+/Nums [0 [8 0 R 12 0 R 16 0 R 17 0 R 18 0 R 19 0 R ] 1 [21 0 R 22 0 R 23 0 R 24 0 R 25 0 R 26 0 R ] 2 [28 0 R 29 0 R 30 0 R 31 0 R 32 0 R 33 0 R ] 3 [35 0 R 36 0 R 37 0 R 38 0 R 39 0 R 40 0 R ] 4 [42 0 R 43 0 R 44 0 R 45 0 R 46 0 R 47 0 R ] 5 [49 0 R 50 0 R 51 0 R 52 0 R 53 0 R 54 0 R ] 6 [56 0 R 57 0 R 58 0 R 59 0 R 60 0 R 61 0 R ] 7 [63 0 R 64 0 R 65 0 R 66 0 R 67 0 R 68 0 R ] 8 [70 0 R 71 0 R 72 0 R 73 0 R 74 0 R 75 0 R ] 9 [77 0 R 78 0 R 79 0 R 80 0 R 81 0 R 82 0 R ] 10 [84 0 R 85 0 R 86 0 R 87 0 R 88 0 R 89 0 R ] 11 [91 0 R 92 0 R 93 0 R 94 0 R 95 0 R 96 0 R ] 12 [98 0 R 99 0 R 100 0 R 101 0 R 102 0 R 103 0 R ] 13 [105 0 R 106 0 R 107 0 R 108 0 R 109 0 R 110 0 R ] 14 [112 0 R 113 0 R 114 0 R 115 0 R 116 0 R 117 0 R ] 15 [119 0 R 120 0 R 121 0 R 122 0 R 123 0 R 124 0 R ] 16 [126 0 R 127 0 R 128 0 R 129 0 R 130 0 R 131 0 R ] 17 [133 0 R 134 0 R 135 0 R 136 0 R 137 0 R 138 0 R ] 18 [140 0 R 141 0 R 142 0 R 143 0 R 144 0 R 145 0 R ] 19 [147 0 R 148 0 R 149 0 R 150 0 R 151 0 R 152 0 R ] 20 [154 0 R 155 0 R 156 0 R 157 0 R 158 0 R 159 0 R ] 21 [161 0 R 162 0 R 163 0 R 164 0 R 165 0 R 166 0 R ] 22 [168 0 R 169 0 R 170 0 R 171 0 R 172 0 R 173 0 R ] 23 [175 0 R 176 0 R 177 0 R 178 0 R 179 0 R 180 0 R ] 24 [182 0 R 183 0 R 184 0 R 185 0 R 186 0 R 187 0 R ] 25 [189 0 R 190 0 R 191 0 R 192 0 R 193 0 R 194 0 R ] 26 [196 0 R 197 0 R 198 0 R 199 0 R 200 0 R 201 0 R ] 27 [203 0 R 204 0 R 205 0 R 206 0 R 207 0 R 208 0 R ] 28 [210 0 R 211 0 R 212 0 R 213 0 R 214 0 R 215 0 R ] 29 [217 0 R 218 0 R 219 0 R 220 0 R 221 0 R 222 0 R ] 30 [224 0 R 225 0 R 226 0 R 227 0 R 228 0 R 229 0 R ] 31 [231 0 R 232 0 R 233 0 R 234 0 R 235 0 R 236 0 R ] 32 [238 0 R 239 0 R 240 0 R 241 0 R 242 0 R 243 0 R ] 33 [245 0 R 246 0 R 247 0 R 248 0 R 249 0 R 250 0 R ] 34 [252 0 R 253 0 R 254 0 R 255 0 R 256 0 R 257 0 R ] 35 [259 0 R 260 0 R 261 0 R 262 0 R 263 0 R 264 0 R ] ] 
+>>
+endobj
+6 0 obj
+<<
+/K [8 0 R 12 0 R 16 0 R 17 0 R 18 0 R 19 0 R 21 0 R 22 0 R 23 0 R 24 0 R 25 0 R 26 0 R 28 0 R 29 0 R 30 0 R 31 0 R 32 0 R 33 0 R 35 0 R 36 0 R 37 0 R 38 0 R 39 0 R 40 0 R 42 0 R 43 0 R 44 0 R 45 0 R 46 0 R 47 0 R 49 0 R 50 0 R 51 0 R 52 0 R 53 0 R 54 0 R 56 0 R 57 0 R 58 0 R 59 0 R 60 0 R 61 0 R 63 0 R 64 0 R 65 0 R 66 0 R 67 0 R 68 0 R 70 0 R 71 0 R 72 0 R 73 0 R 74 0 R 75 0 R 77 0 R 78 0 R 79 0 R 80 0 R 81 0 R 82 0 R 84 0 R 85 0 R 86 0 R 87 0 R 88 0 R 89 0 R 91 0 R 92 0 R 93 0 R 94 0 R 95 0 R 96 0 R 98 0 R 99 0 R 100 0 R 101 0 R 102 0 R 103 0 R 105 0 R 106 0 R 107 0 R 108 0 R 109 0 R 110 0 R 112 0 R 113 0 R 114 0 R 115 0 R 116 0 R 117 0 R 119 0 R 120 0 R 121 0 R 122 0 R 123 0 R 124 0 R 126 0 R 127 0 R 128 0 R 129 0 R 130 0 R 131 0 R 133 0 R 134 0 R 135 0 R 136 0 R 137 0 R 138 0 R 140 0 R 141 0 R 142 0 R 143 0 R 144 0 R 145 0 R 147 0 R 148 0 R 149 0 R 150 0 R 151 0 R 152 0 R 154 0 R 155 0 R 156 0 R 157 0 R 158 0 R 159 0 R 161 0 R 162 0 R 163 0 R 164 0 R 165 0 R 166 0 R 168 0 R 169 0 R 170 0 R 171 0 R 172 0 R 173 0 R 175 0 R 176 0 R 177 0 R 178 0 R 179 0 R 180 0 R 182 0 R 183 0 R 184 0 R 185 0 R 186 0 R 187 0 R 189 0 R 190 0 R 191 0 R 192 0 R 193 0 R 194 0 R 196 0 R 197 0 R 198 0 R 199 0 R 200 0 R 201 0 R 203 0 R 204 0 R 205 0 R 206 0 R 207 0 R 208 0 R 210 0 R 211 0 R 212 0 R 213 0 R 214 0 R 215 0 R 217 0 R 218 0 R 219 0 R 220 0 R 221 0 R 222 0 R 224 0 R 225 0 R 226 0 R 227 0 R 228 0 R 229 0 R 231 0 R 232 0 R 233 0 R 234 0 R 235 0 R 236 0 R 238 0 R 239 0 R 240 0 R 241 0 R 242 0 R 243 0 R 245 0 R 246 0 R 247 0 R 248 0 R 249 0 R 250 0 R 252 0 R 253 0 R 254 0 R 255 0 R 256 0 R 257 0 R 259 0 R 260 0 R 261 0 R 262 0 R 263 0 R 264 0 R ] 
+/ParentTree 5 0 R 
+/ParentTreeNextKey 36 
+/Type /StructTreeRoot 
+>>
+endobj
+7 0 obj
+<<
+/Contents 265 0 R 
+/CropBox [0 0 2383.9370078740158 3370.393700787402 ] 
+/Length 1549 
+/MediaBox [0 0 2383.9370078740158 3370.393700787402 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 0 
+/Type /Page 
+>>
+endobj
+8 0 obj
+<<
+/ActualText (A0) 
+/K <<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+9 0 obj
+<<
+/Ascent 1577 
+/AvgWidth 0 
+/CapHeight 1474 
+/Descent -471 
+/Flags 262144 
+/FontBBox [-2084 -985 2810 1971 ] 
+/FontFamily (Helvetica) 
+/FontFile2 306 0 R 
+/FontName /XOHAIC+Helvetica-Bold 
+/ItalicAngle 0 
+/Leading 2048 
+/MaxWidth 0 
+/MissingWidth 0 
+/StemH 0 
+/StemV 165 
+/Type /FontDescriptor 
+/XHeight 1090 
+>>
+endobj
+10 0 obj
+<<
+/BaseFont /XOHAIC+Helvetica-Bold 
+/CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> 
+/CIDToGIDMap 305 0 R 
+/DW 556 
+/FontDescriptor 9 0 R 
+/Subtype /CIDFontType2 
+/Type /Font 
+/W [1 [722 ] 6 [722 ] 8 [722 722 666 333 ] 13 [610 277 610 277 610 ] 19 [610 389 610 ] 24 [610 ] ] 
+>>
+endobj
+11 0 obj
+<<
+/BaseFont /XOHAIC+Helvetica-Bold 
+/DescendantFonts [10 0 R ] 
+/Encoding /Identity-H 
+/Subtype /Type0 
+/ToUnicode 304 0 R 
+/Type /Font 
+>>
+endobj
+12 0 obj
+<<
+/ActualText (Family: ISO A) 
+/K <<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+13 0 obj
+<<
+/Ascent 1577 
+/AvgWidth 0 
+/CapHeight 1469 
+/Descent -471 
+/Flags 0 
+/FontBBox [-1947 -985 2961 2297 ] 
+/FontFamily (Helvetica) 
+/FontFile2 303 0 R 
+/FontName /OOQZEU+Helvetica 
+/ItalicAngle 0 
+/Leading 2048 
+/MaxWidth 0 
+/MissingWidth 0 
+/StemH 0 
+/StemV 87 
+/Type /FontDescriptor 
+/XHeight 1071 
+>>
+endobj
+14 0 obj
+<<
+/BaseFont /OOQZEU+Helvetica 
+/CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> 
+/CIDToGIDMap 302 0 R 
+/DW 556 
+/FontDescriptor 13 0 R 
+/Subtype /CIDFontType2 
+/Type /Font 
+/W [1 [610 ] 3 [833 222 222 500 277 277 277 666 777 666 333 ] 16 [277 ] 18 [500 ] 20 [500 ] 22 [277 ] 24 [583 ] 28 [259 ] 33 [666 ] 35 [333 500 500 500 277 ] 42 [583 354 722 ] 48 [722 722 ] 51 [722 ] ] 
+>>
+endobj
+15 0 obj
+<<
+/BaseFont /OOQZEU+Helvetica 
+/DescendantFonts [14 0 R ] 
+/Encoding /Identity-H 
+/Subtype /Type0 
+/ToUnicode 301 0 R 
+/Type /Font 
+>>
+endobj
+16 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+17 0 obj
+<<
+/ActualText <feff00530069007a0065003a002000330033002e003100310069006e002000d7002000340036002e0038003100310069006e0020007c0020003800340031002000d7002000310031003800390020006d006d0020007c00200032003300380033002e003900330037002000d700200033003300370030002e003300390034002000700074> 
+/K <<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+18 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="A0".) 
+/K <<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+19 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+20 0 obj
+<<
+/Contents 266 0 R 
+/CropBox [0 0 1683.7795275590552 2383.9370078740158 ] 
+/Length 1539 
+/MediaBox [0 0 1683.7795275590552 2383.9370078740158 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 1 
+/Type /Page 
+>>
+endobj
+21 0 obj
+<<
+/ActualText (A1) 
+/K <<
+/Type /MCR 
+/Pg 20 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+22 0 obj
+<<
+/ActualText (Family: ISO A) 
+/K <<
+/Type /MCR 
+/Pg 20 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+23 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 20 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+24 0 obj
+<<
+/ActualText <feff00530069007a0065003a002000320033002e0033003800360069006e002000d7002000330033002e003100310069006e0020007c0020003500390034002000d700200038003400310020006d006d0020007c00200031003600380033002e00370038002000d700200032003300380033002e003900330037002000700074> 
+/K <<
+/Type /MCR 
+/Pg 20 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+25 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="A1".) 
+/K <<
+/Type /MCR 
+/Pg 20 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+26 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 20 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+27 0 obj
+<<
+/Contents 267 0 R 
+/CropBox [0 0 1190.5511811023623 1683.7795275590552 ] 
+/Length 1545 
+/MediaBox [0 0 1190.5511811023623 1683.7795275590552 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 2 
+/Type /Page 
+>>
+endobj
+28 0 obj
+<<
+/ActualText (A2) 
+/K <<
+/Type /MCR 
+/Pg 27 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+29 0 obj
+<<
+/ActualText (Family: ISO A) 
+/K <<
+/Type /MCR 
+/Pg 27 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+30 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 27 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+31 0 obj
+<<
+/ActualText <feff00530069007a0065003a002000310036002e0035003300350069006e002000d7002000320033002e0033003800360069006e0020007c0020003400320030002000d700200035003900340020006d006d0020007c00200031003100390030002e003500350031002000d700200031003600380033002e00370038002000700074> 
+/K <<
+/Type /MCR 
+/Pg 27 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+32 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="A2".) 
+/K <<
+/Type /MCR 
+/Pg 27 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+33 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 27 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+34 0 obj
+<<
+/Contents 268 0 R 
+/CropBox [0 0 841.8897637795276 1190.5511811023623 ] 
+/Length 1539 
+/MediaBox [0 0 841.8897637795276 1190.5511811023623 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 3 
+/Type /Page 
+>>
+endobj
+35 0 obj
+<<
+/ActualText (A3) 
+/K <<
+/Type /MCR 
+/Pg 34 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+36 0 obj
+<<
+/ActualText (Family: ISO A) 
+/K <<
+/Type /MCR 
+/Pg 34 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+37 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 34 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+38 0 obj
+<<
+/ActualText <feff00530069007a0065003a002000310031002e0036003900330069006e002000d7002000310036002e0035003300350069006e0020007c0020003200390037002000d700200034003200300020006d006d0020007c0020003800340031002e00380039002000d700200031003100390030002e003500350031002000700074> 
+/K <<
+/Type /MCR 
+/Pg 34 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+39 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="A3".) 
+/K <<
+/Type /MCR 
+/Pg 34 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+40 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 34 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+41 0 obj
+<<
+/Contents 269 0 R 
+/CropBox [0 0 2834.645669291339 4008.188976377953 ] 
+/Length 1551 
+/MediaBox [0 0 2834.645669291339 4008.188976377953 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 4 
+/Type /Page 
+>>
+endobj
+42 0 obj
+<<
+/ActualText (B0) 
+/K <<
+/Type /MCR 
+/Pg 41 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+43 0 obj
+<<
+/ActualText (Family: ISO B) 
+/K <<
+/Type /MCR 
+/Pg 41 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+44 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 41 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+45 0 obj
+<<
+/ActualText <feff00530069007a0065003a002000330039002e003300370069006e002000d7002000350035002e0036003600390069006e0020007c00200031003000300030002000d7002000310034003100340020006d006d0020007c00200032003800330034002e003600340036002000d700200034003000300038002e003100380039002000700074> 
+/K <<
+/Type /MCR 
+/Pg 41 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+46 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="B0".) 
+/K <<
+/Type /MCR 
+/Pg 41 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+47 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 41 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+48 0 obj
+<<
+/Contents 270 0 R 
+/CropBox [0 0 2004.0944881889766 2834.645669291339 ] 
+/Length 1549 
+/MediaBox [0 0 2004.0944881889766 2834.645669291339 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 5 
+/Type /Page 
+>>
+endobj
+49 0 obj
+<<
+/ActualText (B1) 
+/K <<
+/Type /MCR 
+/Pg 48 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+50 0 obj
+<<
+/ActualText (Family: ISO B) 
+/K <<
+/Type /MCR 
+/Pg 48 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+51 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 48 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+52 0 obj
+<<
+/ActualText <feff00530069007a0065003a002000320037002e0038003300350069006e002000d7002000330039002e003300370069006e0020007c0020003700300037002000d7002000310030003000300020006d006d0020007c00200032003000300034002e003000390034002000d700200032003800330034002e003600340036002000700074> 
+/K <<
+/Type /MCR 
+/Pg 48 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+53 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="B1".) 
+/K <<
+/Type /MCR 
+/Pg 48 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+54 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 48 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+55 0 obj
+<<
+/Contents 271 0 R 
+/CropBox [0 0 1417.3228346456694 2004.0944881889766 ] 
+/Length 1549 
+/MediaBox [0 0 1417.3228346456694 2004.0944881889766 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 6 
+/Type /Page 
+>>
+endobj
+56 0 obj
+<<
+/ActualText (B2) 
+/K <<
+/Type /MCR 
+/Pg 55 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+57 0 obj
+<<
+/ActualText (Family: ISO B) 
+/K <<
+/Type /MCR 
+/Pg 55 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+58 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 55 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+59 0 obj
+<<
+/ActualText <feff00530069007a0065003a002000310039002e0036003800350069006e002000d7002000320037002e0038003300350069006e0020007c0020003500300030002000d700200037003000370020006d006d0020007c00200031003400310037002e003300320033002000d700200032003000300034002e003000390034002000700074> 
+/K <<
+/Type /MCR 
+/Pg 55 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+60 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="B2".) 
+/K <<
+/Type /MCR 
+/Pg 55 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+61 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 55 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+62 0 obj
+<<
+/Contents 272 0 R 
+/CropBox [0 0 1000.6299212598426 1417.3228346456694 ] 
+/Length 1545 
+/MediaBox [0 0 1000.6299212598426 1417.3228346456694 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 7 
+/Type /Page 
+>>
+endobj
+63 0 obj
+<<
+/ActualText (B3) 
+/K <<
+/Type /MCR 
+/Pg 62 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+64 0 obj
+<<
+/ActualText (Family: ISO B) 
+/K <<
+/Type /MCR 
+/Pg 62 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+65 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 62 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+66 0 obj
+<<
+/ActualText <feff00530069007a0065003a002000310033002e0038003900380069006e002000d7002000310039002e0036003800350069006e0020007c0020003300350033002000d700200035003000300020006d006d0020007c00200031003000300030002e00360033002000d700200031003400310037002e003300320033002000700074> 
+/K <<
+/Type /MCR 
+/Pg 62 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+67 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="B3".) 
+/K <<
+/Type /MCR 
+/Pg 62 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+68 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 62 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+69 0 obj
+<<
+/Contents 273 0 R 
+/CropBox [0 0 708.6614173228347 1000.6299212598426 ] 
+/Length 1533 
+/MediaBox [0 0 708.6614173228347 1000.6299212598426 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 8 
+/Type /Page 
+>>
+endobj
+70 0 obj
+<<
+/ActualText (B4) 
+/K <<
+/Type /MCR 
+/Pg 69 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+71 0 obj
+<<
+/ActualText (Family: ISO B) 
+/K <<
+/Type /MCR 
+/Pg 69 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+72 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 69 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+73 0 obj
+<<
+/ActualText <feff00530069007a0065003a00200039002e0038003400330069006e002000d7002000310033002e0038003900380069006e0020007c0020003200350030002000d700200033003500330020006d006d0020007c0020003700300038002e003600360031002000d700200031003000300030002e00360033002000700074> 
+/K <<
+/Type /MCR 
+/Pg 69 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+74 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="B4".) 
+/K <<
+/Type /MCR 
+/Pg 69 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+75 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 69 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+76 0 obj
+<<
+/Contents 274 0 R 
+/CropBox [0 0 2599.3700787401576 3676.5354330708665 ] 
+/Length 1548 
+/MediaBox [0 0 2599.3700787401576 3676.5354330708665 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 9 
+/Type /Page 
+>>
+endobj
+77 0 obj
+<<
+/ActualText (C0) 
+/K <<
+/Type /MCR 
+/Pg 76 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+78 0 obj
+<<
+/ActualText (Family: ISO C) 
+/K <<
+/Type /MCR 
+/Pg 76 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+79 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 76 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+80 0 obj
+<<
+/ActualText <feff00530069007a0065003a002000330036002e0031003000320069006e002000d7002000350031002e0030003600330069006e0020007c0020003900310037002000d7002000310032003900370020006d006d0020007c00200032003500390039002e00330037002000d700200033003600370036002e003500330035002000700074> 
+/K <<
+/Type /MCR 
+/Pg 76 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+81 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="C0".) 
+/K <<
+/Type /MCR 
+/Pg 76 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+82 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 76 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+83 0 obj
+<<
+/Contents 275 0 R 
+/CropBox [0 0 1836.8503937007874 2599.3700787401576 ] 
+/Length 1541 
+/MediaBox [0 0 1836.8503937007874 2599.3700787401576 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 10 
+/Type /Page 
+>>
+endobj
+84 0 obj
+<<
+/ActualText (C1) 
+/K <<
+/Type /MCR 
+/Pg 83 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+85 0 obj
+<<
+/ActualText (Family: ISO C) 
+/K <<
+/Type /MCR 
+/Pg 83 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+86 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 83 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+87 0 obj
+<<
+/ActualText <feff00530069007a0065003a002000320035002e0035003100320069006e002000d7002000330036002e0031003000320069006e0020007c0020003600340038002000d700200039003100370020006d006d0020007c00200031003800330036002e00380035002000d700200032003500390039002e00330037002000700074> 
+/K <<
+/Type /MCR 
+/Pg 83 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+88 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="C1".) 
+/K <<
+/Type /MCR 
+/Pg 83 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+89 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 83 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+90 0 obj
+<<
+/Contents 276 0 R 
+/CropBox [0 0 1298.2677165354332 1836.8503937007874 ] 
+/Length 1543 
+/MediaBox [0 0 1298.2677165354332 1836.8503937007874 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 11 
+/Type /Page 
+>>
+endobj
+91 0 obj
+<<
+/ActualText (C2) 
+/K <<
+/Type /MCR 
+/Pg 90 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+92 0 obj
+<<
+/ActualText (Family: ISO C) 
+/K <<
+/Type /MCR 
+/Pg 90 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+93 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 90 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+94 0 obj
+<<
+/ActualText <feff00530069007a0065003a002000310038002e0030003300310069006e002000d7002000320035002e0035003100320069006e0020007c0020003400350038002000d700200036003400380020006d006d0020007c00200031003200390038002e003200360038002000d700200031003800330036002e00380035002000700074> 
+/K <<
+/Type /MCR 
+/Pg 90 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+95 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="C2".) 
+/K <<
+/Type /MCR 
+/Pg 90 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+96 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 90 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+97 0 obj
+<<
+/Contents 277 0 R 
+/CropBox [0 0 918.4251968503937 1298.2677165354332 ] 
+/Length 1545 
+/MediaBox [0 0 918.4251968503937 1298.2677165354332 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 12 
+/Type /Page 
+>>
+endobj
+98 0 obj
+<<
+/ActualText (C3) 
+/K <<
+/Type /MCR 
+/Pg 97 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+99 0 obj
+<<
+/ActualText (Family: ISO C) 
+/K <<
+/Type /MCR 
+/Pg 97 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+100 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 97 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+101 0 obj
+<<
+/ActualText <feff00530069007a0065003a002000310032002e0037003500360069006e002000d7002000310038002e0030003300310069006e0020007c0020003300320034002000d700200034003500380020006d006d0020007c0020003900310038002e003400320035002000d700200031003200390038002e003200360038002000700074> 
+/K <<
+/Type /MCR 
+/Pg 97 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+102 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="C3".) 
+/K <<
+/Type /MCR 
+/Pg 97 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+103 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 97 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+104 0 obj
+<<
+/Contents 278 0 R 
+/CropBox [0 0 649.1338582677166 918.4251968503937 ] 
+/Length 1533 
+/MediaBox [0 0 649.1338582677166 918.4251968503937 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 13 
+/Type /Page 
+>>
+endobj
+105 0 obj
+<<
+/ActualText (C4) 
+/K <<
+/Type /MCR 
+/Pg 104 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+106 0 obj
+<<
+/ActualText (Family: ISO C) 
+/K <<
+/Type /MCR 
+/Pg 104 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+107 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 104 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+108 0 obj
+<<
+/ActualText <feff00530069007a0065003a00200039002e0030003100360069006e002000d7002000310032002e0037003500360069006e0020007c0020003200320039002000d700200033003200340020006d006d0020007c0020003600340039002e003100330034002000d70020003900310038002e003400320035002000700074> 
+/K <<
+/Type /MCR 
+/Pg 104 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+109 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="C4".) 
+/K <<
+/Type /MCR 
+/Pg 104 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+110 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 104 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+111 0 obj
+<<
+/Contents 279 0 R 
+/CropBox [0 0 2437.7952755905512 3458.2677165354335 ] 
+/Length 1565 
+/MediaBox [0 0 2437.7952755905512 3458.2677165354335 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 14 
+/Type /Page 
+>>
+endobj
+112 0 obj
+<<
+/ActualText (RA0) 
+/K <<
+/Type /MCR 
+/Pg 111 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+113 0 obj
+<<
+/ActualText (Family: ISO RA) 
+/K <<
+/Type /MCR 
+/Pg 111 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+114 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 111 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+115 0 obj
+<<
+/ActualText <feff00530069007a0065003a002000330033002e0038003500380069006e002000d7002000340038002e0030003300310069006e0020007c0020003800360030002000d7002000310032003200300020006d006d0020007c00200032003400330037002e003700390035002000d700200033003400350038002e003200360038002000700074> 
+/K <<
+/Type /MCR 
+/Pg 111 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+116 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="RA0".) 
+/K <<
+/Type /MCR 
+/Pg 111 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+117 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 111 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+118 0 obj
+<<
+/Contents 280 0 R 
+/CropBox [0 0 1729.1338582677167 2437.7952755905512 ] 
+/Length 1561 
+/MediaBox [0 0 1729.1338582677167 2437.7952755905512 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 15 
+/Type /Page 
+>>
+endobj
+119 0 obj
+<<
+/ActualText (RA1) 
+/K <<
+/Type /MCR 
+/Pg 118 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+120 0 obj
+<<
+/ActualText (Family: ISO RA) 
+/K <<
+/Type /MCR 
+/Pg 118 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+121 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 118 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+122 0 obj
+<<
+/ActualText <feff00530069007a0065003a002000320034002e0030003100360069006e002000d7002000330033002e0038003500380069006e0020007c0020003600310030002000d700200038003600300020006d006d0020007c00200031003700320039002e003100330034002000d700200032003400330037002e003700390035002000700074> 
+/K <<
+/Type /MCR 
+/Pg 118 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+123 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="RA1".) 
+/K <<
+/Type /MCR 
+/Pg 118 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+124 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 118 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+125 0 obj
+<<
+/Contents 281 0 R 
+/CropBox [0 0 1218.8976377952756 1729.1338582677167 ] 
+/Length 1561 
+/MediaBox [0 0 1218.8976377952756 1729.1338582677167 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 16 
+/Type /Page 
+>>
+endobj
+126 0 obj
+<<
+/ActualText (RA2) 
+/K <<
+/Type /MCR 
+/Pg 125 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+127 0 obj
+<<
+/ActualText (Family: ISO RA) 
+/K <<
+/Type /MCR 
+/Pg 125 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+128 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 125 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+129 0 obj
+<<
+/ActualText <feff00530069007a0065003a002000310036002e0039003200390069006e002000d7002000320034002e0030003100360069006e0020007c0020003400330030002000d700200036003100300020006d006d0020007c00200031003200310038002e003800390038002000d700200031003700320039002e003100330034002000700074> 
+/K <<
+/Type /MCR 
+/Pg 125 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+130 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="RA2".) 
+/K <<
+/Type /MCR 
+/Pg 125 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+131 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 125 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+132 0 obj
+<<
+/Contents 282 0 R 
+/CropBox [0 0 864.5669291338584 1218.8976377952756 ] 
+/Length 1557 
+/MediaBox [0 0 864.5669291338584 1218.8976377952756 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 17 
+/Type /Page 
+>>
+endobj
+133 0 obj
+<<
+/ActualText (RA3) 
+/K <<
+/Type /MCR 
+/Pg 132 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+134 0 obj
+<<
+/ActualText (Family: ISO RA) 
+/K <<
+/Type /MCR 
+/Pg 132 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+135 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 132 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+136 0 obj
+<<
+/ActualText <feff00530069007a0065003a002000310032002e0030003000380069006e002000d7002000310036002e0039003200390069006e0020007c0020003300300035002000d700200034003300300020006d006d0020007c0020003800360034002e003500360037002000d700200031003200310038002e003800390038002000700074> 
+/K <<
+/Type /MCR 
+/Pg 132 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+137 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="RA3".) 
+/K <<
+/Type /MCR 
+/Pg 132 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+138 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 132 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+139 0 obj
+<<
+/Contents 283 0 R 
+/CropBox [0 0 2551.181102362205 3628.3464566929138 ] 
+/Length 1576 
+/MediaBox [0 0 2551.181102362205 3628.3464566929138 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 18 
+/Type /Page 
+>>
+endobj
+140 0 obj
+<<
+/ActualText (SRA0) 
+/K <<
+/Type /MCR 
+/Pg 139 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+141 0 obj
+<<
+/ActualText (Family: ISO SRA) 
+/K <<
+/Type /MCR 
+/Pg 139 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+142 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 139 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+143 0 obj
+<<
+/ActualText <feff00530069007a0065003a002000330035002e0034003300330069006e002000d7002000350030002e0033003900340069006e0020007c0020003900300030002000d7002000310032003800300020006d006d0020007c00200032003500350031002e003100380031002000d700200033003600320038002e003300340036002000700074> 
+/K <<
+/Type /MCR 
+/Pg 139 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+144 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="SRA0".) 
+/K <<
+/Type /MCR 
+/Pg 139 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+145 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 139 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+146 0 obj
+<<
+/Contents 284 0 R 
+/CropBox [0 0 1814.1732283464569 2551.181102362205 ] 
+/Length 1572 
+/MediaBox [0 0 1814.1732283464569 2551.181102362205 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 19 
+/Type /Page 
+>>
+endobj
+147 0 obj
+<<
+/ActualText (SRA1) 
+/K <<
+/Type /MCR 
+/Pg 146 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+148 0 obj
+<<
+/ActualText (Family: ISO SRA) 
+/K <<
+/Type /MCR 
+/Pg 146 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+149 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 146 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+150 0 obj
+<<
+/ActualText <feff00530069007a0065003a002000320035002e0031003900370069006e002000d7002000330035002e0034003300330069006e0020007c0020003600340030002000d700200039003000300020006d006d0020007c00200031003800310034002e003100370033002000d700200032003500350031002e003100380031002000700074> 
+/K <<
+/Type /MCR 
+/Pg 146 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+151 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="SRA1".) 
+/K <<
+/Type /MCR 
+/Pg 146 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+152 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 146 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+153 0 obj
+<<
+/Contents 285 0 R 
+/CropBox [0 0 1275.5905511811025 1814.1732283464569 ] 
+/Length 1573 
+/MediaBox [0 0 1275.5905511811025 1814.1732283464569 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 20 
+/Type /Page 
+>>
+endobj
+154 0 obj
+<<
+/ActualText (SRA2) 
+/K <<
+/Type /MCR 
+/Pg 153 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+155 0 obj
+<<
+/ActualText (Family: ISO SRA) 
+/K <<
+/Type /MCR 
+/Pg 153 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+156 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 153 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+157 0 obj
+<<
+/ActualText <feff00530069007a0065003a002000310037002e0037003100370069006e002000d7002000320035002e0031003900370069006e0020007c0020003400350030002000d700200036003400300020006d006d0020007c00200031003200370035002e003500390031002000d700200031003800310034002e003100370033002000700074> 
+/K <<
+/Type /MCR 
+/Pg 153 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+158 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="SRA2".) 
+/K <<
+/Type /MCR 
+/Pg 153 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+159 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 153 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+160 0 obj
+<<
+/Contents 286 0 R 
+/CropBox [0 0 907.0866141732284 1275.5905511811025 ] 
+/Length 1569 
+/MediaBox [0 0 907.0866141732284 1275.5905511811025 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 21 
+/Type /Page 
+>>
+endobj
+161 0 obj
+<<
+/ActualText (SRA3) 
+/K <<
+/Type /MCR 
+/Pg 160 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+162 0 obj
+<<
+/ActualText (Family: ISO SRA) 
+/K <<
+/Type /MCR 
+/Pg 160 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+163 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 160 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+164 0 obj
+<<
+/ActualText <feff00530069007a0065003a002000310032002e0035003900380069006e002000d7002000310037002e0037003100370069006e0020007c0020003300320030002000d700200034003500300020006d006d0020007c0020003900300037002e003000380037002000d700200031003200370035002e003500390031002000700074> 
+/K <<
+/Type /MCR 
+/Pg 160 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+165 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="SRA3".) 
+/K <<
+/Type /MCR 
+/Pg 160 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+166 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 160 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+167 0 obj
+<<
+/Contents 287 0 R 
+/CropBox [0 0 1224 792 ] 
+/Length 1563 
+/MediaBox [0 0 1224 792 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 22 
+/Type /Page 
+>>
+endobj
+168 0 obj
+<<
+/ActualText (tabloid) 
+/K <<
+/Type /MCR 
+/Pg 167 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+169 0 obj
+<<
+/ActualText (Family: North American) 
+/K <<
+/Type /MCR 
+/Pg 167 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+170 0 obj
+<<
+/ActualText (Orientation in sample: landscape) 
+/K <<
+/Type /MCR 
+/Pg 167 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+171 0 obj
+<<
+/ActualText <feff00530069007a0065003a0020003100310069006e002000d70020003100370069006e0020007c0020003200370039002e0034002000d70020003400330031002e00380020006d006d0020007c0020003700390032002000d700200031003200320034002000700074> 
+/K <<
+/Type /MCR 
+/Pg 167 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+172 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="tabloid".) 
+/K <<
+/Type /MCR 
+/Pg 167 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+173 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 167 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+174 0 obj
+<<
+/Contents 288 0 R 
+/CropBox [0 0 1224 792 ] 
+/Length 1555 
+/MediaBox [0 0 1224 792 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 23 
+/Type /Page 
+>>
+endobj
+175 0 obj
+<<
+/ActualText (ledger) 
+/K <<
+/Type /MCR 
+/Pg 174 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+176 0 obj
+<<
+/ActualText (Family: North American) 
+/K <<
+/Type /MCR 
+/Pg 174 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+177 0 obj
+<<
+/ActualText (Orientation in sample: landscape) 
+/K <<
+/Type /MCR 
+/Pg 174 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+178 0 obj
+<<
+/ActualText <feff00530069007a0065003a0020003100310069006e002000d70020003100370069006e0020007c0020003200370039002e0034002000d70020003400330031002e00380020006d006d0020007c0020003700390032002000d700200031003200320034002000700074> 
+/K <<
+/Type /MCR 
+/Pg 174 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+179 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="ledger".) 
+/K <<
+/Type /MCR 
+/Pg 174 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+180 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 174 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+181 0 obj
+<<
+/Contents 289 0 R 
+/CropBox [0 0 1224 792 ] 
+/Length 1507 
+/MediaBox [0 0 1224 792 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 24 
+/Type /Page 
+>>
+endobj
+182 0 obj
+<<
+/ActualText (ansib) 
+/K <<
+/Type /MCR 
+/Pg 181 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+183 0 obj
+<<
+/ActualText (Family: ANSI) 
+/K <<
+/Type /MCR 
+/Pg 181 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+184 0 obj
+<<
+/ActualText (Orientation in sample: landscape) 
+/K <<
+/Type /MCR 
+/Pg 181 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+185 0 obj
+<<
+/ActualText <feff00530069007a0065003a0020003100310069006e002000d70020003100370069006e0020007c0020003200370039002e0034002000d70020003400330031002e00380020006d006d0020007c0020003700390032002000d700200031003200320034002000700074> 
+/K <<
+/Type /MCR 
+/Pg 181 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+186 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="ansib".) 
+/K <<
+/Type /MCR 
+/Pg 181 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+187 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 181 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+188 0 obj
+<<
+/Contents 290 0 R 
+/CropBox [0 0 1584 1224 ] 
+/Length 1515 
+/MediaBox [0 0 1584 1224 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 25 
+/Type /Page 
+>>
+endobj
+189 0 obj
+<<
+/ActualText (ansic) 
+/K <<
+/Type /MCR 
+/Pg 188 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+190 0 obj
+<<
+/ActualText (Family: ANSI) 
+/K <<
+/Type /MCR 
+/Pg 188 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+191 0 obj
+<<
+/ActualText (Orientation in sample: landscape) 
+/K <<
+/Type /MCR 
+/Pg 188 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+192 0 obj
+<<
+/ActualText <feff00530069007a0065003a0020003100370069006e002000d70020003200320069006e0020007c0020003400330031002e0038002000d70020003500350038002e00380020006d006d0020007c00200031003200320034002000d700200031003500380034002000700074> 
+/K <<
+/Type /MCR 
+/Pg 188 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+193 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="ansic".) 
+/K <<
+/Type /MCR 
+/Pg 188 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+194 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 188 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+195 0 obj
+<<
+/Contents 291 0 R 
+/CropBox [0 0 2448 1584 ] 
+/Length 1515 
+/MediaBox [0 0 2448 1584 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 26 
+/Type /Page 
+>>
+endobj
+196 0 obj
+<<
+/ActualText (ansid) 
+/K <<
+/Type /MCR 
+/Pg 195 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+197 0 obj
+<<
+/ActualText (Family: ANSI) 
+/K <<
+/Type /MCR 
+/Pg 195 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+198 0 obj
+<<
+/ActualText (Orientation in sample: landscape) 
+/K <<
+/Type /MCR 
+/Pg 195 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+199 0 obj
+<<
+/ActualText <feff00530069007a0065003a0020003200320069006e002000d70020003300340069006e0020007c0020003500350038002e0038002000d70020003800360033002e00360020006d006d0020007c00200031003500380034002000d700200032003400340038002000700074> 
+/K <<
+/Type /MCR 
+/Pg 195 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+200 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="ansid".) 
+/K <<
+/Type /MCR 
+/Pg 195 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+201 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 195 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+202 0 obj
+<<
+/Contents 292 0 R 
+/CropBox [0 0 3168 2448 ] 
+/Length 1519 
+/MediaBox [0 0 3168 2448 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 27 
+/Type /Page 
+>>
+endobj
+203 0 obj
+<<
+/ActualText (ansie) 
+/K <<
+/Type /MCR 
+/Pg 202 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+204 0 obj
+<<
+/ActualText (Family: ANSI) 
+/K <<
+/Type /MCR 
+/Pg 202 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+205 0 obj
+<<
+/ActualText (Orientation in sample: landscape) 
+/K <<
+/Type /MCR 
+/Pg 202 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+206 0 obj
+<<
+/ActualText <feff00530069007a0065003a0020003300340069006e002000d70020003400340069006e0020007c0020003800360033002e0036002000d700200031003100310037002e00360020006d006d0020007c00200032003400340038002000d700200033003100360038002000700074> 
+/K <<
+/Type /MCR 
+/Pg 202 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+207 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="ansie".) 
+/K <<
+/Type /MCR 
+/Pg 202 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+208 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 202 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+209 0 obj
+<<
+/Contents 293 0 R 
+/CropBox [0 0 648 864 ] 
+/Length 1495 
+/MediaBox [0 0 648 864 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 28 
+/Type /Page 
+>>
+endobj
+210 0 obj
+<<
+/ActualText (archa) 
+/K <<
+/Type /MCR 
+/Pg 209 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+211 0 obj
+<<
+/ActualText (Family: ARCH) 
+/K <<
+/Type /MCR 
+/Pg 209 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+212 0 obj
+<<
+/ActualText (Orientation in sample: portrait) 
+/K <<
+/Type /MCR 
+/Pg 209 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+213 0 obj
+<<
+/ActualText <feff00530069007a0065003a002000390069006e002000d70020003100320069006e0020007c0020003200320038002e0036002000d70020003300300034002e00380020006d006d0020007c0020003600340038002000d70020003800360034002000700074> 
+/K <<
+/Type /MCR 
+/Pg 209 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+214 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="archa".) 
+/K <<
+/Type /MCR 
+/Pg 209 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+215 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 209 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+216 0 obj
+<<
+/Contents 294 0 R 
+/CropBox [0 0 1296 864 ] 
+/Length 1507 
+/MediaBox [0 0 1296 864 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 29 
+/Type /Page 
+>>
+endobj
+217 0 obj
+<<
+/ActualText (archb) 
+/K <<
+/Type /MCR 
+/Pg 216 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+218 0 obj
+<<
+/ActualText (Family: ARCH) 
+/K <<
+/Type /MCR 
+/Pg 216 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+219 0 obj
+<<
+/ActualText (Orientation in sample: landscape) 
+/K <<
+/Type /MCR 
+/Pg 216 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+220 0 obj
+<<
+/ActualText <feff00530069007a0065003a0020003100320069006e002000d70020003100380069006e0020007c0020003300300034002e0038002000d70020003400350037002e00320020006d006d0020007c0020003800360034002000d700200031003200390036002000700074> 
+/K <<
+/Type /MCR 
+/Pg 216 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+221 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="archb".) 
+/K <<
+/Type /MCR 
+/Pg 216 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+222 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 216 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+223 0 obj
+<<
+/Contents 295 0 R 
+/CropBox [0 0 1728 1296 ] 
+/Length 1515 
+/MediaBox [0 0 1728 1296 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 30 
+/Type /Page 
+>>
+endobj
+224 0 obj
+<<
+/ActualText (archc) 
+/K <<
+/Type /MCR 
+/Pg 223 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+225 0 obj
+<<
+/ActualText (Family: ARCH) 
+/K <<
+/Type /MCR 
+/Pg 223 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+226 0 obj
+<<
+/ActualText (Orientation in sample: landscape) 
+/K <<
+/Type /MCR 
+/Pg 223 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+227 0 obj
+<<
+/ActualText <feff00530069007a0065003a0020003100380069006e002000d70020003200340069006e0020007c0020003400350037002e0032002000d70020003600300039002e00360020006d006d0020007c00200031003200390036002000d700200031003700320038002000700074> 
+/K <<
+/Type /MCR 
+/Pg 223 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+228 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="archc".) 
+/K <<
+/Type /MCR 
+/Pg 223 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+229 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 223 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+230 0 obj
+<<
+/Contents 296 0 R 
+/CropBox [0 0 2592 1728 ] 
+/Length 1515 
+/MediaBox [0 0 2592 1728 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 31 
+/Type /Page 
+>>
+endobj
+231 0 obj
+<<
+/ActualText (archd) 
+/K <<
+/Type /MCR 
+/Pg 230 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+232 0 obj
+<<
+/ActualText (Family: ARCH) 
+/K <<
+/Type /MCR 
+/Pg 230 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+233 0 obj
+<<
+/ActualText (Orientation in sample: landscape) 
+/K <<
+/Type /MCR 
+/Pg 230 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+234 0 obj
+<<
+/ActualText <feff00530069007a0065003a0020003200340069006e002000d70020003300360069006e0020007c0020003600300039002e0036002000d70020003900310034002e00340020006d006d0020007c00200031003700320038002000d700200032003500390032002000700074> 
+/K <<
+/Type /MCR 
+/Pg 230 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+235 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="archd".) 
+/K <<
+/Type /MCR 
+/Pg 230 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+236 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 230 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+237 0 obj
+<<
+/Contents 297 0 R 
+/CropBox [0 0 3456 2592 ] 
+/Length 1519 
+/MediaBox [0 0 3456 2592 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 32 
+/Type /Page 
+>>
+endobj
+238 0 obj
+<<
+/ActualText (arche) 
+/K <<
+/Type /MCR 
+/Pg 237 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+239 0 obj
+<<
+/ActualText (Family: ARCH) 
+/K <<
+/Type /MCR 
+/Pg 237 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+240 0 obj
+<<
+/ActualText (Orientation in sample: landscape) 
+/K <<
+/Type /MCR 
+/Pg 237 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+241 0 obj
+<<
+/ActualText <feff00530069007a0065003a0020003300360069006e002000d70020003400380069006e0020007c0020003900310034002e0034002000d700200031003200310039002e00320020006d006d0020007c00200032003500390032002000d700200033003400350036002000700074> 
+/K <<
+/Type /MCR 
+/Pg 237 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+242 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="arche".) 
+/K <<
+/Type /MCR 
+/Pg 237 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+243 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 237 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+244 0 obj
+<<
+/Contents 298 0 R 
+/CropBox [0 0 3024 2160 ] 
+/Length 1519 
+/MediaBox [0 0 3024 2160 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 33 
+/Type /Page 
+>>
+endobj
+245 0 obj
+<<
+/ActualText (arche1) 
+/K <<
+/Type /MCR 
+/Pg 244 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+246 0 obj
+<<
+/ActualText (Family: ARCH) 
+/K <<
+/Type /MCR 
+/Pg 244 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+247 0 obj
+<<
+/ActualText (Orientation in sample: landscape) 
+/K <<
+/Type /MCR 
+/Pg 244 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+248 0 obj
+<<
+/ActualText <feff00530069007a0065003a0020003300300069006e002000d70020003400320069006e0020007c0020003700360032002000d700200031003000360036002e00380020006d006d0020007c00200032003100360030002000d700200033003000320034002000700074> 
+/K <<
+/Type /MCR 
+/Pg 244 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+249 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="arche1".) 
+/K <<
+/Type /MCR 
+/Pg 244 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+250 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 244 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+251 0 obj
+<<
+/Contents 299 0 R 
+/CropBox [0 0 2736 1872 ] 
+/Length 1523 
+/MediaBox [0 0 2736 1872 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 34 
+/Type /Page 
+>>
+endobj
+252 0 obj
+<<
+/ActualText (arche2) 
+/K <<
+/Type /MCR 
+/Pg 251 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+253 0 obj
+<<
+/ActualText (Family: ARCH) 
+/K <<
+/Type /MCR 
+/Pg 251 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+254 0 obj
+<<
+/ActualText (Orientation in sample: landscape) 
+/K <<
+/Type /MCR 
+/Pg 251 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+255 0 obj
+<<
+/ActualText <feff00530069007a0065003a0020003200360069006e002000d70020003300380069006e0020007c0020003600360030002e0034002000d70020003900360035002e00320020006d006d0020007c00200031003800370032002000d700200032003700330036002000700074> 
+/K <<
+/Type /MCR 
+/Pg 251 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+256 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="arche2".) 
+/K <<
+/Type /MCR 
+/Pg 251 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+257 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 251 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+258 0 obj
+<<
+/Contents 300 0 R 
+/CropBox [0 0 2808 1944 ] 
+/Length 1523 
+/MediaBox [0 0 2808 1944 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 35 
+/Type /Page 
+>>
+endobj
+259 0 obj
+<<
+/ActualText (arche3) 
+/K <<
+/Type /MCR 
+/Pg 258 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+260 0 obj
+<<
+/ActualText (Family: ARCH) 
+/K <<
+/Type /MCR 
+/Pg 258 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+261 0 obj
+<<
+/ActualText (Orientation in sample: landscape) 
+/K <<
+/Type /MCR 
+/Pg 258 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+262 0 obj
+<<
+/ActualText <feff00530069007a0065003a0020003200370069006e002000d70020003300390069006e0020007c0020003600380035002e0038002000d70020003900390030002e00360020006d006d0020007c00200031003900340034002000d700200032003800300038002000700074> 
+/K <<
+/Type /MCR 
+/Pg 258 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+263 0 obj
+<<
+/ActualText (Built-in style lookup is case-insensitive; this page uses style="arche3".) 
+/K <<
+/Type /MCR 
+/Pg 258 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+264 0 obj
+<<
+/ActualText <feff00430061006c006900620072006100740069006f006e0020007300710075006100720065003a002000310069006e002000d7002000310069006e> 
+/K <<
+/Type /MCR 
+/Pg 258 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+265 0 obj
+<<
+/Length 1549 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 3317.4533 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<00010002> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b0008000c> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e00070008001500150016001700170004000f0008001800080019001a0016001b001700170004000f0008001c0008001b0019001700080018000800170017001b001d0008000300030008001c0008001e0015001b00150016001d0015001f00080018000800150015001f002000160015001d0019000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0021002200040005001000230004000f00080012001000060005000e00080005001100110024002200130008000400120008002500020012000e00230004000f0012000e000f00120004001000040026000e0027000800100028000400120008001300020029000e000800220012000e001200080012001000060005000e002a002b000c0020002b0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 3182.3937 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 3182.3937 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 3171.0036 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002c000200050004002d000d0002001000040011000f00080012002e00220002000d000e0007000800170004000f00080018000800170004000f> Tj
+EMC
+ET
+endstream
+endobj
+266 0 obj
+<<
+/Length 1539 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 2330.9966 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<00010003> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b0008000c> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e00070008001e001500160015001b001a0004000f000800180008001500150016001700170004000f0008001c0008002f001d0019000800180008001b001900170008000300030008001c00080017001a001b00150016001f001b000800180008001e0015001b00150016001d0015001f000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0021002200040005001000230004000f00080012001000060005000e00080005001100110024002200130008000400120008002500020012000e00230004000f0012000e000f00120004001000040026000e0027000800100028000400120008001300020029000e000800220012000e001200080012001000060005000e002a002b000c0017002b0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 2195.937 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 2195.937 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 2184.5469 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002c000200050004002d000d0002001000040011000f00080012002e00220002000d000e0007000800170004000f00080018000800170004000f> Tj
+EMC
+ET
+endstream
+endobj
+267 0 obj
+<<
+/Length 1545 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 1630.8391 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<00010004> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b0008000c> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e000700080017001a0016002f0015002f0004000f000800180008001e001500160015001b001a0004000f0008001c00080019001e0020000800180008002f001d00190008000300030008001c000800170017001d00200016002f002f00170008001800080017001a001b00150016001f001b000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0021002200040005001000230004000f00080012001000060005000e00080005001100110024002200130008000400120008002500020012000e00230004000f0012000e000f00120004001000040026000e0027000800100028000400120008001300020029000e000800220012000e001200080012001000060005000e002a002b000c001e002b0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 1495.7795 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 1495.7795 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 1484.3894 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002c000200050004002d000d0002001000040011000f00080012002e00220002000d000e0007000800170004000f00080018000800170004000f> Tj
+EMC
+ET
+endstream
+endobj
+268 0 obj
+<<
+/Length 1539 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 1137.6108 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<00010005> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b0008000c> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e00070008001700170016001a001d00150004000f0008001800080017001a0016002f0015002f0004000f0008001c0008001e001d001f0008001800080019001e00200008000300030008001c0008001b001900170016001b001d00080018000800170017001d00200016002f002f0017000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0021002200040005001000230004000f00080012001000060005000e00080005001100110024002200130008000400120008002500020012000e00230004000f0012000e000f00120004001000040026000e0027000800100028000400120008001300020029000e000800220012000e001200080012001000060005000e002a002b000c0015002b0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 1002.5512 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 1002.5512 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 991.161 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002c000200050004002d000d0002001000040011000f00080012002e00220002000d000e0007000800170004000f00080018000800170004000f> Tj
+EMC
+ET
+endstream
+endobj
+269 0 obj
+<<
+/Length 1551 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 3955.2485 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<00060002> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b00080021> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e000700080015001d00160015001f0004000f000800180008002f002f0016001a001a001d0004000f0008001c0008001700200020002000080018000800170019001700190008000300030008001c0008001e001b001500190016001a0019001a000800180008001900200020001b00160017001b001d000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0021002200040005001000230004000f00080012001000060005000e00080005001100110024002200130008000400120008002500020012000e00230004000f0012000e000f00120004001000040026000e0027000800100028000400120008001300020029000e000800220012000e001200080012001000060005000e002a002b00210020002b0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 3820.189 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 3820.189 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 3808.7988 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002c000200050004002d000d0002001000040011000f00080012002e00220002000d000e0007000800170004000f00080018000800170004000f> Tj
+EMC
+ET
+endstream
+endobj
+270 0 obj
+<<
+/Length 1549 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 2781.7052 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<00060003> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b00080021> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e00070008001e001f0016001b0015002f0004000f0008001800080015001d00160015001f0004000f0008001c0008001f0020001f00080018000800170020002000200008000300030008001c0008001e00200020001900160020001d0019000800180008001e001b001500190016001a0019001a000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0021002200040005001000230004000f00080012001000060005000e00080005001100110024002200130008000400120008002500020012000e00230004000f0012000e000f00120004001000040026000e0027000800100028000400120008001300020029000e000800220012000e001200080012001000060005000e002a002b00210017002b0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 2646.6457 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 2646.6457 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 2635.2555 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002c000200050004002d000d0002001000040011000f00080012002e00220002000d000e0007000800170004000f00080018000800170004000f> Tj
+EMC
+ET
+endstream
+endobj
+271 0 obj
+<<
+/Length 1549 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 1951.1541 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<00060004> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b00080021> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e000700080017001d0016001a001b002f0004000f000800180008001e001f0016001b0015002f0004000f0008001c0008002f00200020000800180008001f0020001f0008000300030008001c0008001700190017001f00160015001e0015000800180008001e00200020001900160020001d0019000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0021002200040005001000230004000f00080012001000060005000e00080005001100110024002200130008000400120008002500020012000e00230004000f0012000e000f00120004001000040026000e0027000800100028000400120008001300020029000e000800220012000e001200080012001000060005000e002a002b0021001e002b0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 1816.0945 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 1816.0945 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 1804.7044 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002c000200050004002d000d0002001000040011000f00080012002e00220002000d000e0007000800170004000f00080018000800170004000f> Tj
+EMC
+ET
+endstream
+endobj
+272 0 obj
+<<
+/Length 1545 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 1364.3824 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<00060005> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b00080021> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e00070008001700150016001b001d001b0004000f0008001800080017001d0016001a001b002f0004000f0008001c00080015002f0015000800180008002f002000200008000300030008001c000800170020002000200016001a0015000800180008001700190017001f00160015001e0015000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0021002200040005001000230004000f00080012001000060005000e00080005001100110024002200130008000400120008002500020012000e00230004000f0012000e000f00120004001000040026000e0027000800100028000400120008001300020029000e000800220012000e001200080012001000060005000e002a002b00210015002b0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 1229.3228 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 1229.3228 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 1217.9327 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002c000200050004002d000d0002001000040011000f00080012002e00220002000d000e0007000800170004000f00080018000800170004000f> Tj
+EMC
+ET
+endstream
+endobj
+273 0 obj
+<<
+/Length 1533 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 947.6895 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<00060007> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b00080021> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e00070008001d0016001b001900150004000f000800180008001700150016001b001d001b0004000f0008001c0008001e002f00200008001800080015002f00150008000300030008001c0008001f0020001b0016001a001a001700080018000800170020002000200016001a0015000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0021002200040005001000230004000f00080012001000060005000e00080005001100110024002200130008000400120008002500020012000e00230004000f0012000e000f00120004001000040026000e0027000800100028000400120008001300020029000e000800220012000e001200080012001000060005000e002a002b00210019002b0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 812.6299 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 812.6299 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 801.2398 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002c000200050004002d000d0002001000040011000f00080012002e00220002000d000e0007000800170004000f00080018000800170004000f> Tj
+EMC
+ET
+endstream
+endobj
+274 0 obj
+<<
+/Length 1548 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 3623.595 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<00080002> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b0008002c> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e000700080015001a001600170020001e0004000f000800180008002f001700160020001a00150004000f0008001c0008001d0017001f0008001800080017001e001d001f0008000300030008001c0008001e002f001d001d00160015001f0008001800080015001a001f001a0016002f0015002f000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0021002200040005001000230004000f00080012001000060005000e00080005001100110024002200130008000400120008002500020012000e00230004000f0012000e000f00120004001000040026000e0027000800100028000400120008001300020029000e000800220012000e001200080012001000060005000e002a002b002c0020002b0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 3488.5354 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 3488.5354 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 3477.1453 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002c000200050004002d000d0002001000040011000f00080012002e00220002000d000e0007000800170004000f00080018000800170004000f> Tj
+EMC
+ET
+endstream
+endobj
+275 0 obj
+<<
+/Length 1541 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 2546.4296 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<00080003> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b0008002c> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e00070008001e002f0016002f0017001e0004000f0008001800080015001a001600170020001e0004000f0008001c0008001a0019001b000800180008001d0017001f0008000300030008001c00080017001b0015001a0016001b002f000800180008001e002f001d001d00160015001f000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0021002200040005001000230004000f00080012001000060005000e00080005001100110024002200130008000400120008002500020012000e00230004000f0012000e000f00120004001000040026000e0027000800100028000400120008001300020029000e000800220012000e001200080012001000060005000e002a002b002c0017002b0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 2411.3701 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 2411.3701 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 2399.9799 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002c000200050004002d000d0002001000040011000f00080012002e00220002000d000e0007000800170004000f00080018000800170004000f> Tj
+EMC
+ET
+endstream
+endobj
+276 0 obj
+<<
+/Length 1543 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 1783.91 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<00080004> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b0008002c> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e000700080017001b00160020001500170004000f000800180008001e002f0016002f0017001e0004000f0008001c00080019002f001b000800180008001a0019001b0008000300030008001c00080017001e001d001b0016001e001a001b0008001800080017001b0015001a0016001b002f000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0021002200040005001000230004000f00080012001000060005000e00080005001100110024002200130008000400120008002500020012000e00230004000f0012000e000f00120004001000040026000e0027000800100028000400120008001300020029000e000800220012000e001200080012001000060005000e002a002b002c001e002b0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 1648.8504 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 1648.8504 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 1637.4603 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002c000200050004002d000d0002001000040011000f00080012002e00220002000d000e0007000800170004000f00080018000800170004000f> Tj
+EMC
+ET
+endstream
+endobj
+277 0 obj
+<<
+/Length 1545 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 1245.3273 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<00080005> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b0008002c> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e000700080017001e0016001f002f001a0004000f0008001800080017001b00160020001500170004000f0008001c00080015001e00190008001800080019002f001b0008000300030008001c0008001d0017001b00160019001e002f0008001800080017001e001d001b0016001e001a001b000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0021002200040005001000230004000f00080012001000060005000e00080005001100110024002200130008000400120008002500020012000e00230004000f0012000e000f00120004001000040026000e0027000800100028000400120008001300020029000e000800220012000e001200080012001000060005000e002a002b002c0015002b0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 1110.2677 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 1110.2677 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 1098.8776 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002c000200050004002d000d0002001000040011000f00080012002e00220002000d000e0007000800170004000f00080018000800170004000f> Tj
+EMC
+ET
+endstream
+endobj
+278 0 obj
+<<
+/Length 1533 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 865.4848 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<00080007> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b0008002c> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e00070008001d001600200017001a0004000f0008001800080017001e0016001f002f001a0004000f0008001c0008001e001e001d0008001800080015001e00190008000300030008001c0008001a0019001d0016001700150019000800180008001d0017001b00160019001e002f000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0021002200040005001000230004000f00080012001000060005000e00080005001100110024002200130008000400120008002500020012000e00230004000f0012000e000f00120004001000040026000e0027000800100028000400120008001300020029000e000800220012000e001200080012001000060005000e002a002b002c0019002b0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 730.4252 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 730.4252 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 719.0351 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002c000200050004002d000d0002001000040011000f00080012002e00220002000d000e0007000800170004000f00080018000800170004000f> Tj
+EMC
+ET
+endstream
+endobj
+279 0 obj
+<<
+/Length 1565 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 3405.3273 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<000900010002> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b00080030000c> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e00070008001500150016001b002f001b0004000f0008001800080019001b00160020001500170004000f0008001c0008001b001a00200008001800080017001e001e00200008000300030008001c0008001e00190015001f0016001f001d002f00080018000800150019002f001b0016001e001a001b000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0021002200040005001000230004000f00080012001000060005000e00080005001100110024002200130008000400120008002500020012000e00230004000f0012000e000f00120004001000040026000e0027000800100028000400120008001300020029000e000800220012000e001200080012001000060005000e002a002b0030000c0020002b0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 3270.2677 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 3270.2677 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 3258.8776 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002c000200050004002d000d0002001000040011000f00080012002e00220002000d000e0007000800170004000f00080018000800170004000f> Tj
+EMC
+ET
+endstream
+endobj
+280 0 obj
+<<
+/Length 1561 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 2384.8548 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<000900010003> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b00080030000c> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e00070008001e0019001600200017001a0004000f000800180008001500150016001b002f001b0004000f0008001c0008001a00170020000800180008001b001a00200008000300030008001c00080017001f001e001d0016001700150019000800180008001e00190015001f0016001f001d002f000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0021002200040005001000230004000f00080012001000060005000e00080005001100110024002200130008000400120008002500020012000e00230004000f0012000e000f00120004001000040026000e0027000800100028000400120008001300020029000e000800220012000e001200080012001000060005000e002a002b0030000c0017002b0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 2249.7953 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 2249.7953 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 2238.4051 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002c000200050004002d000d0002001000040011000f00080012002e00220002000d000e0007000800170004000f00080018000800170004000f> Tj
+EMC
+ET
+endstream
+endobj
+281 0 obj
+<<
+/Length 1561 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 1676.1934 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<000900010004> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b00080030000c> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e000700080017001a0016001d001e001d0004000f000800180008001e0019001600200017001a0004000f0008001c0008001900150020000800180008001a001700200008000300030008001c00080017001e0017001b0016001b001d001b0008001800080017001f001e001d0016001700150019000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0021002200040005001000230004000f00080012001000060005000e00080005001100110024002200130008000400120008002500020012000e00230004000f0012000e000f00120004001000040026000e0027000800100028000400120008001300020029000e000800220012000e001200080012001000060005000e002a002b0030000c001e002b0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 1541.1339 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 1541.1339 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 1529.7437 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002c000200050004002d000d0002001000040011000f00080012002e00220002000d000e0007000800170004000f00080018000800170004000f> Tj
+EMC
+ET
+endstream
+endobj
+282 0 obj
+<<
+/Length 1557 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 1165.9572 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<000900010005> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b00080030000c> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e000700080017001e001600200020001b0004000f0008001800080017001a0016001d001e001d0004000f0008001c000800150020002f0008001800080019001500200008000300030008001c0008001b001a00190016002f001a001f0008001800080017001e0017001b0016001b001d001b000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0021002200040005001000230004000f00080012001000060005000e00080005001100110024002200130008000400120008002500020012000e00230004000f0012000e000f00120004001000040026000e0027000800100028000400120008001300020029000e000800220012000e001200080012001000060005000e002a002b0030000c0015002b0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 1030.8976 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 1030.8976 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 1019.5075 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002c000200050004002d000d0002001000040011000f00080012002e00220002000d000e0007000800170004000f00080018000800170004000f> Tj
+EMC
+ET
+endstream
+endobj
+283 0 obj
+<<
+/Length 1576 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 3575.406 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<000a000900010002> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b0008000a0030000c> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e000700080015002f00160019001500150004000f000800180008002f002000160015001d00190004000f0008001c0008001d002000200008001800080017001e001b00200008000300030008001c0008001e002f002f001700160017001b00170008001800080015001a001e001b001600150019001a000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0021002200040005001000230004000f00080012001000060005000e00080005001100110024002200130008000400120008002500020012000e00230004000f0012000e000f00120004001000040026000e0027000800100028000400120008001300020029000e000800220012000e001200080012001000060005000e002a002b000a0030000c0020002b0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 3440.3465 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 3440.3465 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 3428.9563 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002c000200050004002d000d0002001000040011000f00080012002e00220002000d000e0007000800170004000f00080018000800170004000f> Tj
+EMC
+ET
+endstream
+endobj
+284 0 obj
+<<
+/Length 1572 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 2498.2407 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<000a000900010003> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b0008000a0030000c> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e00070008001e002f00160017001d001f0004000f0008001800080015002f00160019001500150004000f0008001c0008001a00190020000800180008001d002000200008000300030008001c00080017001b0017001900160017001f0015000800180008001e002f002f001700160017001b0017000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0021002200040005001000230004000f00080012001000060005000e00080005001100110024002200130008000400120008002500020012000e00230004000f0012000e000f00120004001000040026000e0027000800100028000400120008001300020029000e000800220012000e001200080012001000060005000e002a002b000a0030000c0017002b0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 2363.1811 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 2363.1811 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 2351.791 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002c000200050004002d000d0002001000040011000f00080012002e00220002000d000e0007000800170004000f00080018000800170004000f> Tj
+EMC
+ET
+endstream
+endobj
+285 0 obj
+<<
+/Length 1573 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 1761.2328 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<000a000900010004> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b0008000a0030000c> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e000700080017001f0016001f0017001f0004000f000800180008001e002f00160017001d001f0004000f0008001c00080019002f0020000800180008001a001900200008000300030008001c00080017001e001f002f0016002f001d00170008001800080017001b0017001900160017001f0015000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0021002200040005001000230004000f00080012001000060005000e00080005001100110024002200130008000400120008002500020012000e00230004000f0012000e000f00120004001000040026000e0027000800100028000400120008001300020029000e000800220012000e001200080012001000060005000e002a002b000a0030000c001e002b0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 1626.1732 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 1626.1732 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 1614.7831 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002c000200050004002d000d0002001000040011000f00080012002e00220002000d000e0007000800170004000f00080018000800170004000f> Tj
+EMC
+ET
+endstream
+endobj
+286 0 obj
+<<
+/Length 1569 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 1222.6501 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<000a000900010005> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b0008000a0030000c> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e000700080017001e0016002f001d001b0004000f0008001800080017001f0016001f0017001f0004000f0008001c00080015001e00200008001800080019002f00200008000300030008001c0008001d0020001f00160020001b001f0008001800080017001e001f002f0016002f001d0017000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0021002200040005001000230004000f00080012001000060005000e00080005001100110024002200130008000400120008002500020012000e00230004000f0012000e000f00120004001000040026000e0027000800100028000400120008001300020029000e000800220012000e001200080012001000060005000e002a002b000a0030000c0015002b0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 1087.5906 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 1087.5906 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 1076.2004 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002c000200050004002d000d0002001000040011000f00080012002e00220002000d000e0007000800170004000f00080018000800170004000f> Tj
+EMC
+ET
+endstream
+endobj
+287 0 obj
+<<
+/Length 1563 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 739.0596 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<000b000c000d000e000f00100011> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<0001000200030004000500060007000800310011000d001000280008000c0003000e000d000400250002000f> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800050002000f00320012002500020013000e> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e00070008001700170004000f0008001800080017001f0004000f0008001c0008001e001f001d001600190008001800080019001500170016001b0008000300030008001c0008001f001d001e0008001800080017001e001e0019000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0021002200040005001000230004000f00080012001000060005000e00080005001100110024002200130008000400120008002500020012000e00230004000f0012000e000f00120004001000040026000e0027000800100028000400120008001300020029000e000800220012000e001200080012001000060005000e002a002b00100002002d0005001100040032002b0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 604 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 604 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 592.6099 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002c000200050004002d000d0002001000040011000f00080012002e00220002000d000e0007000800170004000f00080018000800170004000f> Tj
+EMC
+ET
+endstream
+endobj
+288 0 obj
+<<
+/Length 1555 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 739.0596 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<000e00120011001300120014> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<0001000200030004000500060007000800310011000d001000280008000c0003000e000d000400250002000f> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800050002000f00320012002500020013000e> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e00070008001700170004000f0008001800080017001f0004000f0008001c0008001e001f001d001600190008001800080019001500170016001b0008000300030008001c0008001f001d001e0008001800080017001e001e0019000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0021002200040005001000230004000f00080012001000060005000e00080005001100110024002200130008000400120008002500020012000e00230004000f0012000e000f00120004001000040026000e0027000800100028000400120008001300020029000e000800220012000e001200080012001000060005000e002a002b0005000e00320029000e000d002b0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 604 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 604 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 592.6099 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002c000200050004002d000d0002001000040011000f00080012002e00220002000d000e0007000800170004000f00080018000800170004000f> Tj
+EMC
+ET
+endstream
+endobj
+289 0 obj
+<<
+/Length 1507 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 739.0596 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<000c001500160010000d> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<00010002000300040005000600070008000c0031000a0009> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800050002000f00320012002500020013000e> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e00070008001700170004000f0008001800080017001f0004000f0008001c0008001e001f001d001600190008001800080019001500170016001b0008000300030008001c0008001f001d001e0008001800080017001e001e0019000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0021002200040005001000230004000f00080012001000060005000e00080005001100110024002200130008000400120008002500020012000e00230004000f0012000e000f00120004001000040026000e0027000800100028000400120008001300020029000e000800220012000e001200080012001000060005000e002a002b0002000f00120004002d002b0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 604 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 604 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 592.6099 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002c000200050004002d000d0002001000040011000f00080012002e00220002000d000e0007000800170004000f00080018000800170004000f> Tj
+EMC
+ET
+endstream
+endobj
+290 0 obj
+<<
+/Length 1515 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 1171.0596 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<000c0015001600100017> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<00010002000300040005000600070008000c0031000a0009> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800050002000f00320012002500020013000e> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e000700080017001f0004000f000800180008001e001e0004000f0008001c00080019001500170016001b000800180008002f002f001b0016001b0008000300030008001c00080017001e001e00190008001800080017002f001b0019000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0021002200040005001000230004000f00080012001000060005000e00080005001100110024002200130008000400120008002500020012000e00230004000f0012000e000f00120004001000040026000e0027000800100028000400120008001300020029000e000800220012000e001200080012001000060005000e002a002b0002000f001200040025002b0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 1036 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 1036 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 1024.6099 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002c000200050004002d000d0002001000040011000f00080012002e00220002000d000e0007000800170004000f00080018000800170004000f> Tj
+EMC
+ET
+endstream
+endobj
+291 0 obj
+<<
+/Length 1515 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 1531.0596 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<000c0015001600100011> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<00010002000300040005000600070008000c0031000a0009> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800050002000f00320012002500020013000e> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e00070008001e001e0004000f000800180008001500190004000f0008001c0008002f002f001b0016001b000800180008001b001a00150016001a0008000300030008001c00080017002f001b0019000800180008001e00190019001b000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0021002200040005001000230004000f00080012001000060005000e00080005001100110024002200130008000400120008002500020012000e00230004000f0012000e000f00120004001000040026000e0027000800100028000400120008001300020029000e000800220012000e001200080012001000060005000e002a002b0002000f001200040032002b0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 1396 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 1396 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 1384.6099 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002c000200050004002d000d0002001000040011000f00080012002e00220002000d000e0007000800170004000f00080018000800170004000f> Tj
+EMC
+ET
+endstream
+endobj
+292 0 obj
+<<
+/Length 1519 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 2395.0596 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<000c0015001600100012> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<00010002000300040005000600070008000c0031000a0009> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800050002000f00320012002500020013000e> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e00070008001500190004000f000800180008001900190004000f0008001c0008001b001a00150016001a000800180008001700170017001f0016001a0008000300030008001c0008001e00190019001b00080018000800150017001a001b000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0021002200040005001000230004000f00080012001000060005000e00080005001100110024002200130008000400120008002500020012000e00230004000f0012000e000f00120004001000040026000e0027000800100028000400120008001300020029000e000800220012000e001200080012001000060005000e002a002b0002000f00120004000e002b0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 2260 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 2260 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 2248.6099 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002c000200050004002d000d0002001000040011000f00080012002e00220002000d000e0007000800170004000f00080018000800170004000f> Tj
+EMC
+ET
+endstream
+endobj
+293 0 obj
+<<
+/Length 1495 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 811.0596 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<000c001400170018000c> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<00010002000300040005000600070008000c0030002c0033> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800130011000d0010000d000200040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e00070008001d0004000f0008001800080017001e0004000f0008001c0008001e001e001b0016001a0008001800080015002000190016001b0008000300030008001c0008001a0019001b000800180008001b001a0019000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0021002200040005001000230004000f00080012001000060005000e00080005001100110024002200130008000400120008002500020012000e00230004000f0012000e000f00120004001000040026000e0027000800100028000400120008001300020029000e000800220012000e001200080012001000060005000e002a002b0002000d002500280002002b0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 676 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 676 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 664.6099 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002c000200050004002d000d0002001000040011000f00080012002e00220002000d000e0007000800170004000f00080018000800170004000f> Tj
+EMC
+ET
+endstream
+endobj
+294 0 obj
+<<
+/Length 1507 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 811.0596 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<000c001400170018000d> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<00010002000300040005000600070008000c0030002c0033> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800050002000f00320012002500020013000e> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e000700080017001e0004000f0008001800080017001b0004000f0008001c00080015002000190016001b0008001800080019002f001f0016001e0008000300030008001c0008001b001a00190008001800080017001e001d001a000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0021002200040005001000230004000f00080012001000060005000e00080005001100110024002200130008000400120008002500020012000e00230004000f0012000e000f00120004001000040026000e0027000800100028000400120008001300020029000e000800220012000e001200080012001000060005000e002a002b0002000d00250028002d002b0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 676 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 676 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 664.6099 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002c000200050004002d000d0002001000040011000f00080012002e00220002000d000e0007000800170004000f00080018000800170004000f> Tj
+EMC
+ET
+endstream
+endobj
+295 0 obj
+<<
+/Length 1515 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 1243.0596 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<000c0014001700180017> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<00010002000300040005000600070008000c0030002c0033> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800050002000f00320012002500020013000e> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e000700080017001b0004000f000800180008001e00190004000f0008001c00080019002f001f0016001e000800180008001a0020001d0016001a0008000300030008001c00080017001e001d001a0008001800080017001f001e001b000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0021002200040005001000230004000f00080012001000060005000e00080005001100110024002200130008000400120008002500020012000e00230004000f0012000e000f00120004001000040026000e0027000800100028000400120008001300020029000e000800220012000e001200080012001000060005000e002a002b0002000d002500280025002b0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 1108 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 1108 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 1096.6099 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002c000200050004002d000d0002001000040011000f00080012002e00220002000d000e0007000800170004000f00080018000800170004000f> Tj
+EMC
+ET
+endstream
+endobj
+296 0 obj
+<<
+/Length 1515 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 1675.0596 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<000c0014001700180011> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<00010002000300040005000600070008000c0030002c0033> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800050002000f00320012002500020013000e> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e00070008001e00190004000f0008001800080015001a0004000f0008001c0008001a0020001d0016001a000800180008001d00170019001600190008000300030008001c00080017001f001e001b000800180008001e002f001d001e000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0021002200040005001000230004000f00080012001000060005000e00080005001100110024002200130008000400120008002500020012000e00230004000f0012000e000f00120004001000040026000e0027000800100028000400120008001300020029000e000800220012000e001200080012001000060005000e002a002b0002000d002500280032002b0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 1540 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 1540 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 1528.6099 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002c000200050004002d000d0002001000040011000f00080012002e00220002000d000e0007000800170004000f00080018000800170004000f> Tj
+EMC
+ET
+endstream
+endobj
+297 0 obj
+<<
+/Length 1519 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 2539.0596 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<000c0014001700180012> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<00010002000300040005000600070008000c0030002c0033> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800050002000f00320012002500020013000e> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e000700080015001a0004000f0008001800080019001b0004000f0008001c0008001d00170019001600190008001800080017001e0017001d0016001e0008000300030008001c0008001e002f001d001e00080018000800150019002f001a000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0021002200040005001000230004000f00080012001000060005000e00080005001100110024002200130008000400120008002500020012000e00230004000f0012000e000f00120004001000040026000e0027000800100028000400120008001300020029000e000800220012000e001200080012001000060005000e002a002b0002000d00250028000e002b0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 2404 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 2404 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 2392.6099 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002c000200050004002d000d0002001000040011000f00080012002e00220002000d000e0007000800170004000f00080018000800170004000f> Tj
+EMC
+ET
+endstream
+endobj
+298 0 obj
+<<
+/Length 1519 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 2107.0596 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<000c00140017001800120003> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<00010002000300040005000600070008000c0030002c0033> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800050002000f00320012002500020013000e> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e00070008001500200004000f0008001800080019001e0004000f0008001c0008001f001a001e00080018000800170020001a001a0016001b0008000300030008001c0008001e0017001a002000080018000800150020001e0019000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0021002200040005001000230004000f00080012001000060005000e00080005001100110024002200130008000400120008002500020012000e00230004000f0012000e000f00120004001000040026000e0027000800100028000400120008001300020029000e000800220012000e001200080012001000060005000e002a002b0002000d00250028000e0017002b0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 1972 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 1972 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 1960.6099 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002c000200050004002d000d0002001000040011000f00080012002e00220002000d000e0007000800170004000f00080018000800170004000f> Tj
+EMC
+ET
+endstream
+endobj
+299 0 obj
+<<
+/Length 1523 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 1819.0596 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<000c00140017001800120004> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<00010002000300040005000600070008000c0030002c0033> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800050002000f00320012002500020013000e> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e00070008001e001a0004000f0008001800080015001b0004000f0008001c0008001a001a002000160019000800180008001d001a002f0016001e0008000300030008001c00080017001b001f001e000800180008001e001f0015001a000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0021002200040005001000230004000f00080012001000060005000e00080005001100110024002200130008000400120008002500020012000e00230004000f0012000e000f00120004001000040026000e0027000800100028000400120008001300020029000e000800220012000e001200080012001000060005000e002a002b0002000d00250028000e001e002b0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 1684 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 1684 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 1672.6099 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002c000200050004002d000d0002001000040011000f00080012002e00220002000d000e0007000800170004000f00080018000800170004000f> Tj
+EMC
+ET
+endstream
+endobj
+300 0 obj
+<<
+/Length 1523 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 1891.0596 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<000c00140017001800120005> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -16.4497 Td
+/P <<
+/MCID 1 
+>>
+BDC
+/F1 7 Tf
+0 Ts
+<00010002000300040005000600070008000c0030002c0033> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<000b000d0004000e000f00100002001000040011000f00080004000f000800120002000300130005000e0007000800050002000f00320012002500020013000e> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 3 
+>>
+BDC
+<000a00040014000e00070008001e001f0004000f0008001800080015001d0004000f0008001c0008001a001b002f0016001b000800180008001d001d00200016001a0008000300030008001c00080017001d00190019000800180008001e001b0020001b000800130010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -13 Td
+/P <<
+/MCID 4 
+>>
+BDC
+<0021002200040005001000230004000f00080012001000060005000e00080005001100110024002200130008000400120008002500020012000e00230004000f0012000e000f00120004001000040026000e0027000800100028000400120008001300020029000e000800220012000e001200080012001000060005000e002a002b0002000d00250028000e0015002b0016> Tj
+EMC
+/Artifact BMC
+ET
+0.9412 0.9725 1 rg
+36 1756 72 72 re
+f
+EMC
+/Artifact BMC
+0.4392 0.502 0.5647 RG
+0.5 w
+36 1756 72 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 1744.6099 Td
+/P <<
+/MCID 5 
+>>
+BDC
+0 0 0 rg
+/F1 7 Tf
+0 Ts
+<002c000200050004002d000d0002001000040011000f00080012002e00220002000d000e0007000800170004000f00080018000800170004000f> Tj
+EMC
+ET
+endstream
+endobj
+301 0 obj
+<<
+/Length 998 
+>>
+stream
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo << /Registry (Adobe) /Ordering (UCS) /Supplement 0 >> def
+/CMapName /Adobe-Identity-UCS def
+/CMapType 2 def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+51 beginbfchar
+<0001> <0046>
+<0002> <0061>
+<0003> <006D>
+<0004> <0069>
+<0005> <006C>
+<0006> <0079>
+<0007> <003A>
+<0008> <0020>
+<0009> <0049>
+<000A> <0053>
+<000B> <004F>
+<000C> <0041>
+<000D> <0072>
+<000E> <0065>
+<000F> <006E>
+<0010> <0074>
+<0011> <006F>
+<0012> <0073>
+<0013> <0070>
+<0014> <007A>
+<0015> <0033>
+<0016> <002E>
+<0017> <0031>
+<0018> <00D7>
+<0019> <0034>
+<001A> <0036>
+<001B> <0038>
+<001C> <007C>
+<001D> <0039>
+<001E> <0032>
+<001F> <0037>
+<0020> <0030>
+<0021> <0042>
+<0022> <0075>
+<0023> <002D>
+<0024> <006B>
+<0025> <0063>
+<0026> <0076>
+<0027> <003B>
+<0028> <0068>
+<0029> <0067>
+<002A> <003D>
+<002B> <0022>
+<002C> <0043>
+<002D> <0062>
+<002E> <0071>
+<002F> <0035>
+<0030> <0052>
+<0031> <004E>
+<0032> <0064>
+<0033> <0048>
+endbfchar
+endcmap
+CMap end
+end
+endstream
+endobj
+302 0 obj
+<<
+/Length 104 
+>>
+stream
+   ) D P L O \   , 6 2 $ U H Q W R V S ]        _     % X  N F Y  K J    & E T  5 1 G +endstream
+endobj
+303 0 obj
+<<
+/Length 20684 
+/Length1 20684 
+>>
+stream
+     Ä  POS/2G$N   ‹   `cmap+v  <  cvt ò"A€  P  åfpgmR≈≠'  ‹  êglyf å˚  l  )Lhead°Gı  :∏   6hhea
+"	  :   $hmtx	fNÜ  ;  ƒloca I   >ÿ  »maxp	e}  B†    nameqFSy  B¿  post[cN¨  Iÿ  Åprepƒqä  L\  n àê   ô3  ô3  – f             ‡ ˇP x[        pyrs @ 	˚ ˛§ =öÕ  üO  /Ω                      ˛   "       " . ; = C F I O S e i v z | ◊ˇˇ     " - 0 = A F H N R a g k y | ◊ˇˇ                                   " " " $ : : > > @ B D L P f h h                     $ % & ) + , 1 2 5 6 D E F G H J K L N O P Q R S T U V W X Y \ ] _   ¿ Ω (Ä /   ˇŸ  ˇ⁄  ˇŸ˛UˇÊ« ˛mˇÒ;   π   π˛?< ¿ ç õ Ø  ® ¿ ( ^ ò …j π\ ¥ ÷ . Ä  ∏ L Ãˇˇ— f § Ø t ¬ ï ±  ( m  L é%ˇz  @ L b Ñˇ¢ $ 8 Ü Ω 9 ^ é Ìˇ©ˇ≥ @ R U ™ ´ ¬ À#±ˇÆˇ‰  Q t Ñ ™ —ˇLˇØ  , B P Q Ñ æ%⁄ˇh  ; ò ú ü ° ¡ ÏÇ¥ˇhˇvˇ–ˇ·    S S }¥·ØÜˇúˇÍˇ˛  ( * R ` ì £ ™ Ø Ø ¿ Ektìï@Ç¥Ö˛˝  ) G G H o à ¥ π ƒ Ú ˘Ôt≈ˇ5ˇÛ  K L R U e v v á á é ´ ª0CP}îï”*UXwxÊN\y”s≤åò˛ıˇªˇ«ˇ’   [ r ~ ú ¬ – Ù ˙%;B^^Äõπ°πP¿–™ﬂ„Ô˚+tì´¬Œiïôﬂı>°Â%€˛b˛â˛Œˇ;ˇ·ˇ¯   ! 9 B N _ a o p 4  é ≠ ≠ Ø Ω ƒ ≈ … … … „ Ì ¯ ˘ 2MMNOfiû∫∫æ„Ôˆ  	SbmÄ’Ä*JZØØ»÷˚˚GI åmöö¶®≤œ9>NVÄâåc—÷~é≤Ô(Loå ¥ … ¿ ¡             $ Ø 2 n cDb ñC°a ä t dàÔp (ˇ]~G0 ™ æ { b ö } â\ °ˇÿ™ ◊ ì l   Ä ßB ó  Ç 0 * * * * * * ì v † ¨ ∏ ´ ≈   +˛U / !æ '@)*)('&%$#"! 
+	 ,E#F` ∞&`∞&#HH-,E#F#a ∞&a∞&#HH-,E#F`∞ a ∞F`∞&#HH-,E#F#a∞ ` ∞&a∞ a∞&#HH-,E#F`∞@a ∞f`∞&#HH-,E#F#a∞@` ∞&a∞@a∞&#HH-, < <-, E# ∞ÕD# ∏ZQX# ∞çD#Y ∞ÌQX# ∞MD#Y ∞êQX# ∞D#Y!!-,  EhD ∞` E∞FvhäE`D-,π@   
+-, π  @ -, E∞ Ca}h∞ C`D-,E∞#DE∞#D-, E∞%Ead∞PQXED!!Y-, ∞%RX#Y!-,i∞@a∞ ãd#dã∏@ b`d#da\X∞aY∞`-,E∞+∞#D∞zÂ-,E∞+∞#D-,E∞+∞Eå∞#D∞zÂ-,∞%FaeäF∞@`ãH-,∞%F`äF∞@aåH-,KS \X∞ÖYX∞ÖY-, ∞%E∞#jDE∞#DEe#E ∞%`j ∞	#B#häj`a ∞ RX≤@E#aDY∞ PX≤@E#aDY-,π~;!-,π-A-A-,π;!~-,π;!ÁÉ-,π-A“¿-,π~ƒ‡-,KRXED!!Y-, ∞%#I∞@`∞ c ∞ RX#∞%8#∞%e8 äc8!!!!!Y-,Ei ∞	C∞&`∞%∞%Ia∞ÄSX≤@E#ahD≤@E#`jD≤	Ee#E`BY∞	C`ä:-,∞%# äı ∞`#ÌÏ-,∞%# äı ∞a#ÌÏ-,∞%ı ÌÏ-, ∞` < <-, ∞a < <-,vE ∞%E#ah#h`D-,vE∞%E#ah#Eh`D-,vE∞%Eah#E#aD-,Ei∞∞2KPX!∞ YaD-∏ +,K∏ 	PX±éY∏ˇÖ∏ Dπ 	 _^-∏ ,,  EiD∞`-∏ -,∏ ,*!-∏ ., F∞%FRX#Y ä äIdä F had∞%F hadRX#eäY/ ∞ SXi ∞ TX!∞@Yi ∞ TX!∞@eYY:-∏ /, F∞%FRX#äY F jad∞%F jadRX#äY/˝-∏ 0,K ∞&PXQX∞ÄD∞@DY!! E∞¿PX∞¿D!YY-∏ 1,  EiD∞`  E}iD∞`-∏ 2,∏ 1*-∏ 3,K ∞&SX∞Ä∞@Yää ∞&SX#!∞¿äää#Y ∞&SX#!∏ äää#Y ∞&SX#!∏@äää#Y ∏ &SX∞%E∏ÄPX#!∏Ä#!∞%E#!#!Y!YD-∏ 4,KSXED!!Y-∏ 5,K∏ 	PX±éY∏ˇÖ∏ Dπ 	 _^-∏ 6,  EiD∞`-∏ 7,∏ 6*!-∏ 8, F∞%FRX#Y ä äIdä F had∞%F hadRX#eäY/ ∞ SXi ∞ TX!∞@Yi ∞ TX!∞@eYY:-∏ 9, F∞%FRX#äY F jad∞%F jadRX#äY/˝-∏ :,K ∞&PXQX∞ÄD∞@DY!! E∞¿PX∞¿D!YY-∏ ;,  EiD∞`  E}iD∞`-∏ <,∏ ;*-∏ =,K ∞&SX∞Ä∞@Yää ∞&SX#!∞¿äää#Y ∞&SX#!∏ äää#Y ∞&SX#!∏@äää#Y ∏ &SX∞%E∏ÄPX#!∏Ä#!∞%E#!#!Y!YD-∏ >,KSXED!!Y-∏ ?,K∏ 	PX±éY∏ˇÖ∏ Dπ 	 _^-∏ @,  EiD∞`-∏ A,∏ @*!-∏ B, F∞%FRX#Y ä äIdä F had∞%F hadRX#eäY/ ∞ SXi ∞ TX!∞@Yi ∞ TX!∞@eYY:-∏ C, F∞%FRX#äY F jad∞%F jadRX#äY/˝-∏ D,K ∞&PXQX∞ÄD∞@DY!! E∞¿PX∞¿D!YY-∏ E,  EiD∞`  E}iD∞`-∏ F,∏ E*-∏ G,K ∞&SX∞Ä∞@Yää ∞&SX#!∞¿äää#Y ∞&SX#!∏ äää#Y ∞&SX#!∏@äää#Y ∏ &SX∞%E∏ÄPX#!∏Ä#!∞%E#!#!Y!YD-∏ H,KSXED!!Y-∏ I,K∏ 	PX±éY∏ˇÖ∏ Dπ 	 _^-∏ J,  EiD∞`-∏ K,∏ J*!-∏ L, F∞%FRX#Y ä äIdä F had∞%F hadRX#eäY/ ∞ SXi ∞ TX!∞@Yi ∞ TX!∞@eYY:-∏ M, F∞%FRX#äY F jad∞%F jadRX#äY/˝-∏ N,K ∞&PXQX∞ÄD∞@DY!! E∞¿PX∞¿D!YY-∏ O,  EiD∞`  E}iD∞`-∏ P,∏ O*-∏ Q,K ∞&SX∞Ä∞@Yää ∞&SX#!∞¿äää#Y ∞&SX#!∏ äää#Y ∞&SX#!∏@äää#Y ∏ &SX∞%E∏ÄPX#!∏Ä#!∞%E#!#!Y!YD-∏ R,KSXED!!Y-∏ S,K∏ 	PX±éY∏ˇÖ∏ Dπ 	 _^-∏ T,  EiD∞`-∏ U,∏ T*!-∏ V, F∞%FRX#Y ä äIdä F had∞%F hadRX#eäY/ ∞ SXi ∞ TX!∞@Yi ∞ TX!∞@eYY:-∏ W, F∞%FRX#äY F jad∞%F jadRX#äY/˝-∏ X,K ∞&PXQX∞ÄD∞@DY!! E∞¿PX∞¿D!YY-∏ Y,  EiD∞`  E}iD∞`-∏ Z,∏ Y*-∏ [,K ∞&SX∞@∞ Yää ∞&SX#!∞Ääää#Y ∞&SX#!∏ ¿äää#Y ∞&SX#!∏ äää#Y ∞&SX#!∏@äää#Y ∏ &SX∞%E∏ÄPX#!∏Ä#!∞%E#!#!Y!YD-∏ \,KSXED!!Y-∏ ],K∏ 	PX±éY∏ˇÖ∏ Dπ 	 _^-∏ ^,  EiD∞`-∏ _,∏ ^*!-∏ `, F∞%FRX#Y ä äIdä F had∞%F hadRX#eäY/ ∞ SXi ∞ TX!∞@Yi ∞ TX!∞@eYY:-∏ a, F∞%FRX#äY F jad∞%F jadRX#äY/˝-∏ b,K ∞&PXQX∞ÄD∞@DY!! E∞¿PX∞¿D!YY-∏ c,  EiD∞`  E}iD∞`-∏ d,∏ c*-∏ e,K ∞&SX∞@∞ Yää ∞&SX#!∞Ääää#Y ∞&SX#!∏ ¿äää#Y ∞&SX#!∏ äää#Y ∞&SX#!∏@äää#Y ∏ &SX∞%E∏ÄPX#!∏Ä#!∞%E#!#!Y!YD-∏ f,KSXED!!Y-  B  –Ω   C∏ S+∏ /∏ /∏ ∏  –∏  /∏ ∏ ‹∏  ∏ ‹∏ ∏ 	‹ ∫    V+∫   V+013!'!Bé∏¸‚Ω˙C∏M˚≥    Rq^Ω   %@ù  ))	˛!ªH++NÙMÌ÷˝ ?<˝<10###^y°yΩ˝¥L˝¥L  UﬁKó   @
+ / ∏B≥!∫H++N‰Ê /MÌ10!!Uˆ˛
+óπ    Ø  Ä ⁄  &@*
+d d!ce++NÙM˝NEeDÊ ?MÌ1073#Ø——⁄⁄     @ˇŸò   q@áF558o8Gvƒ‘Ì˝Ì ?Ì?Ì10Cy@4 &%&	%&(  (( (((
+( ( +++++++++++++Å ] ! '&47!64#"3@|`W~˛‚˛˛~i?v5ä¶x≠üì/HÆòÂ±˛Ã˛‹ø˛Ó‡ª;ÙØF˙Â¯RÙ;˛’˛›€ÖÀ     ƒ  ’í  #±∏3@ñ 
+G	vƒƒ’˝9 ??ÙÕ105>73#ƒ√ö&é¿ˆäY¶˙nˆ    @  ù " ¶@N6FWknzÑá*Zk||µ "! "
+5 u!"!8o"'Å8"$G#vƒ‘ÌÙÌıÌ‰ ?<˝<?Ì9/999999 ]10Cy@%&( 	(
+(
+( ++++++Å ]6?67654&#"#676!2!!JÖ¡¿Å4Rñ}πG&∑Bu(ˆ„yFµâb8d¸)πpoK5Sk}ìåKÖªv–˛ˆ£¨zGeL61Wj™    1ˇŸö 1 ƒ@IS-e)c-u)u-ñ&K+
++˘15 ∏#@515$51ñ'D∏J@
+8.o) Å'3G2vƒ‘ÌÙÌıÌÌÙÌ ?Ì?Ì9/Ù˝ÊÌÌ9910Cy@6/0& 	&%"& ( 0
+(#( %(( 	/( !(&( +++++++<++++ÅÅÅ ]]5332654&#"5327654&#"#476!2 #Âº(F∑é¨µ°%&eAròe¥E&≤@n€G,Fq˛Ú¯'»ã?qòxîvü 8êktxBz†p»√πÑR3±ÄÕ˛˛     4  /ú   \@"	
+æ
+uÔ∏µñ¨
+∏X≥Gvƒ‘ıÙ<˝‰ ??Ù<˝<99999á.+}≈10	!533#•˛5Œ˝åêò””˚â˝w˛^∞é¸_ù˛¢     Bˇ‹Ä   ª@+Hà9FWg: 
+u  
+5
+∏"@:5 «8o 8 "G!vƒ‘ÌıÌƒ ?ÌÌ?˝9/‰ÙÌ99999á.+}≈ 99910Cy@(	& (   (	(( ( 
+( +++++<<++ÅÅ ]]32654&#"'!!67632!"$'˝}@T†ö∑Ä]Ö/úmË˝ü=2-Pi≈˚˛ÌØ˛Ûmö;Ã|ñ§H@	Æ˛r&!˛√À˛ ≈Ã    Mˇ€#û  ' ©@9w%'XÜ áà	G
+!'!5«5'5)Å8o
+<
+$1)G(vƒ‘˝9|KRxz/ıÌÙÌ ?Ì?ÌÌ9/Ì910Cy@4%&  & (&$( ( (!(%'( '( (++++<+++++ÅÅÅÅ] ] #&'&#"67632#" 7!654&#"3GΩ≤#AÑó≤
+>^Vj¥˛Î…˛‹A}LÅç~¶tØüçû˘ÑU0Z˛È˛¸[-(Ê‰√˛”1i∫d˙›øÇn«öõàπ    K  /Ä  S@68:9JUVb∑
+|¥≈	: 	  o8	¨Gvƒ‘ÙÌÂ99 ??<˝<99]10]#67!5/EÂXW-.«DËâó¸ËÄùC˛¥¿ªöc‹öñÓ≠µ   Bˇ◊ú   2 À@GVW	ZYde	kiw%	I{v#r%s'|1|2àá á'à.à1òG2%%25,55,8!∏Ü∑8)o/8∏Üµ8/4G3vƒ‘ÌÙÌıÌÙÌ ?Ì?Ì9/Ì999910Cy@5*. -( +(
+( ( (.( *( ( ( +++++++++ÅÅÅÅ] ] 654&#"3654&#"3 '&54632#"$5467§ÜÄÉÇtñfà•™ÖÅ£ïú˛µ*OË’ŒÍD&PY3_˛Ë—˛ﬂ|z@Ö\PÜÜZer˝;áÜãêìÇp£†+PÄ†ÊŸëÜS/-)5d†Ω˛˘„ÿπ1   Iˇÿö  ' ´@.+(HXhâàò	F!''5
+
+!55«<1∏U@ )Å$8)G(vƒ‘ÌÙÌı˝9}KRxz/ ?ÌÌ?Ì9/Ì910Cy@4&%&"$(  ( ( &$( #!(!(( %'( ++++++++++ÅÅÅÅ]326#"543 !"&5 654&#"3k7EÅ∂&<±fœÒÓË9wBOÉ˛«“⁄2±ü{ÑõàïZï9◊I_MÀ√(˛ÊõÈ˛˘À˛Æ‹¶&ç∞ûõ±îå•   „  ¥!   2@** 
+	d 	d!x|++NÙM<˝<NEeDÊ ??MÌÌ103#3#„————!⁄˝ì⁄     „˛–∏!   9@ #
+d*
+4
+d x|+NÙM<<˝<ÌNEeDÊ ??MÌÌ‘Ì1067654&'#533#„Fm’4Ç’’—P*2⁄ kHvQ⁄   \ ﬁo6   '@  Õ  		\!?R++NÙ<ˆ< /MÌ˝˝10!5!5o˚Ì˚Ì6®®˛S´´     =Ω  
+ D∏ ]+ ∏∂EX∏ /π ƒ>Y∏∂EX∏ /π æ>Y∏∂EX∏ 	/π 	æ>Yª  π  a+013#!#éﬂÌÖ·⁄ï˝ªüÃZâ˝wc˙C∏˛H   ó  Ω 
+  ( Ç@8ZZjjjzw!IH  ''1i1#*	%()*∏_≥!vf++NÙ<M˝<NˆMÌÙÌ ?˝?Ì9/˝9910Cy@%&++ ++++ÅÅ]]27654'&#!27654'&#!! )ƒ~FnuBÇ˛ù≠∑N1èL}˛u√wm@O)Mq8cYÖ˛ﬁ˝ìP#7èê2˛9˝ZjC_†:˝˚ö[wãY/'+6`©és¨  Zˇ⁄qÂ   ±@;óñÇáâSÜ::	1;1 	1 °!jf++NÙMÌNˆMÌÙÌ9/ ??Ì?Ì9/Ì10Cy@: %&%&	2 2	2  2
+2 2 22++++<<++<<++++++Å]]#.#" 327673! '&76!#4¬!≈≤Ÿ˛ıÒÔ‹s=¬íØ˛◊ˇ ÆÂ¨∫G(Â˛⁄ªé¶˛œ˛≈˛˛˛ø©YëËùΩõÕ¨E–‚    Ø  ™Ω 	 9@	 	k% 
+∏W≥!ï‹++NÙM˝<NˆM‰ ??<Ì9/˝10!!!!#Ø˚¸Ã—˝/«Ω¥˛BØ˝d   °  /Ω  ?@!	
+%
+% †!vp++NÙ<M˝<Nˆ<M˝< ?<?<9/<˝<103!3#!#°…¸……˝…Ω˝°_˙CØ˝Q    …  íΩ  ∏ ++∫    .+ ∏  /∏ /013#………Ω˙C  ú  *Ω 	 
+ v@78'GX∏õ@
+
+
+∏õµ∏õ@
+	 †!vp++NÙ<M˝<Nˆ<M˝<999/ ??<?<99á.+á}≈10 ]]33##úÎÊΩﬂ˝æ:Ω˚Z¶˙C•˚[Ω    Pˇ’ËÂ    ä@,á« «√»…
+C::	11ÿ!jf++NÙMÌNˆMÌ9/ ??Ì?Ì10Cy@2 &%	%&2  22 222
+2 2 ++++++++++++Å ] ! '&7! 5 #" !õªíßƒ˛ï˛≠¬≠îætÎ˛ÒÎ‰˛‡˜Â˙√˛–˛∑⁄ˇ ‡ÿJ*‘˙¢yı<˛«˛œÙ˛±^  ¥  xΩ 	 ' î@IHYXidxª0 @B#! &`qu!&$% 		& %%1i)&%'
+()÷!ïf++NÙ<M˝<NˆMÙÌ‘Ì‘Ì ?<<?˝9/<˝<999999]9+10]2654'&#!!2#./&'&#!#Gå£r=f˛«®®mœmbVW.Ù
+d9z˛;«píù9˛
+°1^˝Ñ®3#rÄ≈T)F!<Vıê1˝ä  `ˇ’ˆÂ / 0 ˛@^)'#&&65!G&b&zw$	k%Yh™"
+:"$"
+Ü//+::+	0
+$"(00%I%(2%I %/12†!jâ++NÙMÌÙÌNˆMÌÙÌ9/9999 ??Ì?Ì9/Ì9.˝3]q10Cy@M(. &&-%%&, + -., + *++ +-+ 	'+%.+ )+ ++ ++++++<++++<++++++ÅÅÅ ]327654'&/&'&54$32#&'&#"# '&74c˙p\≤KL¢«√Qå˚ÁCª1[⁄∞öZ;–ŒïQå˛ùÎ˛ÓõõM⁄}Ní >†x32%-,5\∑∆˛ﬂıv?sîbl2 0/";gƒÙ“åãÓ   Rˇ‹GI  ; < ›@8*0
+'3Hi	j9	2$	;+.);∑;;2*%'"∏ä@#'.5<<<)*®$>)J'8=>ºó ! πñ ++NÙMÌÙÌNˆM‰˝ƒ9/ ??Ì?Ì?ÌÌ99]9.Ì.Ì9910Cy@(67" %6! !  !!" 7! !!! +++<++++ÅÅÅ ]]$3276=67654&#"#>323267#"'&'#"&5467rN_Yñ!h2mb1S¥>Ézç;!
+®˜£Ωvu%*,&]*	7Œ|ïΩ∫óäœZ,I¶ë/gl,-\SL*S∆õHHò˝ó"ÖB#@Hjµàï§‰   vˇﬁ%¬   p@.¶ß◊"  
+' ..)  á!Ω]++NÙ<M˝‰‰NˆMÌ ?Ì??Ì?9910Cy@
+&
+&&	& ++++ÅÅ ]3>32#"'&'#$654&#"3vØ;§`»˘ˆ⁄zT29¶fëëç{π&G¬¬˝ÎMQ˛Ì˛Ù˛˛∞;#Mâ}Ëæ©ﬁ∂—ó^±    ;ˇ·–N   ß@/ßò®™Jõ''
+'∏≥!r}++NÙMÌNˆ<MÌ99Ì9/ ??Ì?Ì9/Ì10Cy@4 %
+& &
+&  !& & 	&!++++<<++<<+++Å ]] #.#"32673#"5 3÷„Ør~¨J0àípÉØª“˙‘N∞◊cÉ®m†°‹âw’≈3Ê:  8ˇ⁄Ì¬   w@27GWß©% 
+..)'á!rB++NÙMÌNˆ<M˝‰‰ ?Ì??Ì?9910Cy@	
+ & 	&  & 
+&++++ÅÅÅ ]32654&#" 3#5#" 543ˆí°}°¶zà©äS0=≠¢?¨o≥˛˙Ôﬁ_Ë◊…À√– 74K˙>ïcX-˙ÍW  Hˇ⁄I  $ %@yóôß@@)K∂«∆«ÿŸ	÷ÿ#ËË#««\!$ö$9!
+%óß∑◊%%
+'''$.'&'‘!¶]++NÙM˝‰NˆMÌ‘˝999999/] ??Ì?Ì9/<˝<Ì910Cy@F #&%"$&   &	& &#!&!&
+& 
+&  ++++<++<+++*+*Åq] q]] !327673#"  3&'&#"¥÷86¸ÔêóçT0±O1RyAR»˛Í‚(J≠|®#GkUQlJ¢£≈]6G;ë.P#B˛&uFÇ≥ä‹     =˛;ËI  - . ∑@M6II	XY	à©®©'¶+π@")ƒ
+")
+
+.....-)0'>&'/0á!rB++NÙMÌÙÌ9NˆM˝‰ı9/ ??Ì?Ì??ÌÌ9910Cy@,#($%&#&& (&& ! %"&')& !  +++<<+++++ÅÅÅ ] 53!"&'33276'#"$ 3 &#"32765|^35¶<p˛…≠Ï∑'=Éœ@&6ò}Æ˛˚∫D§æF%ì|¬O,˛—B>#Cá¸2Ãv⁄õ•H'<íV›RP˜.˛°¿≤_öµΩØcÑ-    Ñ  Ì¬  S@,''uu  
+)
+) ∏≥!bB++NÙ<M˝<NˆMÌ ?<?Ì?99910 ]367632#4'&#"#Ñ¥@3WÇÈS-π1áp∂¥¬˝‹Q!9£Yû˝Q£v7Xö÷˝»     Ñ  ;Ω   6@Â  
+	) 	™!bB++NÙ<Mƒ˝<ƒNEeDÊ ??<?MÌ103#3#Ñ∑∑∑∑*˚÷ΩÃ    Ä  ¯Ω  ß@dY:Wgyxáπ…⁄
+	Ñî§9		m	
+  
+
+	
+) ≤!bπ ++NÙ<M˝<<NÊ ?<<?<?99áM.+}¡á.+]}¿<<10] q]r33	##Ä≠ŒÊ˛f±Ê˛≤ó≠Ω¸´«˛o˝bä˛n    â  =Ω  )@  
+) ™!bB++NÙ<M˝<NEeDÊ ??103#â¥¥Ω˙C    Ñ  %G & Ö@;'''HVg#%
+#
+%! %
+()∏≤)∏@
+ .%)& '(∏≥!bB++NÙ<M˝‰ÙÌÙ˝NEeDÊ ?<??<MÌÌ99910 ]367632>32#4&#"#4'&#"#Ñ≤@4YqÄN,$<¢eÿN*ªkMjô∑)pfß¥/òO$=?$FVSúTé˝7ËkPé¶˝ëªm2Kûœ˝»   Ñ  ÌI   ^@1∑«'vt 
+ )	.) ∏≥!bB++NÙ<M˝‰NˆMÌ9/ ??<??Ì99910 ]]3>32#4'&#"#Ñ´L™h‰P,∑0~@)J8-¥ß/ò^RüW¢˝Q£b<dB5qi˝œI   ;ˇŸ!N    ê@3òñô•®¶©∏»◊ÂÈ:'	'∏	≥!r]++NÙMÌNˆMÌ9/ ??Ì?Ì10Cy@, &	&  &	& &
+& & &&+++++++++Å ]$54'&#"3 !" 5 3‡Ö0L∫•ññ£÷¸˛˜›˛¸Át¶ñ^î¸≤´‰⁄˛Ï˛Ù˛˝˛Æ+¸@  v˛U%I  " t@,©ß( "'$
+..!)"#$á!Ω]++NÙ<M˝‰‰NˆMÌ ??Ì??Ì9910Cy@ && &&& &++++++ÅÅ ]$654'&#"3367632#"'&'#∆ß%F∫ªE%%F∫˛.Ø6@[{∂˛∑töyR0;¥y”“Ä\±ªdö|W¶±éI(<˛È˛˝˛¢ñ_5I˝›   <˛UÌG    z@38HX®ß®( ..)"'!"á!rB++NÙMÌNˆ<M˝‰‰ ??Ì??Ì9910Cy@ && &  & &+++++ÅÅÅ ]327654'&#" 53##" 3¯'E≤ºG'+I∏ußè[2.´µ-üw´˛Ú˝…~^ß∞aóã]üÀ‘>C$Fï˙&&HUJ    â  íG  O@&'&7G		' 
+.) ∏E≥!b~++NÙ<M˝‰NÊ ??M?ƒ˝ƒ99910 ]3>32.#"#â´§kàí¥/π6õæØr˝ò   Bˇ◊∂K . /.@è8	òñôòò*($%'6!F!G$G'V$W'f$g&yyyv#t$t%t&¶®, -. -.(i&%6%%"
++∆.ö+/	 /!/'>(&'(1'> '.01≤!¶]++NÙMÌÙ˝9NˆM˝9Ù˝9999/999 ??ÌÌ?ÌÌ9q10Cy@L-&%&!! 	&!, ! *!! ! "! !"'
+!&%	
+-! )! !! ++++<<+<<++++++++++Å ]]]32654'&/&'&54632#&'&#"#"&'Ô%D®dò='sèâAt€πÚkC™&>ôfiE(Nw¬BiŸﬁÔ«∑PZ0WW[E$$"*IÅòºéZh=2GN@F*/,Eîè–Ÿ†˘  ˇÔ	Z  Rµ.
+¿∏?@%9
+) ¸¸!g}++NÙM˝]9ƒ/<˝<NEeDÊ /??<M˝<Ì˝‰1033#3267#"&5#53®∂´´&1C'~ZëëZ˛’ì˝E8é	Åg≈ì    Äˇ„ﬁI   ^@:∏»	(w◊ 
+ 
+.
+))“!bB++NÙMÌNˆ<M˝‰9/ ??Ì??<9910 ]]327653#7#"'&5%80ÉºD%¥™#4gìÂS-Ø/˝9R4`®Zù˚—û=*TôRâÿ     Í/ @.B≈ g hhgáàß ®G HEJÜâ«»I(s(∏	≥!g~++KRy∏ˇp¥ ∏É∑m∏É@m   
+Ø∫Ñ  Ñ≥ØNÙM˝‡‡˝NEeDÊ ?<?<999M.+N‰M.+N‰M+KQy@%) ) 
+Ø ØNÙM˝99˝99NEeDÊ ?<?<9++10q] ]q	3#‹+≈˛l¿˛u/¸òh˚—/  ˛IËI    @näàß8HXgwwåò óòóó® ®H KG…D∆á¶ ¶ß®$(  ØØè‘!g~++NÙM‰˝99˝99NEeDÊ9/ ??M˝92/?<<<99KRy@ mm  á.+}ƒá.+}ƒ]q10q] ]3#"&'53267>73!«&ÉbBúÄú&)/*2/>˛tÃ/g˛ë˛ÏÆ˛f¥§!î$N¸òÇ   4  ¥I 	 
+ l@B7H W XWg hgw	)  
+
+9 9	
+
+>J ≤!r]++NÙM‰NˆM‰ ??<˝<9?<˝<9999/á.+á}≈10]7!5!!!4{˝¥>˝âä¸Äœé °ì˝°I  ê  ;“  )@ 
+ ¡¡!we++NÙ<M˝<NEeDÊ ??10!#3;´´“     t Z˝  t@?wòò®®  		
+
+    		
+ 
+	 
+/<’< /<’<10á.+ƒá.+ƒ<<<<<<<< ]7			'tv{|y˛Ñ|y˛Ñ˛Öv{áv˛Ö{v˛Ñ˛Öy{˛Öy{          ñ)
+]_<ı      _Mè     ﬁ‡.÷¯e¸'ë˘   	         )˛)  ¯e¸Ìë                Ò B    9  9  9 Ì◊ Rs  s @ BV Yá ú™ é™ D N¨ \9 ™™ U9 Ø9  s @s ƒs @s 1s 4s Bs Ms Ks Bs I9 „9 „¨ ¨ \¨ s ú ·V V ó« Z« •V Ø„ Ø9 c« °9 …  #V ús ú™ ó« ú9 PV Ø9 P« ¥V `„ !« ™V 4ç %V *V *„ /9 Ä9ˇª9 /¡ xs  ™ &s Rs v  ;s 8s H9 s =s Ñ« Ñ«ˇ⁄  Ä« â™ Ñs Ñs ;s vs <™ â  B9 s Ä  «       4¨ˇ’ ê¨ *¨ V V « ZV Ø« ú9 P« ™s Rs Rs Rs Rs Rs R  ;s Hs Hs Hs H9 g9 9  9 %s Ñs ;s ;s ;s ;s ;s Äs Äs Äs Äs P3 os hs 8s KÕ ïLˇı„ «Â Â   Ì™ ä™ Rd \  9 B¥ *d \d Zd \sˇ·úˇ¥Ù j¥ (ñ d /1ˇyˆ ;Ï 1% ^ I„ \„ ∫™ Ë¨ \dˇÔs (d \Â qs ¬s ¬  Ì9  V V 9 P  Iç Gsˇ˚  Ò™ N™ N« Ñ« ™d \Ù B  V *V˛™Ù `™ ¥™ ™    s P9 ó« ™™ N  V V ØV V ØV Ø9 k9ˇ˘9  9 9 P9 PR i9 P« ™« ™« ™9 Ω™ *™ˇ˜™ ™ ™ ˜™ Ñ™ y™ˇˇ™ °™ *sˇË«ˇ◊V `  B„ /  4 ê« !s =V *  V Äs Ä¨ \¨ t       l   l   l   l   l   º   º   º   º   º   º   º   º   º   º   º   ¯  8  8    `  x  –  l  î  ¿  T  	∏  
+‰  <  ∏  ∏          Ñ  å  ¨  ¨  ¨      Ä  ∞  ∞  ∞  ∞  ∞  \  X  X  X  l                              ò  l  p  H  ‹  ‹  ,  Ã  (  (    L  D  ¸  Ï   –  !∏  "D  $  $§  %X  &Ñ  &Ñ  &Ñ  '∞  (P  (P  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  (î  )L    Ò o 	 k     g  Ëê     9≤        P         	 P        Y       "       	A       J       	R       2[       	       	            &      4      H      	Z      /ç      <º      0¯      :(      6b      0ò      <»    `     Ã    |     Ê     |    ò  	   `     ˙     n    ®    ∞     ™    
+ ä     ∫     ö    
+         ⁄    ⁄    2    n    Ê    @    L    T  !  ¬  "  Ù  *    9    >  
+–     î  	  ä    $     “  
+   ¿© 1990-2006 Apple Computer Inc. © 1981 Linotype AG © 1990-91 Type Solutions Inc.HelveticaRegular R e g u l a r C o u r a n t R e g u l a r0Ï0Æ0Â0È0¸^8âƒOS R e g u l i e r R e g o l a r e«|ºÃ¥ N o r m a ljnñö‘9'/J N o r m a l A l m i n d e l i g N o r m a a l i N o r m a l R e g u l a r R e g u l a r1KG=K9 N o r m a l4 N o r m a l R e g u l a r R e g u l a r R e g u l a r R e g u l a rö±ΩøΩπ∫¨Ë“Ÿ‹ S z a b · l y o s R e g u l e r B i a s a N o r m a l R e g u l a r28G09=89	0	G		M	/	A	2	0 T h∞› n gHelvetica; 17.0d1e1; 2020-09-21Helvetica17.0d1e1HelveticaHelvetica is a registered trademark of Linotype AGHelvetica est une marque déposée de Linotype AGHelvetica ist ein eingetragenes Warenzeichen der Linotype AGHelvetica è un marchio registrato di Linotype AGHelvetica is een geregistreerd handelsmerk van Linotype AGHelvetica är ett registrerat varumärke för Linotype AGHelvetica es una marca registrada de Linotype AGHelvetica er et registreret varemærke tilhørende Linotype AGHelveticaLigaturesCommon LigaturesNumber SpacingProportional NumbersMonospaced NumbersNo Change          ˇe e                     Ò           	 
+                        ! " # $ % & ' ( ) * + , - . / 0 1 2 3 4 5 6 7 8 9 : ; < = > ? @ A B C D E F G H I J K L M N O P Q R S T U V W X Y Z [ \ ] ^ _ ` a b c d e f g h i j k l m n o p q r s t u v w x y z { | } ~  Ä Å Ç É Ñ Ö Ü á à â ä ã å ç é ê ë í ì î ï ñ ó ö õ ù û ü † ° ¢ £ § ¶ ® © ™ ´ ¨ ≠ Æ Ø ∞ ± ≤ ≥ ¥ µ ∂ ∑ ∏ π ∫ ª º æ ø ¿ ¡ ¬ √	
+ ∆ « » …   À Ã Õ Œ œ – — “ ” ‘ ’ ÷ ◊ ÿ Ÿ ⁄ € ‹ › ﬁ ﬂ ‡ · ‚ „ ‰ Â Ê Á Ë È Í Î Ï Ì Ó Ô old_notequalold_partialdiffold_summationold_integralold_radicalold_approxequalEuroquotesinglbase.oldquotedblbase.old   ∏ ]+∫ π _+øª > 4 )     e+øº B 4 )     e+øΩ : 4 )     e+ ø∑ M = 7 (    e+ø∏ ` O 7 (    e+øπ G = )     e+ø∫ B 4 )     e+ ∫æ  d+∏∂ E}iD∏ S+∏ I+∏ ?+∏ 5+∏ ++A Ä¶ ê¶ †¶  iã yã âã ôã  âã ôã ©ã πã≤@∫y J@T
+“∏¥ûŸ„ª  ·≤ 	A
+†ü d • %z H (ö≥)l`A
+© p© Ä©  Ä© ©≤2æ, % & ∂Á1-Â1∏≤¬'∏≤¡∏@¿ûøgæg´'∏≤™)∏∂©lì∏ö≤í∏≤ë∏≤u∏∂m)ñd1∏ö≤Lñ∏´≤9∏V@68!5‰/'∏@-L*1Õ$∏´≤ ∏%@ì:LE':E'ª™õ *õ≤%J∫õ %z≥I)8ñ∏{≥H(1%∏z@6H(ñ)H'%)L%)F'')H'V»Ñ[A2+(&!
+∏¨≤?ª´ ? ´≥∏Æ≤?ª≠ ? ≠∑ ∏ˇ‡¥   ∏´¥   ∏´∂   ∏≠≥   ∏≠@               J ∞ç∏ Öv??>9FD>9FD>9FD>9FD>9FD>9F`D>9F`D>9F`D+++++++++++++++++++++++++++∞ñKSX∞™Y∞2KSX∞ˇY+++++++++++++++++++++++++++++++++++++++++tu+++eB++KRy≥vpjfEe#E`#Ee`#E`∞ãvh∞Äb  ±jpEe#E ∞&`bch ∞&ae∞p#eD∞j#D ±vfEe#E ∞&`bch ∞&ae∞f#eD∞v#D± fETX±f@eD≤v@vE#aDY≥bBr]Ee#E`#Ee`#E`∞âvh∞Äb  ±rBEe#E ∞&`bch ∞&ae∞B#eD∞r#D ±b]Ee#E ∞&`bch ∞&ae∞]#eD∞b#D± ]ETX±]@eD≤b@bE#aDY++++EiSBst∏ö EiK ∞(S∞IQZX∞ aYD∏¶ EiDu  endstream
+endobj
+304 0 obj
+<<
+/Length 620 
+>>
+stream
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo << /Registry (Adobe) /Ordering (UCS) /Supplement 0 >> def
+/CMapName /Adobe-Identity-UCS def
+/CMapType 2 def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+24 beginbfchar
+<0001> <0041>
+<0002> <0030>
+<0003> <0031>
+<0004> <0032>
+<0005> <0033>
+<0006> <0042>
+<0007> <0034>
+<0008> <0043>
+<0009> <0052>
+<000A> <0053>
+<000B> <0074>
+<000C> <0061>
+<000D> <0062>
+<000E> <006C>
+<000F> <006F>
+<0010> <0069>
+<0011> <0064>
+<0012> <0065>
+<0013> <0067>
+<0014> <0072>
+<0015> <006E>
+<0016> <0073>
+<0017> <0063>
+<0018> <0068>
+endbfchar
+endcmap
+CMap end
+end
+endstream
+endobj
+305 0 obj
+<<
+/Length 50 
+>>
+stream
+   $     %  & 5 6 W D E O R L G H J U Q V F Kendstream
+endobj
+306 0 obj
+<<
+/Length 11332 
+/Length1 11332 
+>>
+stream
+     Ä  POS/2á,√   ‹   `cmapdÃ  <   úcvt 
+5„  ÿ   fpgm”'õi  Ù  sglyfz$–a  h  Hhead„˜≠  ∞   6hhea	Ü^  Ë   $hmtxÅ]q     `loca @0  !l  dmaxp’ã  "–    namemÒ$   "  ¸postO…  *Ï   “prepRÀ‡o  +¿   Ñ ˘º   ô3  ô3  – f             ‡ ˇR x[        pyrs   	ˇˇ ˛§ =Æ€  üO  B¬                      à       4 C S e i l o tˇˇ   0 A R a g l n rˇˇ                        ( , , .        $ % & 5 6 D E F G H J K L O Q R U V W * ˛ ò*4   )˛P B #¬ -∏ f,K∏ 	PX±éY∏ˇÖ∏ Dπ 	 _^-∏ g,  EiD∞`-∏ h,∏ g*!-∏ i, F∞%FRX#Y ä äIdä F had∞%F hadRX#eäY/ ∞ SXi ∞ TX!∞@Yi ∞ TX!∞@eYY:-∏ j, F∞%FRX#äY F jad∞%F jadRX#äY/˝-∏ k,K ∞&PXQX∞ÄD∞@DY!! E∞¿PX∞¿D!YY-∏ l,  EiD∞`  E}iD∞`-∏ m,∏ l*-∏ n,K ∞&SX∞@∞ Yää ∞&SX#!∞Ääää#Y ∞&SX#!∏ ¿äää#Y ∞&SX#!∏ äää#Y ∞&SX#!∏@äää#Y ∏ &SX∞%E∏ÄPX#!∏Ä#!∞%E#!#!Y!YD-∏ o,KSXED!!Y-   ö  =¬   ^∏ f+ ∏  EX∏  /π   >Y∏  EX∏ /π  >Y∏ ‹∏  ∏ ‹∏ /∏ 	/∏ ∏  –∏  /∏ 	∏ ‹∏ ‹∏  ∏ ‹01!!%!ö£˚]Î¸Õ¬˙>∏R˚Æ  @ˇ‹(¥  #∏ f+ ∏  EX∏  /π   >Y∫   i+∏  ∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∏ /∏ /∏ ∏ –∏ /∏ ∏ 
+‹∏ ‹A ⁄  Í  ]A 	    )  9  I  Y  i  y  â  ô  ©  π  …  ]∏ ∏ ‹A     &  6  F  V  f  v  Ü  ñ  ¶  ∂  ∆  ]A ’  Â  ]01 ! 65&#"324˛Îﬂﬂpoﬂn'ORR$ÑggÜ√√˛ô˛ô˛|mÑ˙¸¸˛˙˙˛˜     é  ™  )∏ f+ ∏  EX∏  /π   >Y∫   i+∫    i+01)!5676767653˛‹˛´á6V6%ÌË¬9'A'    @  !± " (∏ f+ ∏  EX∏ /π  >Y∫   i+∏ ∏ ‹01&#"!676!2!!676767654»3_Ç/˛Î<r#Ê`?êrkOy¸?=„≈:YÉ=a8zπrŸˇ“°}SfQLD-˚úÅë¢ç=_q\    6ˇ‹!± 15∏ f+ ∏  EX∏ /π  >Y∫ 
+ 0 i+∫ ) ( i+∫  ( )9∏ ∏ !‹A  !  ! ' ! 7 ! G ! W ! g ! w ! á ! ó ! ß ! ∑ ! « ! ]A ÷ ! Ê ! ]∫  - i+A ⁄ - Í - ]A 	 -  - ) - 9 - I - Y - i - y - â - ô - © - π - … - ]∫  - 9∫ $ - 9∏ $/A ⁄ $ Í $ ]A 	 $  $ ) $ 9 $ I $ Y $ i $ y $ â $ ô $ © $ π $ … $ ]∏ ‹∏ 3‹01!6767>322# '&'!32654'&#567654&#"à0˛ˆ!#K8öp–ˇL04'Imˇ˙˛Ãx?4âT}tBéã7_aXeâ@klaUH36◊µÄX7CeØ∏˛È…k≠W9islè0Ã*ÄSh     6  /° 
+  Q∏ f+ ∏  EX∏ /π  >Y∫    i+∏ ∏ –∏  ∏ –∫   i+∏ ∏ 	–∏ ∏ –∏ ∏ ‹01#!!5!)/§˛È˝¬@˝~kﬂ˛»8˘p¸vr  4  ®¬  
+ B∏ f+ ∏  EX∏ /π  >Y∏  EX∏ /π  >Y∏  EX∏ /π  >Y∫    i+01!!!!˚˝·f˛æ\
+˛≤µ∏æ/˛—¬˙>-D˝º  °  a¬   * \∏ f+ ∏  EX∏ /π  >Y∏  EX∏  /π   >Y∫ )  i+∫   )9∏  ∏ ‹∏ ∏ &‹∫   i+∏ ∏ '–01)!!!27654'&654'&#!!2=˝dÃqDD&JqsB*?G¡x˛ëja6b_59<PEk˛ºja¬ô^ÉáR.&)≤ÉhE/6(â˛w0às+$]g!˛ª   \ˇ◊{ﬁ ∏ f+ ∏  EX∏ 
+/π 
+ >Y∏  EX∏ /π  >Y∏ 
+∏ ‹A Ÿ  È  ]A     (  8  H  X  h  x  à  ò  ®  ∏  »  ]∏ ∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∫   i+A     &  6  F  V  f  v  Ü  ñ  ¶  ∂  ∆  ]A ’  Â  ]01%! '&76! !&'&#"32767!¨•˛ˇ˛¬∂∂œ¥t¨_˛Ã/T•®¬Õû¢U/1(nóÃÕeÇ—∂Ùâäj6`˛Ò¯¯˜j9rÒ    £  q¬  * £∏ f+ ∏  EX∏ /π  >Y∏  EX∏ /π  >Y∏  EX∏ /π  >Y∫ )   i+∫    )9∏ ∏ &‹∏ +/∏ ,/∏ +∏ –∏ /∏ ‹∏ ,∏ ‹∏ ‹∫   9∏ ∏ –∏ /∏ ∏ –∏ /∏ ∏ '–01!!!!&'&/.654'&#!!2˛¬˛””õß:08jzfU,˛≠c3\Y2d˛ö]hB˝æ¬FD8àWiÀ*)óõce$9%1>Aâç^*|Ü.˛t     Uˇ⁄Ì .∏ f+ ∏  EX∏ /π  >Y∏  EX∏ '/π ' >Y∏  ‹A       '   7   G   W   g   w   á   ó   ß   ∑   «   ]A ÷   Ê   ]∏ ∏ ‹A Ÿ  È  ]A     (  8  H  X  h  x  à  ò  ®  ∏  »  ]∫   i+A     &  6  F  V  f  v  Ü  ñ  ¶  ∂  ∆  ]A ’  Â  ]01%27654'&/&'&54 !2!&'&#" !  5!≥mDÅ@@âúÊXï ÈI˛ÿlHkwéF-ì˛ßUÑ˛À˛Ê˛‡˛∂&)K’.}I('#4=fŸ∆˜ÎÖ8%`VO'#=(Ch≈ ˛ıÊe2[    ;ˇﬁ8\ * : —∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∏  EX∏ /π  >Y∫   9∏ ∏ $‹A Ÿ $ È $ ]A  $  $ ( $ 8 $ H $ X $ h $ x $ à $ ò $ ® $ ∏ $ » $ ]∫ 1  9∫  0 i+∏ ∏ 	–∏ 	/∏ 0∏ –∏ /∏ 0∏ !–∏ !/∏ ∏ <‹016!2!.'#"&5476?67654&#"!632675Æq≥ãã˛ 
+;M\tî¡õU•aO"=]Ze*
+˛Ì	(:\õ70@Z'BÃêGG≈˛4J8(*!:%@-5©õ…Z1
+7C32%?è˝^!lèj	'RI  {ˇ„ú¿   ∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏  /π   >Y∏  EX∏ /π  >Y∏  ∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∫    9∫ 	   9∏ !/∏ "/∏ !∏ –∏ /∏ 	‹∏ –∏ /∏ "∏ ‹∏ ‹A ⁄  Í  ]A 	    )  9  I  Y  i  y  â  ô  ©  π  …  ]∏ 	∏ –∏ /01"'&'!!676324'&#"326’áR19˛È6AMw◊Û;9ôõ:|nz6 Pâ¿˝ÙL(2˛ ı˛˛≤.tLêçKwå∏≤     Gˇ⁄4\ ∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∏ ∏ ‹A Ÿ  È  ]A     (  8  H  X  h  x  à  ò  ®  ∏  »  ]∏ ∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∫ 	  i+A  	  	 & 	 6 	 F 	 V 	 f 	 v 	 Ü 	 ñ 	 ¶ 	 ∂ 	 ∆ 	 ]A ’ 	 Â 	 ]01!&'&#"3267!! 5 324˛‹!0eê53çdT	#
+TÜ˛˘˛˘¯ÒÕª=1BèL~xIàlVÇtª8˘8∏     ?ˇﬁe¿  o∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∏  EX∏ /π  >Y∏ ∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∫   9∏ ∏ ‹A Ÿ  È  ]A     (  8  H  X  h  x  à  ò  ®  ∏  »  ]∫   9∏ /∏  /∏  ‹∏ ‹∏ –∏ /∫    9∏ ∏ 	–∏ 	/∏ ‹A     &  6  F  V  f  v  Ü  ñ  ¶  ∂  ∆  ]A ’  Â  ]∏ ∏ –∏ /01!5#" 5 3232654'&#"e˛Î=útø˛˚◊cö0˛!<;yy~e>R}u¿˙@óaX5Ú@WM¸ZóZ[¥è»V4Ω   /ˇ‹:_  ! Õ∏ f+ ∏  EX∏ 
+/π 
+ 
+>Y∏  EX∏ /π  >Y∫   i+∏ ∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∏ 
+∏ ‹A Ÿ  È  ]A     (  8  H  X  h  x  à  ò  ®  ∏  »  ]01#"  32!32767.#"*Zå¸–˛¬Âà⁄G@˝a;SX7	{[cm@adü..fnaÄKç§B)20Nqu|j    B˛B^\ ! /’∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏ /π  
+>Y∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∏  EX∏ /π  >Y∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∏ ∏ $‹A  $  $ ' $ 7 $ G $ W $ g $ w $ á $ ó $ ß $ ∑ $ « $ ]A ÷ $ Ê $ ]∫   $9∏ ∏ *‹A Ÿ * È * ]A  *  * ( * 8 * H * X * h * x * à * ò * ® * ∏ * » * ]∫   *9∏ 0/∏ 1/∏ ‹∏ ‹∏ –∏ /∏ 0∏ –∏ /∏ ∏ '–∏ '/∏ ∏ .‹A  .  . & . 6 . F . V . f . v . Ü . ñ . ¶ . ∂ . ∆ . ]A ’ . Â . ]013276=#"54325!!"$'!32654&#"π.mö4")/Uà“˚ÚﬁR=h@Gz˛¶—˛¯6:ñdäÉnñ9ø'gBúFF#A'¸ÛK+sù˚ˆ”k∏§£2äó•õ¢çKn_     á  ^Ω  ¡∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∏  EX∏ /π  >Y∏ ∏ ‹A Ÿ  È  ]A     (  8  H  X  h  x  à  ò  ®  ∏  »  ]∫   9∏ /∏ /∏ ‹∏ ‹∏ ∏ –∏ /∏ ‹∏ –∫   901!4'&#"!!>32^˛›'mqu˛‰>£Ze•5-Ä˝ÄóX6Lóå˝≤Ω˝˜_KFH=Å   â  ™À   [∏ f+ ∏  EX∏  /π   
+>Y∏  EX∏ /π  >Y∏  EX∏ /π  >Y∏ ∏ ‹∫   i+∏ ∏ –∏ ∏ –01!!™˛ﬂ!˛ﬂB˚æBâ˛˘   ã  ®¬  2∏ f+ ∏  EX∏  /π   >Y∏  EX∏ /π  >Y∫    i+01!!ã˛„¬˙>     á  a\  {∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∏  EX∏ /π  >Y∫ 	  9∏ /∏ /∏ ∏ –∏ /∏ ‹∏ –∏ /∫ 	  9∏ ∏ ‹∏ ‹01"!!67632!4'&Üë6˛‰71Xá©◊˛‹*o{Ae˝≤@üT%B±Õ˝"óV.T     Bˇ⁄úe  j∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∏ ∏ ‹A Ÿ  È  ]A     (  8  H  X  h  x  à  ò  ®  ∏  »  ]∏ ∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∫   i+∫   i+A     &  6  F  V  f  v  Ü  ñ  ¶  ∂  ∆  ]A ’  Â  ]A ⁄  Í  ]A 	    )  9  I  Y  i  y  â  ô  ©  π  …  ]∏ ∏ ‹01 !  54 ! "32654&ä˛Ï˛Á˛Á˛Ï˛Ê}áá}}ÜÜ∏≠Ï˛´UÏZÒ±§§≤≤§§±   Ç  ˚\  h∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏ /π  
+>Y∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∫ 	  9∫   i+∫ 	  901"!!67632.©¨;!˛·B1PÄ*;p?É˝˜Bæm(C˛‹   Bˇ€%a , ≈∏ f+ ∏  EX∏ +/π + 
+>Y∏  EX∏ /π  >Y∏ +∏ ‹A Ÿ  È  ]A     (  8  H  X  h  x  à  ò  ®  ∏  »  ]∏ ∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]01!&'&#"# &5!32654'&%&'&54632tÄ˛„/q]O**ˇ™UTÒ¸˛ˇı!	5èTc((˛ˇπLLÌ◊ÃR»7 ::'18(QR{¢ÕŸ®L 9220=.EDÄóŸ     ˇÍxh  Y∏ f+ ∏  EX∏ /π  >Y∫ 
+  i+∏ ∏  ‹∏ 
+∏ –∏ ∏ –∏  ∏ –∫   i+∏ ∏ 
+–∏ ∏ –01%'&5#53!3#326xá J0òò±±"WÀ’M1füÀ0˛–À˝¿C!        ¥¯=_<ı      ¢(Ä     ﬁ‡.◊˜‹¸'
+˙≥           )˛)  ˜‹¸€~                X« ö    9  9  ™ ·À ßs  s 8 /« oÁ c™ Y™  /¨ I9 v™ /9 Ä9ˇês @s és @s 6s 6s 6s @s 4s 6s =™ Ë™ Ë¨ ¨ I¨ „ {Õ «« 4« °« \« úV •„ ú9 U« ö9 Ñs -« °„ ú™ ó« ó9 eV £9 e« £V U„ !« úV /ç V !V #„ 4™ Ä9ˇê™ /¨ ãs  ™ˇŒs ;„ {s G„ ?s /™ „ B„ á9 â9 	s Ç9 ã Ä„ á„ B„ }„ < Çs B™        à   à   à   à   à   à   à   à   à   à   à   à   à   à   à   à   à   à   à    l    ‘  `  `  `  `  `  `  `  `  `  `  `  `  `  ‹  ƒ  D  D  D  D  D  D  D  D  D  D  D  D  D  D  D  	t                              †  (  §  |  ¿  ¿  (  <  ƒ  ƒ  ƒ      ‡  §  §  §  T  §  H    X k 	 k     p  Ë¢     EB        P         	 P        Y       $©       Õ       î       ú       2™       S       	a      j      z      à      ú      	Æ      €      /‹      È      <      ˜      0G      
+      :w            6±      $      0Á      <      5    	  H      Y     i     w   
+  á         ≠    
+3     «     m    E  	   ]     Õ     e    Q    W     á     u     ô     Å     ﬂ     Â     π    
+{     ˚    +    Ö            
+  !  
+g  "  ç  *  £  9  
+ô  >  
+q     }  	  =     Ì     ±  
+   ü© 1990-2006 Apple Computer Inc. © 1981 Linotype AG © 1990-91 Type Solutions Inc.HelveticaBold B o l d G r a s F e t t0‹0¸0Î0…|óOS V e t G r a s s e t t oº¸¥‹Ã¥ N e g r i t a|óö‘91J6 N e g r i t o F e d L i h a v o i t u F e t B o l d N e g r i t o8@=K9 F e t+2 K a l1 n N e g r e t a B o l d T u n È B o l dàΩƒøΩ±‚—‘ F È l k ˆ v È r T e b a l T e b a l A l d i n B o l d8@=89	,	K	2	M	!≠ mHelvetica Bold; 17.0d1e1; 2020-09-21Helvetica BoldHelvetica GrasHelvetica FettHelvetica grassettoHelvetica vetHelvetica FetHelvetica NegritaHelvetica CarregadoHelvetica HalvfetHelvetica lihavaHelvetica √”ËœHelvetica »—Ã” ÁHelvetica Ú·‰17.0d1e1Helvetica-BoldHelvetica is a registered trademark of Linotype AGHelvetica est une marque déposée de Linotype AGHelvetica ist ein eingetragenes Warenzeichen der Linotype AGHelvetica è un marchio registrato di Linotype AGHelvetica is een geregistreerd handelsmerk van Linotype AGHelvetica är ett registrerat varumärke för Linotype AGHelvetica es una marca registrada de Linotype AGHelvetica er et registreret varemærke tilhørende Linotype AGHelvetica BoldLigaturesCommon LigaturesNumber SpacingProportional NumbersMonospaced NumbersNo Change          ˇe e                     X           	 
+                        ! " # $ % & ' ( ) * + , - . / 0 1 2 3 4 5 6 7 8 9 : ; < = > ? @ A B C D E F G H I J K L M N O P Q R S T U V W  ∏ f+ ∫   h+∫   h+ø  (       n+ø  %       n+ ø  - %      n+ø  K = 0 "    n+ø  &       n+ ∫   m+∏   E}iDendstream
+endobj
+xref
+0 307
+0000000000 65535 f
+0000000009 00000 n
+0000000339 00000 n
+0000000387 00000 n
+0000000529 00000 n
+0000000627 00000 n
+0000002517 00000 n
+0000004263 00000 n
+0000004501 00000 n
+0000004618 00000 n
+0000004948 00000 n
+0000005270 00000 n
+0000005427 00000 n
+0000005556 00000 n
+0000005876 00000 n
+0000006297 00000 n
+0000006449 00000 n
+0000006596 00000 n
+0000006976 00000 n
+0000007161 00000 n
+0000007397 00000 n
+0000007638 00000 n
+0000007757 00000 n
+0000007887 00000 n
+0000008035 00000 n
+0000008408 00000 n
+0000008594 00000 n
+0000008831 00000 n
+0000009072 00000 n
+0000009191 00000 n
+0000009321 00000 n
+0000009469 00000 n
+0000009846 00000 n
+0000010032 00000 n
+0000010269 00000 n
+0000010508 00000 n
+0000010627 00000 n
+0000010757 00000 n
+0000010905 00000 n
+0000011278 00000 n
+0000011464 00000 n
+0000011701 00000 n
+0000011938 00000 n
+0000012057 00000 n
+0000012187 00000 n
+0000012335 00000 n
+0000012720 00000 n
+0000012906 00000 n
+0000013143 00000 n
+0000013382 00000 n
+0000013501 00000 n
+0000013631 00000 n
+0000013779 00000 n
+0000014160 00000 n
+0000014346 00000 n
+0000014583 00000 n
+0000014824 00000 n
+0000014943 00000 n
+0000015073 00000 n
+0000015221 00000 n
+0000015602 00000 n
+0000015788 00000 n
+0000016025 00000 n
+0000016266 00000 n
+0000016385 00000 n
+0000016515 00000 n
+0000016663 00000 n
+0000017040 00000 n
+0000017226 00000 n
+0000017463 00000 n
+0000017702 00000 n
+0000017821 00000 n
+0000017951 00000 n
+0000018099 00000 n
+0000018468 00000 n
+0000018654 00000 n
+0000018891 00000 n
+0000019132 00000 n
+0000019251 00000 n
+0000019381 00000 n
+0000019529 00000 n
+0000019910 00000 n
+0000020096 00000 n
+0000020333 00000 n
+0000020575 00000 n
+0000020694 00000 n
+0000020824 00000 n
+0000020972 00000 n
+0000021345 00000 n
+0000021531 00000 n
+0000021768 00000 n
+0000022010 00000 n
+0000022129 00000 n
+0000022259 00000 n
+0000022407 00000 n
+0000022784 00000 n
+0000022970 00000 n
+0000023207 00000 n
+0000023447 00000 n
+0000023566 00000 n
+0000023696 00000 n
+0000023845 00000 n
+0000024223 00000 n
+0000024410 00000 n
+0000024648 00000 n
+0000024887 00000 n
+0000025008 00000 n
+0000025140 00000 n
+0000025290 00000 n
+0000025661 00000 n
+0000025849 00000 n
+0000026088 00000 n
+0000026331 00000 n
+0000026453 00000 n
+0000026586 00000 n
+0000026736 00000 n
+0000027123 00000 n
+0000027312 00000 n
+0000027551 00000 n
+0000027794 00000 n
+0000027916 00000 n
+0000028049 00000 n
+0000028199 00000 n
+0000028582 00000 n
+0000028771 00000 n
+0000029010 00000 n
+0000029253 00000 n
+0000029375 00000 n
+0000029508 00000 n
+0000029658 00000 n
+0000030041 00000 n
+0000030230 00000 n
+0000030469 00000 n
+0000030710 00000 n
+0000030832 00000 n
+0000030965 00000 n
+0000031115 00000 n
+0000031494 00000 n
+0000031683 00000 n
+0000031922 00000 n
+0000032163 00000 n
+0000032286 00000 n
+0000032420 00000 n
+0000032570 00000 n
+0000032957 00000 n
+0000033147 00000 n
+0000033386 00000 n
+0000033627 00000 n
+0000033750 00000 n
+0000033884 00000 n
+0000034034 00000 n
+0000034417 00000 n
+0000034607 00000 n
+0000034846 00000 n
+0000035089 00000 n
+0000035212 00000 n
+0000035346 00000 n
+0000035496 00000 n
+0000035879 00000 n
+0000036069 00000 n
+0000036308 00000 n
+0000036549 00000 n
+0000036672 00000 n
+0000036806 00000 n
+0000036956 00000 n
+0000037335 00000 n
+0000037525 00000 n
+0000037764 00000 n
+0000037949 00000 n
+0000038075 00000 n
+0000038216 00000 n
+0000038367 00000 n
+0000038698 00000 n
+0000038891 00000 n
+0000039130 00000 n
+0000039315 00000 n
+0000039440 00000 n
+0000039581 00000 n
+0000039732 00000 n
+0000040063 00000 n
+0000040255 00000 n
+0000040494 00000 n
+0000040679 00000 n
+0000040803 00000 n
+0000040934 00000 n
+0000041085 00000 n
+0000041416 00000 n
+0000041607 00000 n
+0000041846 00000 n
+0000042033 00000 n
+0000042157 00000 n
+0000042288 00000 n
+0000042439 00000 n
+0000042774 00000 n
+0000042965 00000 n
+0000043204 00000 n
+0000043391 00000 n
+0000043515 00000 n
+0000043646 00000 n
+0000043797 00000 n
+0000044132 00000 n
+0000044323 00000 n
+0000044562 00000 n
+0000044749 00000 n
+0000044873 00000 n
+0000045004 00000 n
+0000045155 00000 n
+0000045494 00000 n
+0000045685 00000 n
+0000045924 00000 n
+0000046107 00000 n
+0000046231 00000 n
+0000046362 00000 n
+0000046512 00000 n
+0000046835 00000 n
+0000047026 00000 n
+0000047265 00000 n
+0000047450 00000 n
+0000047574 00000 n
+0000047705 00000 n
+0000047856 00000 n
+0000048187 00000 n
+0000048378 00000 n
+0000048617 00000 n
+0000048804 00000 n
+0000048928 00000 n
+0000049059 00000 n
+0000049210 00000 n
+0000049545 00000 n
+0000049736 00000 n
+0000049975 00000 n
+0000050162 00000 n
+0000050286 00000 n
+0000050417 00000 n
+0000050568 00000 n
+0000050903 00000 n
+0000051094 00000 n
+0000051333 00000 n
+0000051520 00000 n
+0000051644 00000 n
+0000051775 00000 n
+0000051926 00000 n
+0000052265 00000 n
+0000052456 00000 n
+0000052695 00000 n
+0000052882 00000 n
+0000053007 00000 n
+0000053138 00000 n
+0000053289 00000 n
+0000053620 00000 n
+0000053812 00000 n
+0000054051 00000 n
+0000054238 00000 n
+0000054363 00000 n
+0000054494 00000 n
+0000054645 00000 n
+0000054980 00000 n
+0000055172 00000 n
+0000055411 00000 n
+0000055598 00000 n
+0000055723 00000 n
+0000055854 00000 n
+0000056005 00000 n
+0000056340 00000 n
+0000056532 00000 n
+0000056771 00000 n
+0000058374 00000 n
+0000059967 00000 n
+0000061566 00000 n
+0000063159 00000 n
+0000064764 00000 n
+0000066367 00000 n
+0000067970 00000 n
+0000069569 00000 n
+0000071156 00000 n
+0000072758 00000 n
+0000074353 00000 n
+0000075950 00000 n
+0000077549 00000 n
+0000079136 00000 n
+0000080755 00000 n
+0000082370 00000 n
+0000083985 00000 n
+0000085596 00000 n
+0000087226 00000 n
+0000088852 00000 n
+0000090479 00000 n
+0000092102 00000 n
+0000093719 00000 n
+0000095328 00000 n
+0000096889 00000 n
+0000098458 00000 n
+0000100027 00000 n
+0000101600 00000 n
+0000103149 00000 n
+0000104710 00000 n
+0000106279 00000 n
+0000107848 00000 n
+0000109421 00000 n
+0000110994 00000 n
+0000112571 00000 n
+0000114148 00000 n
+0000115199 00000 n
+0000115356 00000 n
+0000136111 00000 n
+0000136784 00000 n
+0000136886 00000 n
+trailer
+<<
+/Root 3 0 R 
+/Size 307 
+>>
+startxref
+148289
+%%EOF

--- a/ltml/samples/test_053_avery_labels.ltml
+++ b/ltml/samples/test_053_avery_labels.ltml
@@ -1,0 +1,72 @@
+<ltml xmlns:avery="avery" units="in" margin="0.5" font.name="Helvetica" font.size="12">
+  <style>
+    p.avery-note { font.name: Helvetica; font.size: 8; color: DimGray; left: 0.3in; top: 0.2in; width: 7.9in; }
+    .demo { border: thin; padding: 6pt; }
+    .demo p { font.size: 9; }
+    .demo label { font.weight: Bold; font.size: 10; }
+  </style>
+
+  <page style="letter" margin="0">
+    <p class="avery-note">Avery-compatible label sheets on letter paper.</p>
+    <avery:labelsheet stock="avery5160" show-metrics="true" show-outline="true">
+      <avery:label class="demo"><label>Avery 5160</label><p>Rows fill first.</p></avery:label>
+      <avery:label class="demo"><label>Jamie Smith</label><p>123 Main St<br/>Seattle, WA 98101</p></avery:label>
+      <avery:label class="demo"><label>Morgan Lee</label><p>987 Market Ave<br/>Portland, OR 97205</p></avery:label>
+      <avery:label class="demo"><label>Casey Nguyen</label><p>450 Pine Rd<br/>Boise, ID 83702</p></avery:label>
+    </avery:labelsheet>
+  </page>
+  <page style="letter" margin="0">
+    <p class="avery-note">Avery-compatible label sheets on letter paper.</p>
+    <avery:labelsheet stock="avery5161" show-metrics="true" show-outline="true">
+      <avery:label class="demo"><label>Shipping</label><p>Wide two-column stock.</p></avery:label>
+      <avery:label class="demo"><label>Order 20481</label><p>Hold at front desk.</p></avery:label>
+    </avery:labelsheet>
+  </page>
+  <page style="letter" margin="0">
+    <p class="avery-note">Avery-compatible label sheets on letter paper.</p>
+    <avery:labelsheet stock="avery5162" show-metrics="true" show-outline="true">
+      <avery:label class="demo"><label>Storage</label><p>Box A-17</p></avery:label>
+      <avery:label class="demo"><label>Storage</label><p>Box A-18</p></avery:label>
+    </avery:labelsheet>
+  </page>
+  <page style="letter" margin="0">
+    <p class="avery-note">Avery-compatible label sheets on letter paper.</p>
+    <avery:labelsheet stock="avery5163" show-metrics="true" show-outline="true">
+      <avery:label class="demo"><label>Badge Insert</label><p>Speaker registration packet.</p></avery:label>
+      <avery:label class="demo"><label>Badge Insert</label><p>Workshop materials inside.</p></avery:label>
+    </avery:labelsheet>
+  </page>
+  <page style="letter" margin="0">
+    <p class="avery-note">Avery-compatible label sheets on letter paper.</p>
+    <avery:labelsheet stock="avery5164" show-metrics="true" show-outline="true">
+      <avery:label class="demo"><label>Project Archive</label><p>Long-format labels for bins and shelves.</p></avery:label>
+    </avery:labelsheet>
+  </page>
+  <page style="letter" margin="0">
+    <p class="avery-note">Avery-compatible label sheets on letter paper.</p>
+    <avery:labelsheet stock="avery5167" show-metrics="true" show-outline="true">
+      <avery:label class="demo"><p>Tab 1</p></avery:label>
+      <avery:label class="demo"><p>Tab 2</p></avery:label>
+      <avery:label class="demo"><p>Tab 3</p></avery:label>
+      <avery:label class="demo"><p>Tab 4</p></avery:label>
+      <avery:label class="demo"><p>Tab 5</p></avery:label>
+    </avery:labelsheet>
+  </page>
+  <page style="letter" margin="0">
+    <p class="avery-note">Avery-compatible label sheets on letter paper.</p>
+    <avery:labelsheet stock="avery5366" show-metrics="true" show-outline="true">
+      <avery:label class="demo"><p>2026 Taxes</p></avery:label>
+      <avery:label class="demo"><p>Receipts</p></avery:label>
+      <avery:label class="demo"><p>HR Forms</p></avery:label>
+    </avery:labelsheet>
+  </page>
+  <page style="letter" margin="0">
+    <p class="avery-note">Avery-compatible label sheets on letter paper.</p>
+    <avery:labelsheet stock="avery5395" show-metrics="true" show-outline="true" order="cols">
+      <avery:label class="demo"><label>Alex Rivera</label><p>Guest Speaker</p></avery:label>
+      <avery:label class="demo"><label>Priya Patel</label><p>Organizer</p></avery:label>
+      <avery:label class="demo"><label>Jordan Kim</label><p>Volunteer</p></avery:label>
+      <avery:label class="demo"><label>Sam Taylor</label><p>Sponsor</p></avery:label>
+    </avery:labelsheet>
+  </page>
+</ltml>

--- a/ltml/samples/test_053_avery_labels.pdf
+++ b/ltml/samples/test_053_avery_labels.pdf
@@ -1,0 +1,2790 @@
+%PDF-1.7
+1 0 obj
+<<
+/Count 8 
+/Kids [7 0 R 23 0 R 29 0 R 35 0 R 41 0 R 45 0 R 52 0 R 57 0 R ] 
+/Type /Pages 
+>>
+endobj
+2 0 obj
+<<
+/Count 0 
+/Type /Outlines 
+>>
+endobj
+3 0 obj
+<<
+/MarkInfo <<
+/Marked true 
+>>
+
+/Outlines 2 0 R 
+/PageMode /UseNone 
+/Pages 1 0 R 
+/StructTreeRoot 6 0 R 
+/Type /Catalog 
+>>
+endobj
+4 0 obj
+<<
+/Font <<
+/F0 11 0 R 
+/F1 15 0 R 
+>>
+
+/ProcSet [/PDF /Text /ImageB /ImageC ] 
+>>
+endobj
+5 0 obj
+<<
+/Nums [0 [8 0 R 12 0 R 16 0 R 17 0 R 18 0 R 19 0 R 20 0 R 21 0 R 22 0 R ] 1 [24 0 R 25 0 R 26 0 R 27 0 R 28 0 R ] 2 [30 0 R 31 0 R 32 0 R 33 0 R 34 0 R ] 3 [36 0 R 37 0 R 38 0 R 39 0 R 40 0 R ] 4 [42 0 R 43 0 R 44 0 R ] 5 [46 0 R 47 0 R 48 0 R 49 0 R 50 0 R 51 0 R ] 6 [53 0 R 54 0 R 55 0 R 56 0 R ] 7 [58 0 R 59 0 R 60 0 R 61 0 R 62 0 R 63 0 R 64 0 R 65 0 R 66 0 R ] ] 
+>>
+endobj
+6 0 obj
+<<
+/K [8 0 R 12 0 R 16 0 R 17 0 R 18 0 R 19 0 R 20 0 R 21 0 R 22 0 R 24 0 R 25 0 R 26 0 R 27 0 R 28 0 R 30 0 R 31 0 R 32 0 R 33 0 R 34 0 R 36 0 R 37 0 R 38 0 R 39 0 R 40 0 R 42 0 R 43 0 R 44 0 R 46 0 R 47 0 R 48 0 R 49 0 R 50 0 R 51 0 R 53 0 R 54 0 R 55 0 R 56 0 R 58 0 R 59 0 R 60 0 R 61 0 R 62 0 R 63 0 R 64 0 R 65 0 R 66 0 R ] 
+/ParentTree 5 0 R 
+/ParentTreeNextKey 8 
+/Type /StructTreeRoot 
+>>
+endobj
+7 0 obj
+<<
+/Contents 67 0 R 
+/CropBox [0 0 612 792 ] 
+/Length 2975 
+/MediaBox [0 0 612 792 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 0 
+/Type /Page 
+>>
+endobj
+8 0 obj
+<<
+/ActualText (Avery-compatible label sheets on letter paper.) 
+/K <<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+9 0 obj
+<<
+/Ascent 1577 
+/AvgWidth 0 
+/CapHeight 1469 
+/Descent -471 
+/Flags 0 
+/FontBBox [-1947 -985 2961 2297 ] 
+/FontFamily (Helvetica) 
+/FontFile2 77 0 R 
+/FontName /KKRAYK+Helvetica 
+/ItalicAngle 0 
+/Leading 2048 
+/MaxWidth 0 
+/MissingWidth 0 
+/StemH 0 
+/StemV 87 
+/Type /FontDescriptor 
+/XHeight 1071 
+>>
+endobj
+10 0 obj
+<<
+/BaseFont /KKRAYK+Helvetica 
+/CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> 
+/CIDToGIDMap 76 0 R 
+/DW 556 
+/FontDescriptor 9 0 R 
+/Subtype /CIDFontType2 
+/Type /Font 
+/W [1 [666 500 ] 4 [333 500 333 500 ] 9 [833 ] 12 [277 222 ] 15 [222 277 500 ] 20 [277 500 277 ] 28 [500 ] 31 [583 722 722 277 833 666 277 943 ] 42 [666 777 ] 45 [666 277 722 ] 49 [722 ] 52 [610 610 777 500 666 ] ] 
+>>
+endobj
+11 0 obj
+<<
+/BaseFont /KKRAYK+Helvetica 
+/DescendantFonts [10 0 R ] 
+/Encoding /Identity-H 
+/Subtype /Type0 
+/ToUnicode 75 0 R 
+/Type /Font 
+>>
+endobj
+12 0 obj
+<<
+/ActualText (Avery 5160) 
+/K <<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+13 0 obj
+<<
+/Ascent 1577 
+/AvgWidth 0 
+/CapHeight 1474 
+/Descent -471 
+/Flags 262144 
+/FontBBox [-2084 -985 2810 1971 ] 
+/FontFamily (Helvetica) 
+/FontFile2 80 0 R 
+/FontName /QOYFNH+Helvetica-Bold 
+/ItalicAngle 0 
+/Leading 2048 
+/MaxWidth 0 
+/MissingWidth 0 
+/StemH 0 
+/StemV 165 
+/Type /FontDescriptor 
+/XHeight 1090 
+>>
+endobj
+14 0 obj
+<<
+/BaseFont /QOYFNH+Helvetica-Bold 
+/CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> 
+/CIDToGIDMap 79 0 R 
+/DW 556 
+/FontDescriptor 13 0 R 
+/Subtype /CIDFontType2 
+/Type /Font 
+/W [1 [722 ] 4 [389 ] 6 [277 ] 13 [889 277 666 333 610 833 610 610 610 610 722 ] 25 [722 610 610 777 610 ] 33 [722 277 666 277 ] 38 [277 ] 40 [722 722 610 ] ] 
+>>
+endobj
+15 0 obj
+<<
+/BaseFont /QOYFNH+Helvetica-Bold 
+/DescendantFonts [14 0 R ] 
+/Encoding /Identity-H 
+/Subtype /Type0 
+/ToUnicode 78 0 R 
+/Type /Font 
+>>
+endobj
+16 0 obj
+<<
+/ActualText (Rows fill first.) 
+/K <<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+17 0 obj
+<<
+/ActualText (Jamie Smith) 
+/K <<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+18 0 obj
+<<
+/ActualText (123 Main StSeattle, WA 98101) 
+/K <<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+19 0 obj
+<<
+/ActualText (Morgan Lee) 
+/K <<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+20 0 obj
+<<
+/ActualText (987 Market AvePortland, OR 97205) 
+/K <<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 6 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+21 0 obj
+<<
+/ActualText (Casey Nguyen) 
+/K <<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 7 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+22 0 obj
+<<
+/ActualText (450 Pine RdBoise, ID 83702) 
+/K <<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 8 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+23 0 obj
+<<
+/Contents 68 0 R 
+/CropBox [0 0 612 792 ] 
+/Length 1902 
+/MediaBox [0 0 612 792 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 1 
+/Type /Page 
+>>
+endobj
+24 0 obj
+<<
+/ActualText (Avery-compatible label sheets on letter paper.) 
+/K <<
+/Type /MCR 
+/Pg 23 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+25 0 obj
+<<
+/ActualText (Shipping) 
+/K <<
+/Type /MCR 
+/Pg 23 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+26 0 obj
+<<
+/ActualText (Wide two-column stock.) 
+/K <<
+/Type /MCR 
+/Pg 23 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+27 0 obj
+<<
+/ActualText (Order 20481) 
+/K <<
+/Type /MCR 
+/Pg 23 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+28 0 obj
+<<
+/ActualText (Hold at front desk.) 
+/K <<
+/Type /MCR 
+/Pg 23 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+29 0 obj
+<<
+/Contents 69 0 R 
+/CropBox [0 0 612 792 ] 
+/Length 1649 
+/MediaBox [0 0 612 792 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 2 
+/Type /Page 
+>>
+endobj
+30 0 obj
+<<
+/ActualText (Avery-compatible label sheets on letter paper.) 
+/K <<
+/Type /MCR 
+/Pg 29 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+31 0 obj
+<<
+/ActualText (Storage) 
+/K <<
+/Type /MCR 
+/Pg 29 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+32 0 obj
+<<
+/ActualText (Box A-17) 
+/K <<
+/Type /MCR 
+/Pg 29 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+33 0 obj
+<<
+/ActualText (Storage) 
+/K <<
+/Type /MCR 
+/Pg 29 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+34 0 obj
+<<
+/ActualText (Box A-18) 
+/K <<
+/Type /MCR 
+/Pg 29 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+35 0 obj
+<<
+/Contents 70 0 R 
+/CropBox [0 0 612 792 ] 
+/Length 1767 
+/MediaBox [0 0 612 792 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 3 
+/Type /Page 
+>>
+endobj
+36 0 obj
+<<
+/ActualText (Avery-compatible label sheets on letter paper.) 
+/K <<
+/Type /MCR 
+/Pg 35 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+37 0 obj
+<<
+/ActualText (Badge Insert) 
+/K <<
+/Type /MCR 
+/Pg 35 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+38 0 obj
+<<
+/ActualText (Speaker registration packet.) 
+/K <<
+/Type /MCR 
+/Pg 35 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+39 0 obj
+<<
+/ActualText (Badge Insert) 
+/K <<
+/Type /MCR 
+/Pg 35 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+40 0 obj
+<<
+/ActualText (Workshop materials inside.) 
+/K <<
+/Type /MCR 
+/Pg 35 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+41 0 obj
+<<
+/Contents 71 0 R 
+/CropBox [0 0 612 792 ] 
+/Length 1336 
+/MediaBox [0 0 612 792 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 4 
+/Type /Page 
+>>
+endobj
+42 0 obj
+<<
+/ActualText (Avery-compatible label sheets on letter paper.) 
+/K <<
+/Type /MCR 
+/Pg 41 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+43 0 obj
+<<
+/ActualText (Project Archive) 
+/K <<
+/Type /MCR 
+/Pg 41 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+44 0 obj
+<<
+/ActualText (Long-format labels for bins and shelves.) 
+/K <<
+/Type /MCR 
+/Pg 41 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+45 0 obj
+<<
+/Contents 72 0 R 
+/CropBox [0 0 612 792 ] 
+/Length 3188 
+/MediaBox [0 0 612 792 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 5 
+/Type /Page 
+>>
+endobj
+46 0 obj
+<<
+/ActualText (Avery-compatible label sheets on letter paper.) 
+/K <<
+/Type /MCR 
+/Pg 45 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+47 0 obj
+<<
+/ActualText (Tab 1) 
+/K <<
+/Type /MCR 
+/Pg 45 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+48 0 obj
+<<
+/ActualText (Tab 2) 
+/K <<
+/Type /MCR 
+/Pg 45 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+49 0 obj
+<<
+/ActualText (Tab 3) 
+/K <<
+/Type /MCR 
+/Pg 45 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+50 0 obj
+<<
+/ActualText (Tab 4) 
+/K <<
+/Type /MCR 
+/Pg 45 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+51 0 obj
+<<
+/ActualText (Tab 5) 
+/K <<
+/Type /MCR 
+/Pg 45 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+52 0 obj
+<<
+/Contents 73 0 R 
+/CropBox [0 0 612 792 ] 
+/Length 2019 
+/MediaBox [0 0 612 792 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 6 
+/Type /Page 
+>>
+endobj
+53 0 obj
+<<
+/ActualText (Avery-compatible label sheets on letter paper.) 
+/K <<
+/Type /MCR 
+/Pg 52 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+54 0 obj
+<<
+/ActualText (2026 Taxes) 
+/K <<
+/Type /MCR 
+/Pg 52 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+55 0 obj
+<<
+/ActualText (Receipts) 
+/K <<
+/Type /MCR 
+/Pg 52 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+56 0 obj
+<<
+/ActualText (HR Forms) 
+/K <<
+/Type /MCR 
+/Pg 52 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+57 0 obj
+<<
+/Contents 74 0 R 
+/CropBox [0 0 612 792 ] 
+/Length 2274 
+/MediaBox [0 0 612 792 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 7 
+/Type /Page 
+>>
+endobj
+58 0 obj
+<<
+/ActualText (Avery-compatible label sheets on letter paper.) 
+/K <<
+/Type /MCR 
+/Pg 57 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+59 0 obj
+<<
+/ActualText (Alex Rivera) 
+/K <<
+/Type /MCR 
+/Pg 57 0 R 
+/MCID 1 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+60 0 obj
+<<
+/ActualText (Guest Speaker) 
+/K <<
+/Type /MCR 
+/Pg 57 0 R 
+/MCID 2 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+61 0 obj
+<<
+/ActualText (Priya Patel) 
+/K <<
+/Type /MCR 
+/Pg 57 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+62 0 obj
+<<
+/ActualText (Organizer) 
+/K <<
+/Type /MCR 
+/Pg 57 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+63 0 obj
+<<
+/ActualText (Jordan Kim) 
+/K <<
+/Type /MCR 
+/Pg 57 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+64 0 obj
+<<
+/ActualText (Volunteer) 
+/K <<
+/Type /MCR 
+/Pg 57 0 R 
+/MCID 6 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+65 0 obj
+<<
+/ActualText (Sam Taylor) 
+/K <<
+/Type /MCR 
+/Pg 57 0 R 
+/MCID 7 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+66 0 obj
+<<
+/ActualText (Sponsor) 
+/K <<
+/Type /MCR 
+/Pg 57 0 R 
+/MCID 8 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+67 0 obj
+<<
+/Length 2975 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+21.6 771.4398 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 8 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b000c000d000e000f00030010000f000b000e0003000f00100011001200030003000c00110010000800130010000f0003000c000c000300040010000a000b000a000300040014> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+ET
+0.4118 0.4118 0.4118 RG
+0.4 w
+[] 0 d
+0 J
+13.5 684 189 72 re
+S
+211.5 684 189 72 re
+S
+409.5 684 189 72 re
+S
+13.5 612 189 72 re
+S
+211.5 612 189 72 re
+S
+409.5 612 189 72 re
+S
+13.5 540 189 72 re
+S
+211.5 540 189 72 re
+S
+409.5 540 189 72 re
+S
+13.5 468 189 72 re
+S
+211.5 468 189 72 re
+S
+409.5 468 189 72 re
+S
+13.5 396 189 72 re
+S
+211.5 396 189 72 re
+S
+409.5 396 189 72 re
+S
+13.5 324 189 72 re
+S
+211.5 324 189 72 re
+S
+409.5 324 189 72 re
+S
+13.5 252 189 72 re
+S
+211.5 252 189 72 re
+S
+409.5 252 189 72 re
+S
+13.5 180 189 72 re
+S
+211.5 180 189 72 re
+S
+409.5 180 189 72 re
+S
+13.5 108 189 72 re
+S
+211.5 108 189 72 re
+S
+409.5 108 189 72 re
+S
+13.5 36 189 72 re
+S
+211.5 36 189 72 re
+S
+409.5 36 189 72 re
+S
+BT
+6 778 Td
+0.4118 0.4118 0.4118 rg
+/F0 10 Tf
+0 Ts
+<0001000200030004000500100011000c00080007001500160010000b0002000300040005001700180019001a00100010001b00140019001b0017000d00130010001c001000180014001a001a001a000d001300100010001d001c0018001a0010001000080004001e00030004001f0004000800200011> Tj
+/Artifact BMC
+EMC
+/Artifact BMC
+ET
+0 0 0 RG
+0 w
+13.5 684 189 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+19.5 742.2998 Td
+/P <<
+/MCID 1 
+>>
+BDC
+0 0 0 rg
+/F1 10 Tf
+0 Ts
+<000100020003000400050006000700080009000a> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -9.23 Td
+/P <<
+/MCID 2 
+>>
+BDC
+/F0 9 Tf
+0 Ts
+<002100080020001100100022000d000f000f00100022000d00040011000c0014> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+ET
+211.5 684 189 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+217.5 742.2998 Td
+/P <<
+/MCID 3 
+>>
+BDC
+/F1 10 Tf
+0 Ts
+<000b000c000d000e00030006000f000d000e00100011> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -9.23 Td
+/P <<
+/MCID 4 
+>>
+BDC
+/F0 9 Tf
+0 Ts
+<0018001b001d00100023000b000d001300100024000c00240003000b000c000c000f000300250010002600010010002700280018001a0018> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+ET
+409.5 684 189 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+415.5 742.2998 Td
+/P <<
+/MCID 5 
+>>
+BDC
+/F1 10 Tf
+0 Ts
+<0012001300040014000c00150006001600030003> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -9.23 Td
+/P <<
+/MCID 6 
+>>
+BDC
+/F0 9 Tf
+0 Ts
+<00270028002900100023000b000400150003000c0010000100020003002a00080004000c000f000b0013001e00250010002b0021001000270029001b001a0017> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+ET
+13.5 612 189 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+19.5 670.2998 Td
+/P <<
+/MCID 7 
+>>
+BDC
+/F1 10 Tf
+0 Ts
+<0017000c001800030005000600190014001a000500030015> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -9.23 Td
+/P <<
+/MCID 8 
+>>
+BDC
+/F0 9 Tf
+0 Ts
+<002c0017001a0010002a000d0013000300100021001e002d0008000d0011000300250010002e002f00100028001d0029001a001b> Tj
+EMC
+ET
+endstream
+endobj
+68 0 obj
+<<
+/Length 1902 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+21.6 771.4398 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 8 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b000c000d000e000f00030010000f000b000e0003000f00100011001200030003000c00110010000800130010000f0003000c000c000300040010000a000b000a000300040014> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+ET
+0.4118 0.4118 0.4118 RG
+0.4 w
+[] 0 d
+0 J
+13.5 684 288 72 re
+S
+310.5 684 288 72 re
+S
+13.5 612 288 72 re
+S
+310.5 612 288 72 re
+S
+13.5 540 288 72 re
+S
+310.5 540 288 72 re
+S
+13.5 468 288 72 re
+S
+310.5 468 288 72 re
+S
+13.5 396 288 72 re
+S
+310.5 396 288 72 re
+S
+13.5 324 288 72 re
+S
+310.5 324 288 72 re
+S
+13.5 252 288 72 re
+S
+310.5 252 288 72 re
+S
+13.5 180 288 72 re
+S
+310.5 180 288 72 re
+S
+13.5 108 288 72 re
+S
+310.5 108 288 72 re
+S
+13.5 36 288 72 re
+S
+310.5 36 288 72 re
+S
+BT
+6 778 Td
+0.4118 0.4118 0.4118 rg
+/F0 10 Tf
+0 Ts
+<0001000200030004000500100011000c00080007001500160010000b0002000300040005001700180019001800100010002c0014001a001a001a000d00130010001c001000180014001a001a001a000d001300100010001b001c0018001a0010001000080004001e00030004001f0004000800200011> Tj
+/Artifact BMC
+EMC
+/Artifact BMC
+ET
+0 0 0 RG
+0 w
+13.5 684 288 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+19.5 742.2998 Td
+/P <<
+/MCID 1 
+>>
+BDC
+0 0 0 rg
+/F1 10 Tf
+0 Ts
+<000f0011000e001b001b000e00150014> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -9.23 Td
+/P <<
+/MCID 2 
+>>
+BDC
+/F0 9 Tf
+0 Ts
+<0026000d001e00030010000c00200008000600070008000f00300009001300100011000c0008000700150014> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+ET
+310.5 684 288 72 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+316.5 742.2998 Td
+/P <<
+/MCID 3 
+>>
+BDC
+/F1 10 Tf
+0 Ts
+<001c0004001d000300040006001e000a001f00200008> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -9.23 Td
+/P <<
+/MCID 4 
+>>
+BDC
+/F0 9 Tf
+0 Ts
+<00310008000f001e0010000b000c00100022000400080013000c0010001e0003001100150014> Tj
+EMC
+ET
+endstream
+endobj
+69 0 obj
+<<
+/Length 1649 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+21.6 771.4398 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 8 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b000c000d000e000f00030010000f000b000e0003000f00100011001200030003000c00110010000800130010000f0003000c000c000300040010000a000b000a000300040014> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+ET
+0.4118 0.4118 0.4118 RG
+0.4 w
+[] 0 d
+0 J
+13.5 660 288 96 re
+S
+310.5 660 288 96 re
+S
+13.5 564 288 96 re
+S
+310.5 564 288 96 re
+S
+13.5 468 288 96 re
+S
+310.5 468 288 96 re
+S
+13.5 372 288 96 re
+S
+310.5 372 288 96 re
+S
+13.5 276 288 96 re
+S
+310.5 276 288 96 re
+S
+13.5 180 288 96 re
+S
+310.5 180 288 96 re
+S
+13.5 84 288 96 re
+S
+310.5 84 288 96 re
+S
+BT
+6 778 Td
+0.4118 0.4118 0.4118 rg
+/F0 10 Tf
+0 Ts
+<0001000200030004000500100011000c00080007001500160010000b0002000300040005001700180019001b00100010002c0014001a001a001a000d00130010001c001000180014001d001d001d000d001300100010001b001c00290010001000080004001e00030004001f0004000800200011> Tj
+/Artifact BMC
+EMC
+/Artifact BMC
+ET
+0 0 0 RG
+0 w
+13.5 660 288 96 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+19.5 742.2998 Td
+/P <<
+/MCID 1 
+>>
+BDC
+0 0 0 rg
+/F1 10 Tf
+0 Ts
+<000f001000130004000c00140003> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -9.23 Td
+/P <<
+/MCID 2 
+>>
+BDC
+/F0 9 Tf
+0 Ts
+<002d0008001c00100001000600180029> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+ET
+310.5 660 288 96 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+316.5 742.2998 Td
+/P <<
+/MCID 3 
+>>
+BDC
+/F1 10 Tf
+0 Ts
+<000f001000130004000c00140003> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -9.23 Td
+/P <<
+/MCID 4 
+>>
+BDC
+/F0 9 Tf
+0 Ts
+<002d0008001c00100001000600180028> Tj
+EMC
+ET
+endstream
+endobj
+70 0 obj
+<<
+/Length 1767 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+21.6 771.4398 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 8 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b000c000d000e000f00030010000f000b000e0003000f00100011001200030003000c00110010000800130010000f0003000c000c000300040010000a000b000a000300040014> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+ET
+0.4118 0.4118 0.4118 RG
+0.4 w
+[] 0 d
+0 J
+13.5 612 288 144 re
+S
+310.5 612 288 144 re
+S
+13.5 468 288 144 re
+S
+310.5 468 288 144 re
+S
+13.5 324 288 144 re
+S
+310.5 324 288 144 re
+S
+13.5 180 288 144 re
+S
+310.5 180 288 144 re
+S
+13.5 36 288 144 re
+S
+310.5 36 288 144 re
+S
+BT
+6 778 Td
+0.4118 0.4118 0.4118 rg
+/F0 10 Tf
+0 Ts
+<0001000200030004000500100011000c00080007001500160010000b0002000300040005001700180019001d00100010002c0014001a001a001a000d00130010001c0010001b0014001a001a001a000d001300100010001b001c00170010001000080004001e00030004001f0004000800200011> Tj
+/Artifact BMC
+EMC
+/Artifact BMC
+ET
+0 0 0 RG
+0 w
+13.5 612 288 144 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+19.5 742.2998 Td
+/P <<
+/MCID 1 
+>>
+BDC
+0 0 0 rg
+/F1 10 Tf
+0 Ts
+<0021000c001d001400030006002200150018000300040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -9.23 Td
+/P <<
+/MCID 2 
+>>
+BDC
+/F0 9 Tf
+0 Ts
+<0024000a0003000b0015000300040010000400030032000d0011000c0004000b000c000d000800130010000a000b000700150003000c0014> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+ET
+310.5 612 288 144 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+316.5 742.2998 Td
+/P <<
+/MCID 3 
+>>
+BDC
+/F1 10 Tf
+0 Ts
+<0021000c001d001400030006002200150018000300040010> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -9.23 Td
+/P <<
+/MCID 4 
+>>
+BDC
+/F0 9 Tf
+0 Ts
+<0026000800040015001100120008000a00100009000b000c00030004000d000b000f00110010000d00130011000d001e00030014> Tj
+EMC
+ET
+endstream
+endobj
+71 0 obj
+<<
+/Length 1336 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+21.6 771.4398 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 8 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b000c000d000e000f00030010000f000b000e0003000f00100011001200030003000c00110010000800130010000f0003000c000c000300040010000a000b000a000300040014> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+ET
+0.4118 0.4118 0.4118 RG
+0.4 w
+[] 0 d
+0 J
+11.25 468 240 288 re
+S
+312.75 468 240 288 re
+S
+11.25 216 240 288 re
+S
+312.75 216 240 288 re
+S
+11.25 -36 240 288 re
+S
+312.75 -36 240 288 re
+S
+BT
+6 778 Td
+0.4118 0.4118 0.4118 rg
+/F0 10 Tf
+0 Ts
+<0001000200030004000500100011000c00080007001500160010000b0002000300040005001700180019002c00100010001d0014001d001d001d000d00130010001c0010002c0014001a001a001a000d001300100010001b001c001d0010001000080004001e00030004001f0004000800200011> Tj
+/Artifact BMC
+EMC
+/Artifact BMC
+ET
+0 0 0 RG
+0 w
+11.25 468 240 288 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+17.25 742.2998 Td
+/P <<
+/MCID 1 
+>>
+BDC
+0 0 0 rg
+/F1 10 Tf
+0 Ts
+<002300040013002400030025001000060001000400250011000e00020003> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -9.23 Td
+/P <<
+/MCID 2 
+>>
+BDC
+/F0 9 Tf
+0 Ts
+<003300080013003200060022000800040009000b000c0010000f000b000e0003000f001100100022000800040010000e000d001300110010000b0013001e0010001100120003000f0002000300110014> Tj
+EMC
+ET
+endstream
+endobj
+72 0 obj
+<<
+/Length 3188 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+21.6 771.4398 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 8 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b000c000d000e000f00030010000f000b000e0003000f00100011001200030003000c00110010000800130010000f0003000c000c000300040010000a000b000a000300040014> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+ET
+0.4118 0.4118 0.4118 RG
+0.4 w
+[] 0 d
+0 J
+18 720 126 36 re
+S
+162 720 126 36 re
+S
+306 720 126 36 re
+S
+450 720 126 36 re
+S
+18 684 126 36 re
+S
+162 684 126 36 re
+S
+306 684 126 36 re
+S
+450 684 126 36 re
+S
+18 648 126 36 re
+S
+162 648 126 36 re
+S
+306 648 126 36 re
+S
+450 648 126 36 re
+S
+18 612 126 36 re
+S
+162 612 126 36 re
+S
+306 612 126 36 re
+S
+450 612 126 36 re
+S
+18 576 126 36 re
+S
+162 576 126 36 re
+S
+306 576 126 36 re
+S
+450 576 126 36 re
+S
+18 540 126 36 re
+S
+162 540 126 36 re
+S
+306 540 126 36 re
+S
+450 540 126 36 re
+S
+18 504 126 36 re
+S
+162 504 126 36 re
+S
+306 504 126 36 re
+S
+450 504 126 36 re
+S
+18 468 126 36 re
+S
+162 468 126 36 re
+S
+306 468 126 36 re
+S
+450 468 126 36 re
+S
+18 432 126 36 re
+S
+162 432 126 36 re
+S
+306 432 126 36 re
+S
+450 432 126 36 re
+S
+18 396 126 36 re
+S
+162 396 126 36 re
+S
+306 396 126 36 re
+S
+450 396 126 36 re
+S
+18 360 126 36 re
+S
+162 360 126 36 re
+S
+306 360 126 36 re
+S
+450 360 126 36 re
+S
+18 324 126 36 re
+S
+162 324 126 36 re
+S
+306 324 126 36 re
+S
+450 324 126 36 re
+S
+18 288 126 36 re
+S
+162 288 126 36 re
+S
+306 288 126 36 re
+S
+450 288 126 36 re
+S
+18 252 126 36 re
+S
+162 252 126 36 re
+S
+306 252 126 36 re
+S
+450 252 126 36 re
+S
+18 216 126 36 re
+S
+162 216 126 36 re
+S
+306 216 126 36 re
+S
+450 216 126 36 re
+S
+18 180 126 36 re
+S
+162 180 126 36 re
+S
+306 180 126 36 re
+S
+450 180 126 36 re
+S
+18 144 126 36 re
+S
+162 144 126 36 re
+S
+306 144 126 36 re
+S
+450 144 126 36 re
+S
+18 108 126 36 re
+S
+162 108 126 36 re
+S
+306 108 126 36 re
+S
+450 108 126 36 re
+S
+18 72 126 36 re
+S
+162 72 126 36 re
+S
+306 72 126 36 re
+S
+450 72 126 36 re
+S
+18 36 126 36 re
+S
+162 36 126 36 re
+S
+306 36 126 36 re
+S
+450 36 126 36 re
+S
+BT
+6 778 Td
+0.4118 0.4118 0.4118 rg
+/F0 10 Tf
+0 Ts
+<0001000200030004000500100011000c00080007001500160010000b00020003000400050017001800190029001000100018001400290017001a000d00130010001c0010001a00140017001a001a000d001300100010002c001c001b001a0010001000080004001e00030004001f0004000800200011> Tj
+/Artifact BMC
+EMC
+/Artifact BMC
+ET
+0 0 0 RG
+0 w
+18 720 126 36 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+24 743.0698 Td
+/P <<
+/MCID 1 
+>>
+BDC
+0 0 0 rg
+/F0 9 Tf
+0 Ts
+<0034000b000e00100018> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+ET
+162 720 126 36 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+168 743.0698 Td
+/P <<
+/MCID 2 
+>>
+BDC
+/F0 9 Tf
+0 Ts
+<0034000b000e0010001b> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+ET
+306 720 126 36 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+312 743.0698 Td
+/P <<
+/MCID 3 
+>>
+BDC
+/F0 9 Tf
+0 Ts
+<0034000b000e0010001d> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+ET
+450 720 126 36 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+456 743.0698 Td
+/P <<
+/MCID 4 
+>>
+BDC
+/F0 9 Tf
+0 Ts
+<0034000b000e0010002c> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+ET
+18 684 126 36 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+24 707.0698 Td
+/P <<
+/MCID 5 
+>>
+BDC
+/F0 9 Tf
+0 Ts
+<0034000b000e00100017> Tj
+EMC
+ET
+endstream
+endobj
+73 0 obj
+<<
+/Length 2019 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+21.6 771.4398 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 8 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b000c000d000e000f00030010000f000b000e0003000f00100011001200030003000c00110010000800130010000f0003000c000c000300040010000a000b000a000300040014> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+ET
+0.4118 0.4118 0.4118 RG
+0.4 w
+[] 0 d
+0 J
+40.5 708 247.5 48 re
+S
+319.5 708 247.5 48 re
+S
+40.5 660 247.5 48 re
+S
+319.5 660 247.5 48 re
+S
+40.5 612 247.5 48 re
+S
+319.5 612 247.5 48 re
+S
+40.5 564 247.5 48 re
+S
+319.5 564 247.5 48 re
+S
+40.5 516 247.5 48 re
+S
+319.5 516 247.5 48 re
+S
+40.5 468 247.5 48 re
+S
+319.5 468 247.5 48 re
+S
+40.5 420 247.5 48 re
+S
+319.5 420 247.5 48 re
+S
+40.5 372 247.5 48 re
+S
+319.5 372 247.5 48 re
+S
+40.5 324 247.5 48 re
+S
+319.5 324 247.5 48 re
+S
+40.5 276 247.5 48 re
+S
+319.5 276 247.5 48 re
+S
+40.5 228 247.5 48 re
+S
+319.5 228 247.5 48 re
+S
+40.5 180 247.5 48 re
+S
+319.5 180 247.5 48 re
+S
+40.5 132 247.5 48 re
+S
+319.5 132 247.5 48 re
+S
+40.5 84 247.5 48 re
+S
+319.5 84 247.5 48 re
+S
+40.5 36 247.5 48 re
+S
+319.5 36 247.5 48 re
+S
+BT
+6 778 Td
+0.4118 0.4118 0.4118 rg
+/F0 10 Tf
+0 Ts
+<0001000200030004000500100011000c00080007001500160010000b00020003000400050017001d0019001900100010001d0014002c001d0028000d00130010001c0010001a0014001900190029000d001300100010001b001c001800170010001000080004001e00030004001f0004000800200011> Tj
+/Artifact BMC
+EMC
+/Artifact BMC
+ET
+0 0 0 RG
+0 w
+40.5 708 247.5 48 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+46.5 743.0698 Td
+/P <<
+/MCID 1 
+>>
+BDC
+0 0 0 rg
+/F0 9 Tf
+0 Ts
+<001b001a001b001900100034000b001c00030011> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+ET
+319.5 708 247.5 48 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+325.5 743.0698 Td
+/P <<
+/MCID 2 
+>>
+BDC
+/F0 9 Tf
+0 Ts
+<0021000300070003000d000a000c0011> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+ET
+40.5 660 247.5 48 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+46.5 695.0698 Td
+/P <<
+/MCID 3 
+>>
+BDC
+/F0 9 Tf
+0 Ts
+<00310021001000350008000400090011> Tj
+EMC
+ET
+endstream
+endobj
+74 0 obj
+<<
+/Length 2274 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+21.6 771.4398 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 8 Tf
+0 Ts
+<000100020003000400050006000700080009000a000b000c000d000e000f00030010000f000b000e0003000f00100011001200030003000c00110010000800130010000f0003000c000c000300040010000a000b000a000300040014> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+ET
+0.4118 0.4118 0.4118 RG
+0.4 w
+[] 0 d
+0 J
+49.5 584.4 243 168 re
+S
+319.5 584.4 243 168 re
+S
+49.5 402.72 243 168 re
+S
+319.5 402.72 243 168 re
+S
+49.5 221.04 243 168 re
+S
+319.5 221.04 243 168 re
+S
+49.5 39.36 243 168 re
+S
+319.5 39.36 243 168 re
+S
+BT
+6 778 Td
+0.4118 0.4118 0.4118 rg
+/F0 10 Tf
+0 Ts
+<0001000200030004000500100011000c00080007001500160010000b00020003000400050017001d0027001700100010001d0014001d00290017000d00130010001c0010001b0014001d001d001d000d001300100010001b001c002c0010001000080004001e00030004001f00070008000f0011> Tj
+/Artifact BMC
+EMC
+/Artifact BMC
+ET
+0 0 0 RG
+0 w
+49.5 584.4 243 168 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+55.5 738.6998 Td
+/P <<
+/MCID 1 
+>>
+BDC
+0 0 0 rg
+/F1 10 Tf
+0 Ts
+<000100260003002700060028000e000200030004000c> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -9.23 Td
+/P <<
+/MCID 2 
+>>
+BDC
+/F0 9 Tf
+0 Ts
+<0036003000030011000c00100024000a0003000b001500030004> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+ET
+49.5 402.72 243 168 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+55.5 557.0198 Td
+/P <<
+/MCID 3 
+>>
+BDC
+/F1 10 Tf
+0 Ts
+<00230004000e0005000c00060023000c001000030026> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -9.23 Td
+/P <<
+/MCID 4 
+>>
+BDC
+/F0 9 Tf
+0 Ts
+<002b00040032000b0013000d003700030004> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+ET
+49.5 221.04 243 168 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+55.5 375.3398 Td
+/P <<
+/MCID 5 
+>>
+BDC
+/F1 10 Tf
+0 Ts
+<000b00130004001d000c001500060029000e000d> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -9.23 Td
+/P <<
+/MCID 6 
+>>
+BDC
+/F0 9 Tf
+0 Ts
+<00380008000f00300013000c000300030004> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+ET
+49.5 39.36 243 168 re
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+55.5 193.6598 Td
+/P <<
+/MCID 7 
+>>
+BDC
+/F1 10 Tf
+0 Ts
+<000f000c000d0006002a000c0005002600130004> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -9.23 Td
+/P <<
+/MCID 8 
+>>
+BDC
+/F0 9 Tf
+0 Ts
+<0024000a00080013001100080004> Tj
+EMC
+ET
+endstream
+endobj
+75 0 obj
+<<
+/Length 1068 
+>>
+stream
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo << /Registry (Adobe) /Ordering (UCS) /Supplement 0 >> def
+/CMapName /Adobe-Identity-UCS def
+/CMapType 2 def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+56 beginbfchar
+<0001> <0041>
+<0002> <0076>
+<0003> <0065>
+<0004> <0072>
+<0005> <0079>
+<0006> <002D>
+<0007> <0063>
+<0008> <006F>
+<0009> <006D>
+<000A> <0070>
+<000B> <0061>
+<000C> <0074>
+<000D> <0069>
+<000E> <0062>
+<000F> <006C>
+<0010> <0020>
+<0011> <0073>
+<0012> <0068>
+<0013> <006E>
+<0014> <002E>
+<0015> <006B>
+<0016> <003A>
+<0017> <0035>
+<0018> <0031>
+<0019> <0036>
+<001A> <0030>
+<001B> <0032>
+<001C> <0078>
+<001D> <0033>
+<001E> <0064>
+<001F> <003D>
+<0020> <0077>
+<0021> <0052>
+<0022> <0066>
+<0023> <004D>
+<0024> <0053>
+<0025> <002C>
+<0026> <0057>
+<0027> <0039>
+<0028> <0038>
+<0029> <0037>
+<002A> <0050>
+<002B> <004F>
+<002C> <0034>
+<002D> <0042>
+<002E> <0049>
+<002F> <0044>
+<0030> <0075>
+<0031> <0048>
+<0032> <0067>
+<0033> <004C>
+<0034> <0054>
+<0035> <0046>
+<0036> <0047>
+<0037> <007A>
+<0038> <0056>
+endbfchar
+endcmap
+CMap end
+end
+endstream
+endobj
+76 0 obj
+<<
+/Length 114 
+>>
+stream
+   $ Y H U \  F R P S D W L E O  V K Q  N       [  G   Z 5 I 0 6  :    3 2  % , ' X + J / 7 ) * ] 9endstream
+endobj
+77 0 obj
+<<
+/Length 20380 
+/Length1 20380 
+>>
+stream
+     Ä  POS/2G$N   ‹   `cmapπ  <  cvt ò"A€  H  åfpgmR≈≠'  ‘  êglyfÔm≥Z  d  .`head°Gı  ?ƒ   6hhea
+"v  ?¸   $hmtxã±!  @   xloca ª(  Aò  |maxp“}  C    nameqFSy  C4  postf◊  JL   ﬁprepƒqä  K,  n àê   ô3  ô3  – f             ‡ ˇP x[        pyrs @ 	˚ ˛§ =öÕ  üO  /Ω                      ¯         . : = B D I M P T W i p zˇˇ     , 0 = A D F L O R V a k rˇˇ                                 " 6 6 8 8 > @ B F H X b                    $ % ' ) * + , / 0 2 3 5 6 7 9 : D E F G H I J K L N O P Q R S U V W X Y Z [ \ ]¿ Ω (Ä /   ˇŸ  ˇ⁄  ˇŸ˛UˇÊ« ˛mˇÒ;   π   π˛?< ¿ ç õ Ø  ® ¿ ( ^ ò …j π\ ¥ ÷ . Ä  ∏ L Ãˇˇ— f § Ø t ¬ ï ±  ( m  L é%ˇz  @ L b Ñˇ¢ $ 8 Ü Ω 9 ^ é Ìˇ©ˇ≥ @ R U ™ ´ ¬ À#±ˇÆˇ‰  Q t Ñ ™ —ˇLˇØ  , B P Q Ñ æ%⁄ˇh  ; ò ú ü ° ¡ ÏÇ¥ˇhˇvˇ–ˇ·    S S }¥·ØÜˇúˇÍˇ˛  ( * R ` ì £ ™ Ø Ø ¿ Ektìï@Ç¥Ö˛˝  ) G G H o à ¥ π ƒ Ú ˘Ôt≈ˇ5ˇÛ  K L R U e v v á á é ´ ª0CP}îï”*UXwxÊN\y”s≤åò˛ıˇªˇ«ˇ’   [ r ~ ú ¬ – Ù ˙%;B^^Äõπ°πP¿–™ﬂ„Ô˚+tì´¬Œiïôﬂı>°Â%€˛b˛â˛Œˇ;ˇ·ˇ¯   ! 9 B N _ a o p 4  é ≠ ≠ Ø Ω ƒ ≈ … … … „ Ì ¯ ˘ 2MMNOfiû∫∫æ„Ôˆ  	SbmÄ’Ä*JZØØ»÷˚˚GI åmöö¶®≤œ9>NVÄâåc—÷~é≤Ô(Loå ¥ … ¿ ¡             $ Ø 2 n cDb ñC°a ä t dàÔp (ˇ]~G0 ™ æ { b ö } â\ °ˇÿ™ ◊ ì l   Ä ßB ó  Ç 0 * * * * * * ì v † ¨ ∏ ´ ≈   +˛U / !æ '@)*)('&%$#"! 
+	 ,E#F` ∞&`∞&#HH-,E#F#a ∞&a∞&#HH-,E#F`∞ a ∞F`∞&#HH-,E#F#a∞ ` ∞&a∞ a∞&#HH-,E#F`∞@a ∞f`∞&#HH-,E#F#a∞@` ∞&a∞@a∞&#HH-, < <-, E# ∞ÕD# ∏ZQX# ∞çD#Y ∞ÌQX# ∞MD#Y ∞êQX# ∞D#Y!!-,  EhD ∞` E∞FvhäE`D-,π@   
+-, π  @ -, E∞ Ca}h∞ C`D-,E∞#DE∞#D-, E∞%Ead∞PQXED!!Y-, ∞%RX#Y!-,i∞@a∞ ãd#dã∏@ b`d#da\X∞aY∞`-,E∞+∞#D∞zÂ-,E∞+∞#D-,E∞+∞Eå∞#D∞zÂ-,∞%FaeäF∞@`ãH-,∞%F`äF∞@aåH-,KS \X∞ÖYX∞ÖY-, ∞%E∞#jDE∞#DEe#E ∞%`j ∞	#B#häj`a ∞ RX≤@E#aDY∞ PX≤@E#aDY-,π~;!-,π-A-A-,π;!~-,π;!ÁÉ-,π-A“¿-,π~ƒ‡-,KRXED!!Y-, ∞%#I∞@`∞ c ∞ RX#∞%8#∞%e8 äc8!!!!!Y-,Ei ∞	C∞&`∞%∞%Ia∞ÄSX≤@E#ahD≤@E#`jD≤	Ee#E`BY∞	C`ä:-,∞%# äı ∞`#ÌÏ-,∞%# äı ∞a#ÌÏ-,∞%ı ÌÏ-, ∞` < <-, ∞a < <-,vE ∞%E#ah#h`D-,vE∞%E#ah#Eh`D-,vE∞%Eah#E#aD-,Ei∞∞2KPX!∞ YaD-∏ +,K∏ 	PX±éY∏ˇÖ∏ Dπ 	 _^-∏ ,,  EiD∞`-∏ -,∏ ,*!-∏ ., F∞%FRX#Y ä äIdä F had∞%F hadRX#eäY/ ∞ SXi ∞ TX!∞@Yi ∞ TX!∞@eYY:-∏ /, F∞%FRX#äY F jad∞%F jadRX#äY/˝-∏ 0,K ∞&PXQX∞ÄD∞@DY!! E∞¿PX∞¿D!YY-∏ 1,  EiD∞`  E}iD∞`-∏ 2,∏ 1*-∏ 3,K ∞&SX∞Ä∞@Yää ∞&SX#!∞¿äää#Y ∞&SX#!∏ äää#Y ∞&SX#!∏@äää#Y ∏ &SX∞%E∏ÄPX#!∏Ä#!∞%E#!#!Y!YD-∏ 4,KSXED!!Y-∏ 5,K∏ 	PX±éY∏ˇÖ∏ Dπ 	 _^-∏ 6,  EiD∞`-∏ 7,∏ 6*!-∏ 8, F∞%FRX#Y ä äIdä F had∞%F hadRX#eäY/ ∞ SXi ∞ TX!∞@Yi ∞ TX!∞@eYY:-∏ 9, F∞%FRX#äY F jad∞%F jadRX#äY/˝-∏ :,K ∞&PXQX∞ÄD∞@DY!! E∞¿PX∞¿D!YY-∏ ;,  EiD∞`  E}iD∞`-∏ <,∏ ;*-∏ =,K ∞&SX∞Ä∞@Yää ∞&SX#!∞¿äää#Y ∞&SX#!∏ äää#Y ∞&SX#!∏@äää#Y ∏ &SX∞%E∏ÄPX#!∏Ä#!∞%E#!#!Y!YD-∏ >,KSXED!!Y-∏ ?,K∏ 	PX±éY∏ˇÖ∏ Dπ 	 _^-∏ @,  EiD∞`-∏ A,∏ @*!-∏ B, F∞%FRX#Y ä äIdä F had∞%F hadRX#eäY/ ∞ SXi ∞ TX!∞@Yi ∞ TX!∞@eYY:-∏ C, F∞%FRX#äY F jad∞%F jadRX#äY/˝-∏ D,K ∞&PXQX∞ÄD∞@DY!! E∞¿PX∞¿D!YY-∏ E,  EiD∞`  E}iD∞`-∏ F,∏ E*-∏ G,K ∞&SX∞Ä∞@Yää ∞&SX#!∞¿äää#Y ∞&SX#!∏ äää#Y ∞&SX#!∏@äää#Y ∏ &SX∞%E∏ÄPX#!∏Ä#!∞%E#!#!Y!YD-∏ H,KSXED!!Y-∏ I,K∏ 	PX±éY∏ˇÖ∏ Dπ 	 _^-∏ J,  EiD∞`-∏ K,∏ J*!-∏ L, F∞%FRX#Y ä äIdä F had∞%F hadRX#eäY/ ∞ SXi ∞ TX!∞@Yi ∞ TX!∞@eYY:-∏ M, F∞%FRX#äY F jad∞%F jadRX#äY/˝-∏ N,K ∞&PXQX∞ÄD∞@DY!! E∞¿PX∞¿D!YY-∏ O,  EiD∞`  E}iD∞`-∏ P,∏ O*-∏ Q,K ∞&SX∞Ä∞@Yää ∞&SX#!∞¿äää#Y ∞&SX#!∏ äää#Y ∞&SX#!∏@äää#Y ∏ &SX∞%E∏ÄPX#!∏Ä#!∞%E#!#!Y!YD-∏ R,KSXED!!Y-∏ S,K∏ 	PX±éY∏ˇÖ∏ Dπ 	 _^-∏ T,  EiD∞`-∏ U,∏ T*!-∏ V, F∞%FRX#Y ä äIdä F had∞%F hadRX#eäY/ ∞ SXi ∞ TX!∞@Yi ∞ TX!∞@eYY:-∏ W, F∞%FRX#äY F jad∞%F jadRX#äY/˝-∏ X,K ∞&PXQX∞ÄD∞@DY!! E∞¿PX∞¿D!YY-∏ Y,  EiD∞`  E}iD∞`-∏ Z,∏ Y*-∏ [,K ∞&SX∞@∞ Yää ∞&SX#!∞Ääää#Y ∞&SX#!∏ ¿äää#Y ∞&SX#!∏ äää#Y ∞&SX#!∏@äää#Y ∏ &SX∞%E∏ÄPX#!∏Ä#!∞%E#!#!Y!YD-∏ \,KSXED!!Y-∏ ],K∏ 	PX±éY∏ˇÖ∏ Dπ 	 _^-∏ ^,  EiD∞`-∏ _,∏ ^*!-∏ `, F∞%FRX#Y ä äIdä F had∞%F hadRX#eäY/ ∞ SXi ∞ TX!∞@Yi ∞ TX!∞@eYY:-∏ a, F∞%FRX#äY F jad∞%F jadRX#äY/˝-∏ b,K ∞&PXQX∞ÄD∞@DY!! E∞¿PX∞¿D!YY-∏ c,  EiD∞`  E}iD∞`-∏ d,∏ c*-∏ e,K ∞&SX∞@∞ Yää ∞&SX#!∞Ääää#Y ∞&SX#!∏ ¿äää#Y ∞&SX#!∏ äää#Y ∞&SX#!∏@äää#Y ∏ &SX∞%E∏ÄPX#!∏Ä#!∞%E#!#!Y!YD-∏ f,KSXED!!Y-  B  –Ω   C∏ S+∏ /∏ /∏ ∏  –∏  /∏ ∏ ‹∏  ∏ ‹∏ ∏ 	‹ ∫    V+∫   V+013!'!Bé∏¸‚Ω˙C∏M˚≥    ™˛–Ä ⁄  -@ #
+d
+4
+d ce+NÙM<˝ÌNEeDÊ ?MÌ‘Ì1067654&'#53™Em÷`v—U-*⁄ w¥     UﬁKó   @
+ / ∏B≥!∫H++N‰Ê /MÌ10!!Uˆ˛
+óπ    Ø  Ä ⁄  &@*
+d d!ce++NÙM˝NEeDÊ ?MÌ1073#Ø——⁄⁄     @ˇŸò   q@áF558o8Gvƒ‘Ì˝Ì ?Ì?Ì10Cy@4 &%&	%&(  (( (((
+( ( +++++++++++++Å ] ! '&47!64#"3@|`W~˛‚˛˛~i?v5ä¶x≠üì/HÆòÂ±˛Ã˛‹ø˛Ó‡ª;ÙØF˙Â¯RÙ;˛’˛›€ÖÀ     ƒ  ’í  #±∏3@ñ 
+G	vƒƒ’˝9 ??ÙÕ105>73#ƒ√ö&é¿ˆäY¶˙nˆ    @  ù " ¶@N6FWknzÑá*Zk||µ "! "
+5 u!"!8o"'Å8"$G#vƒ‘ÌÙÌıÌ‰ ?<˝<?Ì9/999999 ]10Cy@%&( 	(
+(
+( ++++++Å ]6?67654&#"#676!2!!JÖ¡¿Å4Rñ}πG&∑Bu(ˆ„yFµâb8d¸)πpoK5Sk}ìåKÖªv–˛ˆ£¨zGeL61Wj™    1ˇŸö 1 ƒ@IS-e)c-u)u-ñ&K+
++˘15 ∏#@515$51ñ'D∏J@
+8.o) Å'3G2vƒ‘ÌÙÌıÌÌÙÌ ?Ì?Ì9/Ù˝ÊÌÌ9910Cy@6/0& 	&%"& ( 0
+(#( %(( 	/( !(&( +++++++<++++ÅÅÅ ]]5332654&#"5327654&#"#476!2 #Âº(F∑é¨µ°%&eAròe¥E&≤@n€G,Fq˛Ú¯'»ã?qòxîvü 8êktxBz†p»√πÑR3±ÄÕ˛˛     4  /ú   \@"	
+æ
+uÔ∏µñ¨
+∏X≥Gvƒ‘ıÙ<˝‰ ??Ù<˝<99999á.+}≈10	!533#•˛5Œ˝åêò””˚â˝w˛^∞é¸_ù˛¢     Bˇ‹Ä   ª@+Hà9FWg: 
+u  
+5
+∏"@:5 «8o 8 "G!vƒ‘ÌıÌƒ ?ÌÌ?˝9/‰ÙÌ99999á.+}≈ 99910Cy@(	& (   (	(( ( 
+( +++++<<++ÅÅ ]]32654&#"'!!67632!"$'˝}@T†ö∑Ä]Ö/úmË˝ü=2-Pi≈˚˛ÌØ˛Ûmö;Ã|ñ§H@	Æ˛r&!˛√À˛ ≈Ã    Mˇ€#û  ' ©@9w%'XÜ áà	G
+!'!5«5'5)Å8o
+<
+$1)G(vƒ‘˝9|KRxz/ıÌÙÌ ?Ì?ÌÌ9/Ì910Cy@4%&  & (&$( ( (!(%'( '( (++++<+++++ÅÅÅÅ] ] #&'&#"67632#" 7!654&#"3GΩ≤#AÑó≤
+>^Vj¥˛Î…˛‹A}LÅç~¶tØüçû˘ÑU0Z˛È˛¸[-(Ê‰√˛”1i∫d˙›øÇn«öõàπ    K  /Ä  S@68:9JUVb∑
+|¥≈	: 	  o8	¨Gvƒ‘ÙÌÂ99 ??<˝<99]10]#67!5/EÂXW-.«DËâó¸ËÄùC˛¥¿ªöc‹öñÓ≠µ   Bˇ◊ú   2 À@GVW	ZYde	kiw%	I{v#r%s'|1|2àá á'à.à1òG2%%25,55,8!∏Ü∑8)o/8∏Üµ8/4G3vƒ‘ÌÙÌıÌÙÌ ?Ì?Ì9/Ì999910Cy@5*. -( +(
+( ( (.( *( ( ( +++++++++ÅÅÅÅ] ] 654&#"3654&#"3 '&54632#"$5467§ÜÄÉÇtñfà•™ÖÅ£ïú˛µ*OË’ŒÍD&PY3_˛Ë—˛ﬂ|z@Ö\PÜÜZer˝;áÜãêìÇp£†+PÄ†ÊŸëÜS/-)5d†Ω˛˘„ÿπ1   Iˇÿö  ' ´@.+(HXhâàò	F!''5
+
+!55«<1∏U@ )Å$8)G(vƒ‘ÌÙÌı˝9}KRxz/ ?ÌÌ?Ì9/Ì910Cy@4&%&"$(  ( ( &$( #!(!(( %'( ++++++++++ÅÅÅÅ]326#"543 !"&5 654&#"3k7EÅ∂&<±fœÒÓË9wBOÉ˛«“⁄2±ü{ÑõàïZï9◊I_MÀ√(˛ÊõÈ˛˘À˛Æ‹¶&ç∞ûõ±îå•   „  ¥!   2@** 
+	d 	d!x|++NÙM<˝<NEeDÊ ??MÌÌ103#3#„————!⁄˝ì⁄     \ ﬁo6   '@  Õ  		\!?R++NÙ<ˆ< /MÌ˝˝10!5!5o˚Ì˚Ì6®®˛S´´     =Ω  
+ D∏ ]+ ∏∂EX∏ /π ƒ>Y∏∂EX∏ /π æ>Y∏∂EX∏ 	/π 	æ>Yª  π  a+013#!#éﬂÌÖ·⁄ï˝ªüÃZâ˝wc˙C∏˛H   ó  Ω 
+  ( Ç@8ZZjjjzw!IH  ''1i1#*	%()*∏_≥!vf++NÙ<M˝<NˆMÌÙÌ ?˝?Ì9/˝9910Cy@%&++ ++++ÅÅ]]27654'&#!27654'&#!! )ƒ~FnuBÇ˛ù≠∑N1èL}˛u√wm@O)Mq8cYÖ˛ﬁ˝ìP#7èê2˛9˝ZjC_†:˝˚ö[wãY/'+6`©és¨  •  cΩ   g@áñ2 1%÷!vâ++NÙM˝NˆMÌ ?˝?˝10Cy@&%&
+22	2 2 ++++*++Å]%27676765#!! )–eAtJ;ŸÒ˛ü»S/ßïXõ˛Ü˝Ø™'oYãSG.˚ò◊¬˛—ÍΩ˛≤    Ø  ™Ω 	 9@	 	k% 
+∏W≥!ï‹++NÙM˝<NˆM‰ ??<Ì9/˝10!!!!#Ø˚¸Ã—˝/«Ω¥˛BØ˝d   cˇŸ°Â " # —@>ÜÖÜâ∂ @m~Ü":":	###∏K@1;%%
+1$%∏g≥!jp++NÙMÌNˆMÌÙ˝Ì9/ ??Ì??Ì9/<˝<Ì99]99910Cy@,! % &%
+2 !
+2  22 	22 +++<<++++++ÅÅ]] #.#" !2$!5!#'# '&76!'Êó€1≈$‚¨Ã˛ÈÊ«˛4ÖÄ0eNÉ ˛˚ºÕ»æ.!„Ps˛‡°ì˛Œ˛—˛˙˛∑Á•¸ÓΩo+J©‘rq⁄–    °  /Ω  ?@!	
+%
+% †!vp++NÙ<M˝<Nˆ<M˝< ?<?<9/<˝<103!3#!#°…¸……˝…Ω˝°_˙CØ˝Q    …  íΩ  ∏ ++∫    .+ ∏  /∏ /013#………Ω˙C  ú  KΩ  1@ % ∏S≥!v^++NÙ<M˝<NÊ ?<M˝<?103!!ú«Ë¸QΩ˙ÚØ  ó  Ω  À@YDK	◊WX‘€‘€
+
+EÜQó)
+(8
+8GWv%d
+∏õ@
+˝˝∏õ∂ vp+NÙ<M˝‰Ù99Ù99‰˝<NEeDÊ ?<?<9KRy±∏™¥
+∏™≤áM.z˝}ƒá.z˝}ƒ10 ]rqr]q!	!#465##ó¶£Ω˛]≈˛ZæΩ˚&⁄˙Cc-–w˚)◊-6›4¸ù    Pˇ’ËÂ    ä@,á« «√»…
+C::	11ÿ!jf++NÙMÌNˆMÌ9/ ??Ì?Ì10Cy@2 &%	%&2  22 222
+2 2 ++++++++++++Å ] ! '&7! 5 #" !õªíßƒ˛ï˛≠¬≠îætÎ˛ÒÎ‰˛‡˜Â˙√˛–˛∑⁄ˇ ‡ÿJ*‘˙¢yı<˛«˛œÙ˛±^  Ø  ¯Ω 
+  a@5iiyzHXhz
+ 
+	1	% ∏≥!ïâ++NÙM˝<NˆM˝9 ??<˝<9/<˝<]10]!2#!# '&#!!265Øïƒ÷ﬁ˛2«ÄxBs˛tåÜßΩ›»¨ˇ˝ìπ:˛rê   ¥  xΩ 	 ' î@IHYXidxª0 @B#! &`qu!&$% 		& %%1i)&%'
+()÷!ïf++NÙ<M˝<NˆMÙÌ‘Ì‘Ì ?<<?˝9/<˝<999999]9+10]2654'&#!!2#./&'&#!#Gå£r=f˛«®®mœmbVW.Ù
+d9z˛;«píù9˛
+°1^˝Ñ®3#rÄ≈T)F!<Vıê1˝ä  `ˇ’ˆÂ / 0 ˛@^)'#&&65!G&b&zw$	k%Yh™"
+:"$"
+Ü//+::+	0
+$"(00%I%(2%I %/12†!jâ++NÙMÌÙÌNˆMÌÙÌ9/9999 ??Ì?Ì9/Ì9.˝3]q10Cy@M(. &&-%%&, + -., + *++ +-+ 	'+%.+ )+ ++ ++++++<++++<++++++ÅÅÅ ]327654'&/&'&54$32#&'&#"# '&74c˙p\≤KL¢«√Qå˚ÁCª1[⁄∞öZ;–ŒïQå˛ùÎ˛ÓõõM⁄}Ní >†x32%-,5\∑∆˛ﬂıv?sîbl2 0/";gƒÙ“åãÓ   !  …Ω  4@ 	 ˚%˚å^+NÙMÙ<˝<ÙNEeDÊ ??<M˝<10!#!5…˛ ˛ΩØ˙ÚØ     4  6Ω  è@Dê†@TxÊghà(% % û ûé^+NÙM˝99˝99NEeDÊ ?<?<9áM.+á.+KRy@  á}ƒá}ƒ10] ]qqr	3#¶°ﬂ˝Ë”˝ÈΩ˚„˙CΩ     %  qΩ V@ï	xy	xáÜGKDHMB
+âá
+»««»XghâÜÜâôñïö©¶•™
+
+W
+>(E(% %	 
+Ü@Ù
+	ÙÄ Üé^+NÙM˝99˝99˝99˝99NEeDÊ ?<?<9áM.Ìá.ÌKRy¥	
+	
+∏ö@		
+∏ö@
+ á}≈á.+}≈á≈á.+}≈KQy≥ ∏ö∂	
+	∏ö@		 á¿á¿áz˝ƒáz˝}ƒ10r]]q ]r	3	3#	#˝LÿL⁄˛~—˛≠˛´—˛ÄΩ˚U´˚U´˙C¬˚>Ω  Rˇ‹GI  ; < ›@8*0
+'3Hi	j9	2$	;+.);∑;;2*%'"∏ä@#'.5<<<)*®$>)J'8=>ºó ! πñ ++NÙMÌÙÌNˆM‰˝ƒ9/ ??Ì?Ì?ÌÌ99]9.Ì.Ì9910Cy@(67" %6! !  !!" 7! !!! +++<++++ÅÅÅ ]]$3276=67654&#"#>323267#"'&'#"&5467rN_Yñ!h2mb1S¥>Ézç;!
+®˜£Ωvu%*,&]*	7Œ|ïΩ∫óäœZ,I¶ë/gl,-\SL*S∆õHHò˝ó"ÖB#@Hjµàï§‰   vˇﬁ%¬   p@.¶ß◊"  
+' ..)  á!Ω]++NÙ<M˝‰‰NˆMÌ ?Ì??Ì?9910Cy@
+&
+&&	& ++++ÅÅ ]3>32#"'&'#$654&#"3vØ;§`»˘ˆ⁄zT29¶fëëç{π&G¬¬˝ÎMQ˛Ì˛Ù˛˛∞;#Mâ}Ëæ©ﬁ∂—ó^±    ;ˇ·–N   ß@/ßò®™Jõ''
+'∏≥!r}++NÙMÌNˆ<MÌ99Ì9/ ??Ì?Ì9/Ì10Cy@4 %
+& &
+&  !& & 	&!++++<<++<<+++Å ]] #.#"32673#"5 3÷„Ør~¨J0àípÉØª“˙‘N∞◊cÉ®m†°‹âw’≈3Ê:  8ˇ⁄Ì¬   w@27GWß©% 
+..)'á!rB++NÙMÌNˆ<M˝‰‰ ?Ì??Ì?9910Cy@	
+ & 	&  & 
+&++++ÅÅÅ ]32654&#" 3#5#" 543ˆí°}°¶zà©äS0=≠¢?¨o≥˛˙Ôﬁ_Ë◊…À√– 74K˙>ïcX-˙ÍW  Hˇ⁄I  $ %@yóôß@@)K∂«∆«ÿŸ	÷ÿ#ËË#««\!$ö$9!
+%óß∑◊%%
+'''$.'&'‘!¶]++NÙM˝‰NˆMÌ‘˝999999/] ??Ì?Ì9/<˝<Ì910Cy@F #&%"$&   &	& &#!&!&
+& 
+&  ++++<++<+++*+*Åq] q]] !327673#"  3&'&#"¥÷86¸ÔêóçT0±O1RyAR»˛Í‚(J≠|®#GkUQlJ¢£≈]6G;ë.P#B˛&uFÇ≥ä‹       “  M@+
+9
+)¸¸!g~++NÙM˝]9ƒ/<˝<NEeDÊ ??<M˝<?Ì‘Ì107632.#"3###535µ#?¥$R ≤¥≤ïïB4\§UÆé¸dúé®    =˛;ËI  - . ∑@M6II	XY	à©®©'¶+π@")ƒ
+")
+
+.....-)0'>&'/0á!rB++NÙMÌÙÌ9NˆM˝‰ı9/ ??Ì?Ì??ÌÌ9910Cy@,#($%&#&& (&& ! %"&')& !  +++<<+++++ÅÅÅ ] 53!"&'33276'#"$ 3 &#"32765|^35¶<p˛…≠Ï∑'=Éœ@&6ò}Æ˛˚∫D§æF%ì|¬O,˛—B>#Cá¸2Ãv⁄õ•H'<íV›RP˜.˛°¿≤_öµΩØcÑ-    Ñ  Ì¬  S@,''uu  
+)
+) ∏≥!bB++NÙ<M˝<NˆMÌ ?<?Ì?99910 ]367632#4'&#"#Ñ¥@3WÇÈS-π1áp∂¥¬˝‹Q!9£Yû˝Q£v7Xö÷˝»     Ñ  ;Ω   6@Â  
+	) 	™!bB++NÙ<Mƒ˝<ƒNEeDÊ ??<?MÌ103#3#Ñ∑∑∑∑*˚÷ΩÃ    Ä  ¯Ω  ß@dY:Wgyxáπ…⁄
+	Ñî§9		m	
+  
+
+	
+) ≤!bπ ++NÙ<M˝<<NÊ ?<<?<?99áM.+}¡á.+]}¿<<10] q]r33	##Ä≠ŒÊ˛f±Ê˛≤ó≠Ω¸´«˛o˝bä˛n    â  =Ω  )@  
+) ™!bB++NÙ<M˝<NEeDÊ ??103#â¥¥Ω˙C    Ñ  %G & Ö@;'''HVg#%
+#
+%! %
+()∏≤)∏@
+ .%)& '(∏≥!bB++NÙ<M˝‰ÙÌÙ˝NEeDÊ ?<??<MÌÌ99910 ]367632>32#4&#"#4'&#"#Ñ≤@4YqÄN,$<¢eÿN*ªkMjô∑)pfß¥/òO$=?$FVSúTé˝7ËkPé¶˝ëªm2Kûœ˝»   Ñ  ÌI   ^@1∑«'vt 
+ )	.) ∏≥!bB++NÙ<M˝‰NˆMÌ9/ ??<??Ì99910 ]]3>32#4'&#"#Ñ´L™h‰P,∑0~@)J8-¥ß/ò^RüW¢˝Q£b<dB5qi˝œI   ;ˇŸ!N    ê@3òñô•®¶©∏»◊ÂÈ:'	'∏	≥!r]++NÙMÌNˆMÌ9/ ??Ì?Ì10Cy@, &	&  &	& &
+& & &&+++++++++Å ]$54'&#"3 !" 5 3‡Ö0L∫•ññ£÷¸˛˜›˛¸Át¶ñ^î¸≤´‰⁄˛Ï˛Ù˛˝˛Æ+¸@  v˛U%I  " t@,©ß( "'$
+..!)"#$á!Ω]++NÙ<M˝‰‰NˆMÌ ??Ì??Ì9910Cy@ && &&& &++++++ÅÅ ]$654'&#"3367632#"'&'#∆ß%F∫ªE%%F∫˛.Ø6@[{∂˛∑töyR0;¥y”“Ä\±ªdö|W¶±éI(<˛È˛˝˛¢ñ_5I˝›   â  íG  O@&'&7G		' 
+.) ∏E≥!b~++NÙ<M˝‰NÊ ??M?ƒ˝ƒ99910 ]3>32.#"#â´§kàí¥/π6õæØr˝ò   Bˇ◊∂K . /.@è8	òñôòò*($%'6!F!G$G'V$W'f$g&yyyv#t$t%t&¶®, -. -.(i&%6%%"
++∆.ö+/	 /!/'>(&'(1'> '.01≤!¶]++NÙMÌÙ˝9NˆM˝9Ù˝9999/999 ??ÌÌ?ÌÌ9q10Cy@L-&%&!! 	&!, ! *!! ! "! !"'
+!&%	
+-! )! !! ++++<<+<<++++++++++Å ]]]32654'&/&'&54632#&'&#"#"&'Ô%D®dò='sèâAt€πÚkC™&>ôfiE(Nw¬BiŸﬁÔ«∑PZ0WW[E$$"*IÅòºéZh=2GN@F*/,Eîè–Ÿ†˘  ˇÔ	Z  Rµ.
+¿∏?@%9
+) ¸¸!g}++NÙM˝]9ƒ/<˝<NEeDÊ /??<M˝<Ì˝‰1033#3267#"&5#53®∂´´&1C'~ZëëZ˛’ì˝E8é	Åg≈ì    Äˇ„ﬁI   ^@:∏»	(w◊ 
+ 
+.
+))“!bB++NÙMÌNˆ<M˝‰9/ ??Ì??<9910 ]]327653#7#"'&5%80ÉºD%¥™#4gìÂS-Ø/˝9R4`®Zù˚—û=*TôRâÿ     Í/ @.B≈ g hhgáàß ®G HEJÜâ«»I(s(∏	≥!g~++KRy∏ˇp¥ ∏É∑m∏É@m   
+Ø∫Ñ  Ñ≥ØNÙM˝‡‡˝NEeDÊ ?<?<999M.+N‰M.+N‰M+KQy@%) ) 
+Ø ØNÙM˝99˝99NEeDÊ ?<?<9++10q] ]q	3#‹+≈˛l¿˛u/¸òh˚—/    °/  @~G™	é	FIáäÖ
+ ƒ∆…∆
+…fje
+ivyv
+yÖä
+FIGw xW((++;;èè	 
+
+õƒ
+	ƒ õg~+NÙM˝99˝99˝99˝99NEeDÊ ?<?<9]KQy@) )á+á+KRy¥	
+	
+∏ã@)		
+∏ã@  )áM.+á}ƒá.+}≈á.+á}ƒá.+}≈10]qqq q]33##◊Œ— “€¥˛…ª⁄”ª˛À/¸¥L¸πG˚—=¸√/     ·/  # ±
+?∞3± ?∞3∞/∞÷ ± 
+±99013	#	#Èˆ˘€˛óyÊ˛ˆ˛˛‰y/˛áy˝˚˝€í˛n%   ˛IËI    @näàß8HXgwwåò óòóó® ®H KG…D∆á¶ ¶ß®$(  ØØè‘!g~++NÙM‰˝99˝99NEeDÊ9/ ??M˝92/?<<<99KRy@ mm  á.+}ƒá.+}ƒ]q10q] ]3#"&'53267>73!«&ÉbBúÄú&)/*2/>˛tÃ/g˛ë˛ÏÆ˛f¥§!î$N¸òÇ   4  ¥I 	 
+ l@B7H W XWg hgw	)  
+
+9 9	
+
+>J ≤!r]++NÙM‰NˆM‰ ??<˝<9?<˝<9999/á.+á}≈10]7!5!!!4{˝¥>˝âä¸Äœé °ì˝°I       Çñ±∞_<ı      _Mè     ﬁ‡.÷¯e¸'ë˘   	         )˛)  ¯e¸Ìë                ^ B    9  9  9 Ì◊ Rs  s @ BV Yá ú™ é™ D N¨ \9 ™™ U9 Ø9  s @s ƒs @s 1s 4s Bs Ms Ks Bs I9 „9 „¨ ¨ \¨ s ú ·V V ó« Z« •V Ø„ Ø9 c« °9 …  #V ús ú™ ó« ú9 PV Ø9 P« ¥V `„ !« ™V 4ç %V *V *„ /9 Ä9ˇª9 /¡ xs  ™ &s Rs v  ;s 8s H9 s =s Ñ« Ñ«ˇ⁄  Ä« â™ Ñs Ñs ;s vs <™ â  B9 s Ä  «       4       l   l   l   l   l   l   l   l   l   l   l   l   l   l   l   –    L  L  (  t  å  ‰  Ä  ®  ‘  h  	Ã  
+¯  P  P  P  †  †  †  †    $  $  Ë  Ë  L  ú    <  <  <  å  §  §  †  L  L  `  ¯  T  T    ®  ®  ®  ®  ®  ®  ®  ®  ®  ®  <      Ï  Ä     h  !  !d  !d  "D  "à  #Ä  $8  %(  &  &  &ò  (X  (¯  )¨  *ÿ  ,4  ,î  -¿  .`    ^ o 	 k     g  Ëê     9≤        P         	 P        Y       "       	A       J       	R       2[       	       	            &      4      H      	Z      /ç      <º      0¯      :(      6b      0ò      <»    `     Ã    |     Ê     |    ò  	   `     ˙     n    ®    ∞     ™    
+ ä     ∫     ö    
+         ⁄    ⁄    2    n    Ê    @    L    T  !  ¬  "  Ù  *    9    >  
+–     î  	  ä    $     “  
+   ¿© 1990-2006 Apple Computer Inc. © 1981 Linotype AG © 1990-91 Type Solutions Inc.HelveticaRegular R e g u l a r C o u r a n t R e g u l a r0Ï0Æ0Â0È0¸^8âƒOS R e g u l i e r R e g o l a r e«|ºÃ¥ N o r m a ljnñö‘9'/J N o r m a l A l m i n d e l i g N o r m a a l i N o r m a l R e g u l a r R e g u l a r1KG=K9 N o r m a l4 N o r m a l R e g u l a r R e g u l a r R e g u l a r R e g u l a rö±ΩøΩπ∫¨Ë“Ÿ‹ S z a b · l y o s R e g u l e r B i a s a N o r m a l R e g u l a r28G09=89	0	G		M	/	A	2	0 T h∞› n gHelvetica; 17.0d1e1; 2020-09-21Helvetica17.0d1e1HelveticaHelvetica is a registered trademark of Linotype AGHelvetica est une marque déposée de Linotype AGHelvetica ist ein eingetragenes Warenzeichen der Linotype AGHelvetica è un marchio registrato di Linotype AGHelvetica is een geregistreerd handelsmerk van Linotype AGHelvetica är ett registrerat varumärke för Linotype AGHelvetica es una marca registrada de Linotype AGHelvetica er et registreret varemærke tilhørende Linotype AGHelveticaLigaturesCommon LigaturesNumber SpacingProportional NumbersMonospaced NumbersNo Change          ˇe e                     ^           	 
+                        ! " # $ % & ' ( ) * + , - . / 0 1 2 3 4 5 6 7 8 9 : ; < = > ? @ A B C D E F G H I J K L M N O P Q R S T U V W X Y Z [ \ ]  ∏ ]+∫ π _+øª > 4 )     e+øº B 4 )     e+øΩ : 4 )     e+ ø∑ M = 7 (    e+ø∏ ` O 7 (    e+øπ G = )     e+ø∫ B 4 )     e+ ∫æ  d+∏∂ E}iD∏ S+∏ I+∏ ?+∏ 5+∏ ++A Ä¶ ê¶ †¶  iã yã âã ôã  âã ôã ©ã πã≤@∫y J@T
+“∏¥ûŸ„ª  ·≤ 	A
+†ü d • %z H (ö≥)l`A
+© p© Ä©  Ä© ©≤2æ, % & ∂Á1-Â1∏≤¬'∏≤¡∏@¿ûøgæg´'∏≤™)∏∂©lì∏ö≤í∏≤ë∏≤u∏∂m)ñd1∏ö≤Lñ∏´≤9∏V@68!5‰/'∏@-L*1Õ$∏´≤ ∏%@ì:LE':E'ª™õ *õ≤%J∫õ %z≥I)8ñ∏{≥H(1%∏z@6H(ñ)H'%)L%)F'')H'V»Ñ[A2+(&!
+∏¨≤?ª´ ? ´≥∏Æ≤?ª≠ ? ≠∑ ∏ˇ‡¥   ∏´¥   ∏´∂   ∏≠≥   ∏≠@               J ∞ç∏ Öv??>9FD>9FD>9FD>9FD>9FD>9F`D>9F`D>9F`D+++++++++++++++++++++++++++∞ñKSX∞™Y∞2KSX∞ˇY+++++++++++++++++++++++++++++++++++++++++tu+++eB++KRy≥vpjfEe#E`#Ee`#E`∞ãvh∞Äb  ±jpEe#E ∞&`bch ∞&ae∞p#eD∞j#D ±vfEe#E ∞&`bch ∞&ae∞f#eD∞v#D± fETX±f@eD≤v@vE#aDY≥bBr]Ee#E`#Ee`#E`∞âvh∞Äb  ±rBEe#E ∞&`bch ∞&ae∞B#eD∞r#D ±b]Ee#E ∞&`bch ∞&ae∞]#eD∞b#D± ]ETX±]@eD≤b@bE#aDY++++EiSBst∏ö EiK ∞(S∞IQZX∞ aYD∏¶ EiDu  endstream
+endobj
+78 0 obj
+<<
+/Length 872 
+>>
+stream
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo << /Registry (Adobe) /Ordering (UCS) /Supplement 0 >> def
+/CMapName /Adobe-Identity-UCS def
+/CMapType 2 def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+42 beginbfchar
+<0001> <0041>
+<0002> <0076>
+<0003> <0065>
+<0004> <0072>
+<0005> <0079>
+<0006> <0020>
+<0007> <0035>
+<0008> <0031>
+<0009> <0036>
+<000A> <0030>
+<000B> <004A>
+<000C> <0061>
+<000D> <006D>
+<000E> <0069>
+<000F> <0053>
+<0010> <0074>
+<0011> <0068>
+<0012> <004D>
+<0013> <006F>
+<0014> <0067>
+<0015> <006E>
+<0016> <004C>
+<0017> <0043>
+<0018> <0073>
+<0019> <004E>
+<001A> <0075>
+<001B> <0070>
+<001C> <004F>
+<001D> <0064>
+<001E> <0032>
+<001F> <0034>
+<0020> <0038>
+<0021> <0042>
+<0022> <0049>
+<0023> <0050>
+<0024> <006A>
+<0025> <0063>
+<0026> <006C>
+<0027> <0078>
+<0028> <0052>
+<0029> <004B>
+<002A> <0054>
+endbfchar
+endcmap
+CMap end
+end
+endstream
+endobj
+79 0 obj
+<<
+/Length 86 
+>>
+stream
+   $ Y H U \      - D P L 6 W K 0 R J Q / & V 1 X S 2 G    % , 3 M F O [ 5 . 7endstream
+endobj
+80 0 obj
+<<
+/Length 15236 
+/Length1 15236 
+>>
+stream
+     Ä  POS/2á,√   ‹   `cmap
+XC  <   Ëcvt 
+5„  $   fpgm”'õi  @  sglyft∞¯W  ¥  +head„˜≠  .¿   6hhea	Üc  .¯   $hmtxô“E  /  tloca ﬂl  0ê  xmaxp⁄ã  2    namemÒ$   2(  ¸post◊  :$   ‹prepRÀ‡o  ;    Ñ ˘º   ô3  ô3  – f             ‡ ˇR x[        pyrs   	ˇˇ ˛§ =Æ€  üO  B¬                      ‘         2 6 8 C P T a e j p v yˇˇ     0 4 8 A I R a c g l r xˇˇ                                 $ $ ( 6 : : > D L T           $ % & , - . / 0 1 2 3 5 6 7 D F G H J K L M O P Q R S U V W X Y [ \ * ˛ ò*4   )˛P B #¬ -∏ f,K∏ 	PX±éY∏ˇÖ∏ Dπ 	 _^-∏ g,  EiD∞`-∏ h,∏ g*!-∏ i, F∞%FRX#Y ä äIdä F had∞%F hadRX#eäY/ ∞ SXi ∞ TX!∞@Yi ∞ TX!∞@eYY:-∏ j, F∞%FRX#äY F jad∞%F jadRX#äY/˝-∏ k,K ∞&PXQX∞ÄD∞@DY!! E∞¿PX∞¿D!YY-∏ l,  EiD∞`  E}iD∞`-∏ m,∏ l*-∏ n,K ∞&SX∞@∞ Yää ∞&SX#!∞Ääää#Y ∞&SX#!∏ ¿äää#Y ∞&SX#!∏ äää#Y ∞&SX#!∏@äää#Y ∏ &SX∞%E∏ÄPX#!∏Ä#!∞%E#!#!Y!YD-∏ o,KSXED!!Y-   ö  =¬   ^∏ f+ ∏  EX∏  /π   >Y∏  EX∏ /π  >Y∏ ‹∏  ∏ ‹∏ /∏ 	/∏ ∏  –∏  /∏ 	∏ ‹∏ ‹∏  ∏ ‹01!!%!ö£˚]Î¸Õ¬˙>∏R˚Æ  @ˇ‹(¥  #∏ f+ ∏  EX∏  /π   >Y∫   i+∏  ∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∏ /∏ /∏ ∏ –∏ /∏ ∏ 
+‹∏ ‹A ⁄  Í  ]A 	    )  9  I  Y  i  y  â  ô  ©  π  …  ]∏ ∏ ‹A     &  6  F  V  f  v  Ü  ñ  ¶  ∂  ∆  ]A ’  Â  ]01 ! 65&#"324˛Îﬂﬂpoﬂn'ORR$ÑggÜ√√˛ô˛ô˛|mÑ˙¸¸˛˙˙˛˜     é  ™  )∏ f+ ∏  EX∏  /π   >Y∫   i+∫    i+01)!5676767653˛‹˛´á6V6%ÌË¬9'A'    @  !± " (∏ f+ ∏  EX∏ /π  >Y∫   i+∏ ∏ ‹01&#"!676!2!!676767654»3_Ç/˛Î<r#Ê`?êrkOy¸?=„≈:YÉ=a8zπrŸˇ“°}SfQLD-˚úÅë¢ç=_q\    6  /° 
+  Q∏ f+ ∏  EX∏ /π  >Y∫    i+∏ ∏ –∏  ∏ –∫   i+∏ ∏ 	–∏ ∏ –∏ ∏ ‹01#!!5!)/§˛È˝¬@˝~kﬂ˛»8˘p¸vr  6ˇ⁄!ó   ◊∏ f+ ∏  EX∏ /π  >Y∫   i+∫    i+∫ 
+   9∏ ∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∫   i+A ⁄  Í  ]A 	    )  9  I  Y  i  y  â  ô  ©  π  …  ]∏ ∏ "‹01"%!!67632 !"$'!32654&"4&C"ˇ f˝Ø4B%>Y¥˛˛˛ˇœ˛ˆ`\joh–A!Ú˛√+ÚÁ…˛ƒﬁÃ]eïqoô    @ˇ⁄*∏  , ◊∏ f+ ∏  EX∏ /π  >Y∫   i+∫   + i+∫  +  9∏ ∏ %‹A  %  % ' % 7 % G % W % g % w % á % ó % ß % ∑ % « % ]A ÷ % Ê % ]∫  ( i+A ⁄ ( Í ( ]A 	 (  ( ) ( 9 ( I ( Y ( i ( y ( â ( ô ( © ( π ( … ( ]∏ ∏ .‹012# '&4767>32!4'&#">32654&#"r¡˜Úˇ˛ÓÇeH>…å ˛‰.]ã; 5åfT~a_m|ZI≠˛˙ÃÀ˛ Â≥¶hπ{iÄœ¨#*DúV®?:˛Aëuîèrá     6ˇ⁄%±  $ 1õ∏ f+ ∏  EX∏ /π  >Y∫  - i+∫ ' " i+∫  " '9∫  " '9∏ ∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∫   i+∫   i+A     &  6  F  V  f  v  Ü  ñ  ¶  ∂  ∆  ]A ’  Â  ]∫   9A ⁄  Í  ]A 	    )  9  I  Y  i  y  â  ô  ©  π  …  ]∫   9∏ /∫   9∏ *‹A ⁄ * Í * ]A 	 *  * ) * 9 * I * Y * i * y * â * ô * © * π * … * ]∏ ∏ 3‹017&5467.54632 #"32654&#"32654&#"≥}oki?ÓŸŸÓ?ikl˛ÒÛÛ.obboq``qK0VW__WVa[Ä∑z∆2F£GûﬂﬂûG£<<∆z∑˛ˇÀkvvkoss2dOVaaVO  4  ®¬  
+ B∏ f+ ∏  EX∏ /π  >Y∏  EX∏ /π  >Y∏  EX∏ /π  >Y∫    i+01!!!!˚˝·f˛æ\
+˛≤µ∏æ/˛—¬˙>-D˝º  °  a¬   * \∏ f+ ∏  EX∏ /π  >Y∏  EX∏  /π   >Y∫ )  i+∫   )9∏  ∏ ‹∏ ∏ &‹∫   i+∏ ∏ '–01)!!!27654'&654'&#!!2=˝dÃqDD&JqsB*?G¡x˛ëja6b_59<PEk˛ºja¬ô^ÉáR.&)≤ÉhE/6(â˛w0às+$]g!˛ª   \ˇ◊{ﬁ ∏ f+ ∏  EX∏ 
+/π 
+ >Y∏  EX∏ /π  >Y∏ 
+∏ ‹A Ÿ  È  ]A     (  8  H  X  h  x  à  ò  ®  ∏  »  ]∏ ∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∫   i+A     &  6  F  V  f  v  Ü  ñ  ¶  ∂  ∆  ]A ’  Â  ]01%! '&76! !&'&#"32767!¨•˛ˇ˛¬∂∂œ¥t¨_˛Ã/T•®¬Õû¢U/1(nóÃÕeÇ—∂Ùâäj6`˛Ò¯¯˜j9rÒ    Ñ  ∂¬  :∏ f+ ∏  EX∏  /π   >Y∏  EX∏ /π  >Y∫    i+∏ ∏ ‹01!!Ñ2˛Œ¬˙>     -ˇ‹ﬁ¬  î∏ f+ ∏  EX∏ /π  >Y∏  EX∏ /π  >Y∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∏ /∏ /∏ ‹∏  ‹∏ ∏ 
+–∏ 
+/∏ ‹01!! 5!3276™4An˛·˛·ƒ#Cnm#ª˚˛ºn∫-""´ãL-  °  ∂¬  f∏ f+ ∏  EX∏ /π  >Y∏  EX∏ 	/π 	 >Y∏  EX∏  /π   >Y∏  EX∏ /π  >Y∫    9∫   i+∏ ∏ –01)!!!∂˛t˛9ì˛—/9é˝§Ñó˛¬˝°_˝°    ú  ™¬  6∏ f+ ∏  EX∏  /π   >Y∏  EX∏ /π  >Y∏ ‹∫    i+01!!!ú4⁄˚Ú¬˚G˛˜   ó  (¬  Ω∏ f+ ∏  EX∏ /π  >Y∏  EX∏ /π  >Y∏  EX∏  /π   >Y∏  EX∏ /π  >Y∏  EX∏ /π  >Y∫    9∫    9∫    9∏ /∏ /∏ ∏ –∏ /∏  ‹∏ ∏ ‹∫   9∏ ‹∏ –∏ /∏  ∏ –∏ /01)!	!!465!∂˛·¿
+ª˛·˛È˛’˛Î¬˚yá˙>Â+õ*˚+’*õ+  ó  D¬ 	 Ñ∏ f+ ∏  EX∏ /π  >Y∏  EX∏ /π  >Y∏  EX∏  /π   >Y∏  EX∏ /π  >Y∫    9∫    9∏ 
+/∏ /∏  ‹∏ 
+∏ –∏ /∏ ‹∏  ∏ ‹01)!!!D˛Ã˝¶˛·CK˚È¬˚˚  eˇ◊ÍÔ  j∏ f+ ∏  EX∏ /π  >Y∏  EX∏  /π   >Y∏ ∏ ‹A Ÿ  È  ]A     (  8  H  X  h  x  à  ò  ®  ∏  »  ]∏  ∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∫   i+∫   i+A ⁄  Í  ]A 	    )  9  I  Y  i  y  â  ô  ©  π  …  ]A     &  6  F  V  f  v  Ü  ñ  ¶  ∂  ∆  ]A ’  Â  ]∏ ∏ ‹01 '&76! 654#"32(˛ƒß‡‡ß<<ßﬂﬂßk◊∑∑⁄⁄∑∑)¨”çïÀ¨¨À˛k˛s”¨åá˘¯˛Ú˘˘˛Ú    £  ¬ 
+  ¨∏ f+ ∏  EX∏ /π  >Y∏  EX∏ /π  >Y∫    i+∏ ∏ ‹∏ /∏ /∏ ∏ –∏ /∏ ‹∏ ∏ ‹∏ ‹A ⁄  Í  ]A 	    )  9  I  Y  i  y  â  ô  ©  π  …  ]∏ ∏ –01!!!2654&#!!2˛«˛ŒÇﬁ˛¯e<ym˛·m˝Ó¬‰Ô˛˚ÿ35ssb˛N    £  q¬  * £∏ f+ ∏  EX∏ /π  >Y∏  EX∏ /π  >Y∏  EX∏ /π  >Y∫ )   i+∫    )9∏ ∏ &‹∏ +/∏ ,/∏ +∏ –∏ /∏ ‹∏ ,∏ ‹∏ ‹∫   9∏ ∏ –∏ /∏ ∏ –∏ /∏ ∏ '–01!!!!&'&/.654'&#!!2˛¬˛””õß:08jzfU,˛≠c3\Y2d˛ö]hB˝æ¬FD8àWiÀ*)óõce$9%1>Aâç^*|Ü.˛t     Uˇ⁄Ì .∏ f+ ∏  EX∏ /π  >Y∏  EX∏ '/π ' >Y∏  ‹A       '   7   G   W   g   w   á   ó   ß   ∑   «   ]A ÷   Ê   ]∏ ∏ ‹A Ÿ  È  ]A     (  8  H  X  h  x  à  ò  ®  ∏  »  ]∫   i+A     &  6  F  V  f  v  Ü  ñ  ¶  ∂  ∆  ]A ’  Â  ]01%27654'&/&'&54 !2!&'&#" !  5!≥mDÅ@@âúÊXï ÈI˛ÿlHkwéF-ì˛ßUÑ˛À˛Ê˛‡˛∂&)K’.}I('#4=fŸ∆˜ÎÖ8%`VO'#=(Ch≈ ˛ıÊe2[    !  À¬  B∏ f+ ∏  EX∏  /π   >Y∏  EX∏ /π  >Y∏  ∏ ‹∏ –∏ –∫   i+01!!!À˛G˛ ˛E¬˛˚˚CΩ    ;ˇﬁ8\ * : —∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∏  EX∏ /π  >Y∫   9∏ ∏ $‹A Ÿ $ È $ ]A  $  $ ( $ 8 $ H $ X $ h $ x $ à $ ò $ ® $ ∏ $ » $ ]∫ 1  9∫  0 i+∏ ∏ 	–∏ 	/∏ 0∏ –∏ /∏ 0∏ !–∏ !/∏ ∏ <‹016!2!.'#"&5476?67654&#"!632675Æq≥ãã˛ 
+;M\tî¡õU•aO"=]Ze*
+˛Ì	(:\õ70@Z'BÃêGG≈˛4J8(*!:%@-5©õ…Z1
+7C32%?è˝^!lèj	'RI  Gˇ⁄4\ ∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∏ ∏ ‹A Ÿ  È  ]A     (  8  H  X  h  x  à  ò  ®  ∏  »  ]∏ ∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∫ 	  i+A  	  	 & 	 6 	 F 	 V 	 f 	 v 	 Ü 	 ñ 	 ¶ 	 ∂ 	 ∆ 	 ]A ’ 	 Â 	 ]01!&'&#"3267!! 5 324˛‹!0eê53çdT	#
+TÜ˛˘˛˘¯ÒÕª=1BèL~xIàlVÇtª8˘8∏     ?ˇﬁe¿  o∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∏  EX∏ /π  >Y∏ ∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∫   9∏ ∏ ‹A Ÿ  È  ]A     (  8  H  X  h  x  à  ò  ®  ∏  »  ]∫   9∏ /∏  /∏  ‹∏ ‹∏ –∏ /∫    9∏ ∏ 	–∏ 	/∏ ‹A     &  6  F  V  f  v  Ü  ñ  ¶  ∂  ∆  ]A ’  Â  ]∏ ∏ –∏ /01!5#" 5 3232654'&#"e˛Î=útø˛˚◊cö0˛!<;yy~e>R}u¿˙@óaX5Ú@WM¸ZóZ[¥è»V4Ω   /ˇ‹:_  ! Õ∏ f+ ∏  EX∏ 
+/π 
+ 
+>Y∏  EX∏ /π  >Y∫   i+∏ ∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∏ 
+∏ ‹A Ÿ  È  ]A     (  8  H  X  h  x  à  ò  ®  ∏  »  ]01#"  32!32767.#"*Zå¸–˛¬Âà⁄G@˝a;SX7	{[cm@adü..fnaÄKç§B)20Nqu|j    B˛B^\ ! /’∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏ /π  
+>Y∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∏  EX∏ /π  >Y∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∏ ∏ $‹A  $  $ ' $ 7 $ G $ W $ g $ w $ á $ ó $ ß $ ∑ $ « $ ]A ÷ $ Ê $ ]∫   $9∏ ∏ *‹A Ÿ * È * ]A  *  * ( * 8 * H * X * h * x * à * ò * ® * ∏ * » * ]∫   *9∏ 0/∏ 1/∏ ‹∏ ‹∏ –∏ /∏ 0∏ –∏ /∏ ∏ '–∏ '/∏ ∏ .‹A  .  . & . 6 . F . V . f . v . Ü . ñ . ¶ . ∂ . ∆ . ]A ’ . Â . ]013276=#"54325!!"$'!32654&#"π.mö4")/Uà“˚ÚﬁR=h@Gz˛¶—˛¯6:ñdäÉnñ9ø'gBúFF#A'¸ÛK+sù˚ˆ”k∏§£2äó•õ¢çKn_     á  ^Ω  ¡∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∏  EX∏ /π  >Y∏ ∏ ‹A Ÿ  È  ]A     (  8  H  X  h  x  à  ò  ®  ∏  »  ]∫   9∏ /∏ /∏ ‹∏ ‹∏ ∏ –∏ /∏ ‹∏ –∫   901!4'&#"!!>32^˛›'mqu˛‰>£Ze•5-Ä˝ÄóX6Lóå˝≤Ω˝˜_KFH=Å   â  ™À   [∏ f+ ∏  EX∏  /π   
+>Y∏  EX∏ /π  >Y∏  EX∏ /π  >Y∏ ∏ ‹∫   i+∏ ∏ –∏ ∏ –01!!™˛ﬂ!˛ﬂB˚æBâ˛˘   	˛HØÀ   k∏ f+ ∏  EX∏ /π  >Y∏  EX∏ /π  >Y∏  EX∏ /π  >Y∏ 	‹∏ –∏ ∏ ‹∫    i+∏  ∏ –∏ ∏ –∏ ∏ ‹01!#"&'53265!!íÇæ3&*+˛„=˚N•û‰);;˛˘     ã  ®¬  2∏ f+ ∏  EX∏  /π   >Y∏  EX∏ /π  >Y∫    i+01!!ã˛„¬˙>     Ä  úZ - ±∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∏  EX∏ /π  >Y∏  EX∏ */π * >Y∫   9∫   9∫   i+∫ * + i+∫  ! i+∏ ∏ 
+–∏ 
+/∫   9∫  + *9∏ ∏ /‹01&#"!!6763267632!4'&#"!4È$iz*˛ﬂ5/SÑ}M> 8SXlHå9.
+˛‹&fv-˛·OO-Y˝p@üU$@73P`--8F9S7j˝Q∂>(Lb4I˝wâa    á  a\  {∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∏  EX∏ /π  >Y∫ 	  9∏ /∏ /∏ ∏ –∏ /∏ ‹∏ –∏ /∫ 	  9∏ ∏ ‹∏ ‹01"!!67632!4'&Üë6˛‰71Xá©◊˛‹*o{Ae˝≤@üT%B±Õ˝"óV.T     Bˇ⁄úe  j∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∏ ∏ ‹A Ÿ  È  ]A     (  8  H  X  h  x  à  ò  ®  ∏  »  ]∏ ∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∫   i+∫   i+A     &  6  F  V  f  v  Ü  ñ  ¶  ∂  ∆  ]A ’  Â  ]A ⁄  Í  ]A 	    )  9  I  Y  i  y  â  ô  ©  π  …  ]∏ ∏ ‹01 !  54 ! "32654&ä˛Ï˛Á˛Á˛Ï˛Ê}áá}}ÜÜ∏≠Ï˛´UÏZÒ±§§≤≤§§±   }˛SöZ  !!∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∫ 	  9∫   9∏ "/∏ #/∏ ‹∏ "∏ –∏ /∏ 
+‹∏ –∏ /∫   
+9∏ ∏ ‹A ⁄  Í  ]A 	    )  9  I  Y  i  y  â  ô  ©  π  …  ]∏ 
+∏ –∏ /01 #"'&'!!676324&#"326Ñ˛˝ÃÇV/-˛Ê.4_ÉøsÅõ:e<Rw}Õç˛Ô˛‡˛“A$E˝»Ô°G)I˝«~¬ìNxæM-∏  Ç  ˚\  h∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏ /π  
+>Y∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∫ 	  9∫   i+∫ 	  901"!!67632.©¨;!˛·B1PÄ*;p?É˝˜Bæm(C˛‹   Bˇ€%a , ≈∏ f+ ∏  EX∏ +/π + 
+>Y∏  EX∏ /π  >Y∏ +∏ ‹A Ÿ  È  ]A     (  8  H  X  h  x  à  ò  ®  ∏  »  ]∏ ∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]01!&'&#"# &5!32654'&%&'&54632tÄ˛„/q]O**ˇ™UTÒ¸˛ˇı!	5èTc((˛ˇπLLÌ◊ÃR»7 ::'18(QR{¢ÕŸ®L 9220=.EDÄóŸ     ˇÍxh  Y∏ f+ ∏  EX∏ /π  >Y∫ 
+  i+∏ ∏  ‹∏ 
+∏ –∏ ∏ –∏  ∏ –∫   i+∏ ∏ 
+–∏ ∏ –01%'&5#53!3#326xá J0òò±±"WÀ’M1füÀ0˛–À˝¿C!    }ˇËUB  »∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∏  EX∏ /π  >Y∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∫    9∏ /∏ /∏ ‹∏ ‹∏  –∏  /∏ ∏ 
+–∏ 
+/∏ ‹01%#"'&5!32765!!@ C}TÚT/$'rí6!˛Îö2<,Æ`ªë˝o]/Sv@iQ˚æ      WB  D∏ f+ ∏  EX∏  /π   
+>Y∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∫    901!!!@„Ë2˛w˛”B¸‹$˚æ    P@  )∏ f+ ∏  EX∏  /π   >Y∏  EX∏ /π  >Y01)!	!!P˛ùºΩ˛¶t˛ú]∂≤S˛öG˛π(˛ƒ<˝Ì     ˛GPB  Y∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∏  EX∏ 	/π 	 >Y∫    9∏ 
+‹01!#"&'567>'!@·/˛äl~Ω&..$*L+˛p=$˚–˛ ï‰
+lr      ﬂH”ª_<ı      ¢(Ä     ﬁ‡.◊˜‹¸'
+˙≥           )˛)  ˜‹¸€~                ]« ö    9  9  ™ ·À ßs  s 8 /« oÁ c™ Y™  /¨ I9 v™ /9 Ä9ˇês @s és @s 6s 6s 6s @s 4s 6s =™ Ë™ Ë¨ ¨ I¨ „ {Õ «« 4« °« \« úV •„ ú9 U« ö9 Ñs -« °„ ú™ ó« ó9 eV £9 e« £V U„ !« úV /ç V !V #„ 4™ Ä9ˇê™ /¨ ãs  ™ˇŒs ;„ {s G„ ?s /™ „ B„ á9 â9 	s Ç9 ã Ä„ á„ B„ }„ < Çs B™ „ }s 9 s s        à   à   à   à   à   à   à   à   à   à   à   à   à   à   à   à   à   à   à    l      î  ‹  @  @  l  l  l  l  l  l  l  l  l  Ë  	–  P  P  P  P  P  P  ®  Ñ  $  |  Ñ  8        4  ‹  H  H  H  H  H  H  H  H  H  H  H  H  H  Ã  Ã  H     d  d  Ã  ‡  h         l  !¨  "x  $<  %Ã  %Ã  &|  'Ã  (p  )ê  )¸  )¸  *d  +    ] k 	 k     p  Ë¢     EB        P         	 P        Y       $©       Õ       î       ú       2™       S       	a      j      z      à      ú      	Æ      €      /‹      È      <      ˜      0G      
+      :w            6±      $      0Á      <      5    	  H      Y     i     w   
+  á         ≠    
+3     «     m    E  	   ]     Õ     e    Q    W     á     u     ô     Å     ﬂ     Â     π    
+{     ˚    +    Ö            
+  !  
+g  "  ç  *  £  9  
+ô  >  
+q     }  	  =     Ì     ±  
+   ü© 1990-2006 Apple Computer Inc. © 1981 Linotype AG © 1990-91 Type Solutions Inc.HelveticaBold B o l d G r a s F e t t0‹0¸0Î0…|óOS V e t G r a s s e t t oº¸¥‹Ã¥ N e g r i t a|óö‘91J6 N e g r i t o F e d L i h a v o i t u F e t B o l d N e g r i t o8@=K9 F e t+2 K a l1 n N e g r e t a B o l d T u n È B o l dàΩƒøΩ±‚—‘ F È l k ˆ v È r T e b a l T e b a l A l d i n B o l d8@=89	,	K	2	M	!≠ mHelvetica Bold; 17.0d1e1; 2020-09-21Helvetica BoldHelvetica GrasHelvetica FettHelvetica grassettoHelvetica vetHelvetica FetHelvetica NegritaHelvetica CarregadoHelvetica HalvfetHelvetica lihavaHelvetica √”ËœHelvetica »—Ã” ÁHelvetica Ú·‰17.0d1e1Helvetica-BoldHelvetica is a registered trademark of Linotype AGHelvetica est une marque déposée de Linotype AGHelvetica ist ein eingetragenes Warenzeichen der Linotype AGHelvetica è un marchio registrato di Linotype AGHelvetica is een geregistreerd handelsmerk van Linotype AGHelvetica är ett registrerat varumärke för Linotype AGHelvetica es una marca registrada de Linotype AGHelvetica er et registreret varemærke tilhørende Linotype AGHelvetica BoldLigaturesCommon LigaturesNumber SpacingProportional NumbersMonospaced NumbersNo Change          ˇe e                     ]           	 
+                        ! " # $ % & ' ( ) * + , - . / 0 1 2 3 4 5 6 7 8 9 : ; < = > ? @ A B C D E F G H I J K L M N O P Q R S T U V W X Y Z [ \∏ f+ ∫   h+∫   h+ø  (       n+ø  %       n+ ø  - %      n+ø  K = 0 "    n+ø  &       n+ ∫   m+∏   E}iDendstream
+endobj
+xref
+0 81
+0000000000 65535 f
+0000000009 00000 n
+0000000119 00000 n
+0000000167 00000 n
+0000000309 00000 n
+0000000407 00000 n
+0000000799 00000 n
+0000001212 00000 n
+0000001391 00000 n
+0000001552 00000 n
+0000001870 00000 n
+0000002302 00000 n
+0000002453 00000 n
+0000002579 00000 n
+0000002909 00000 n
+0000003291 00000 n
+0000003447 00000 n
+0000003579 00000 n
+0000003706 00000 n
+0000003850 00000 n
+0000003976 00000 n
+0000004124 00000 n
+0000004252 00000 n
+0000004394 00000 n
+0000004574 00000 n
+0000004737 00000 n
+0000004862 00000 n
+0000005001 00000 n
+0000005129 00000 n
+0000005265 00000 n
+0000005445 00000 n
+0000005608 00000 n
+0000005732 00000 n
+0000005857 00000 n
+0000005981 00000 n
+0000006106 00000 n
+0000006286 00000 n
+0000006449 00000 n
+0000006578 00000 n
+0000006723 00000 n
+0000006852 00000 n
+0000006995 00000 n
+0000007175 00000 n
+0000007338 00000 n
+0000007470 00000 n
+0000007627 00000 n
+0000007807 00000 n
+0000007970 00000 n
+0000008092 00000 n
+0000008214 00000 n
+0000008336 00000 n
+0000008458 00000 n
+0000008580 00000 n
+0000008760 00000 n
+0000008923 00000 n
+0000009050 00000 n
+0000009175 00000 n
+0000009300 00000 n
+0000009480 00000 n
+0000009643 00000 n
+0000009771 00000 n
+0000009901 00000 n
+0000010029 00000 n
+0000010155 00000 n
+0000010282 00000 n
+0000010408 00000 n
+0000010535 00000 n
+0000010659 00000 n
+0000013687 00000 n
+0000015642 00000 n
+0000017344 00000 n
+0000019164 00000 n
+0000020553 00000 n
+0000023794 00000 n
+0000025866 00000 n
+0000028193 00000 n
+0000029314 00000 n
+0000029480 00000 n
+0000049930 00000 n
+0000050854 00000 n
+0000050991 00000 n
+trailer
+<<
+/Root 3 0 R 
+/Size 81 
+>>
+startxref
+66297
+%%EOF

--- a/ltml/std_page.go
+++ b/ltml/std_page.go
@@ -175,6 +175,16 @@ func (p *StdPage) SetAttrs(attrs map[string]string) {
 	if style, ok := attrs["style"]; ok {
 		p.pageStyle = PageStyleFor(style, p.scope)
 	}
+	if MapHasKeyPrefix(attrs, "style.") {
+		base := p.pageStyle
+		if base == nil {
+			base = PageStyleFor("letter", p.scope)
+		}
+		if base != nil {
+			p.pageStyle = base.Clone()
+			p.pageStyle.SetAttrs(addUnits(filterMapAttrs("style.", attrs), p.Units()))
+		}
+	}
 	if grid, ok := attrs["grid"]; ok {
 		switch grid {
 		case "", "false":


### PR DESCRIPTION
## Summary
- Expand LTML’s built-in page size catalog to cover the common ISO, North American, ANSI, and ARCH families
- Add page-style orientation overrides so samples can request landscape via `style.orientation`
- Move Avery into a separate extension package with `avery:labelsheet` and authored `avery:label` children
- Split the paper-size and Avery demos into dedicated samples and update the syntax docs

## Testing
- `go test ./ltml`
- `go test ./avery`
- `go test ./...`