### PR TITLE
Add memoized LTML canvas form rendering

### DIFF
--- a/ltml/SYNTAX.md
+++ b/ltml/SYNTAX.md
@@ -6,11 +6,15 @@ declarative control over layout, typography, and visual elements.
 ## Document Structure
 
 Every LTML document begins with a root `<ltml>` element containing style
-definitions and one or more `<page>` elements.
+definitions, optional reusable `<canvas>` assets, and one or more `<page>`
+elements.
 
 ```xml
 <ltml units="in" margin="1">
   <!-- style definitions -->
+  <canvas key="badge" width="120" height="60">
+    <!-- reusable drawing -->
+  </canvas>
   <page>
     <!-- content -->
   </page>
@@ -19,13 +23,13 @@ definitions and one or more `<page>` elements.
 
 ### Scope
 
-Both `<ltml>` and `<page>` establish a style scope. Style definitions
+`<ltml>`, `<canvas>`, and `<page>` establish a style scope. Style definitions
 (`<font>`, `<pen>`, `<brush>`, `<para>`, `<bullet>`, `<layout>`), aliases
-(`<define>`), and selector styles (`<style>`) placed inside a
-`<page>` are visible only to that page. Definitions placed directly inside
-`<ltml>` are visible to all pages. A page can always reference definitions from
-its parent `<ltml>` scope, but other pages cannot see definitions made inside a
-sibling page.
+(`<define>`), and selector styles (`<style>`) placed inside a `<canvas>` are
+visible only to that canvas capture. Definitions placed inside a `<page>` are
+visible only to that page. Definitions placed directly inside `<ltml>` are
+visible to all pages and canvases. A page or canvas can always reference
+definitions from its parent `<ltml>` scope, but sibling scopes stay isolated.
 
 ```xml
 <ltml>
@@ -50,7 +54,9 @@ sibling page.
 
 ### `<ltml>` — Document Root
 
-The root element. Attributes set here apply as defaults to all pages.
+The root element. Attributes set here apply as defaults to all pages. Direct
+children may include style definitions, `<canvas>` definitions, and `<page>`
+elements.
 
 | Attribute | Description |
 |-----------|-------------|
@@ -127,6 +133,52 @@ for the PDF and Go API versions of the same setting.
 
 ---
 
+### `<canvas>` — Reusable Drawing Asset
+
+Defines a document-scoped reusable drawing with its own local coordinate
+system. `<canvas>` is captured once at its natural size and later placed with
+`<draw>` one or more times.
+
+`<canvas>` must be a direct child of `<ltml>`. It is not rendered directly into
+page flow.
+
+```xml
+<ltml units="pt">
+  <canvas key="badge" width="160" height="80" layout="absolute">
+    <circle left="16" top="16" width="48" height="48" fill.color="#cfe4ff" />
+    <label left="76" top="24">Score 92</label>
+  </canvas>
+
+  <page>
+    <draw key="badge" />
+    <draw key="badge" width="80" />
+  </page>
+</ltml>
+```
+
+| Attribute | Description |
+|-----------|-------------|
+| `key` | Required document-wide asset key used by `<draw>`. Duplicate keys are rejected. |
+| `width`, `height` | Required natural canvas size. LTML captures the canvas using this fixed coordinate system. |
+| `layout` | Optional layout manager for child widgets. Default: `absolute`. Use `layout.*` for inline overrides. |
+| `font` | Optional default font style for child text widgets. |
+| `fill` / `fill.*` | Optional background brush for the canvas root box. |
+| `border` / `border.*` | Optional border pen for the canvas root box. |
+| `padding`, `padding-top`, `padding-right`, `padding-bottom`, `padding-left` | Optional inner spacing before child content begins. |
+
+`<canvas>` supports ordinary LTML child widgets and local style definitions, but
+not page-only behavior such as page creation, overflow retries, debug grids, or
+page-flow splitting.
+
+Inner page-dependent semantics are treated as visual-only during capture:
+
+- inner links and destinations do not create PDF annotations
+- inner `<pageno>` resolves to empty text
+- inner `<index>` and `<index_entry>` widgets do not participate in document indexes
+- child tagged-PDF structure is suppressed so accessibility stays on the outer `<draw>`
+
+---
+
 ### `<page>` — Page
 
 Defines a single page in the document. Pages must be direct children of `<ltml>`.
@@ -144,6 +196,32 @@ Defines a single page in the document. Pages must be direct children of `<ltml>`
 | `font`        | Reference to a named `<font>` style. |
 | `fill`        | Reference to a named `<brush>` style for the background. |
 | `border`      | Reference to a named `<pen>` style for all borders. |
+
+---
+
+### `<draw>` — Canvas Placement
+
+Places a named `<canvas>` asset into page or container layout. `<draw>` behaves
+like an image-style placement widget.
+
+```xml
+<draw key="badge" width="96" alt="Score badge" />
+```
+
+| Attribute | Description |
+|-----------|-------------|
+| `key` | Required canvas key to place. |
+| `width`, `height` | Optional explicit placement dimensions. If both are omitted, LTML uses the canvas natural size. If only one is supplied, LTML preserves aspect ratio. If both are supplied, LTML stretches to the exact box. |
+| `margin`, `margin-top`, `margin-right`, `margin-bottom`, `margin-left` | Outer spacing around the widget box. |
+| `padding`, `padding-top`, `padding-right`, `padding-bottom`, `padding-left` | Inner spacing inside the widget box. |
+| `border` | Optional enclosing widget border, separate from the captured canvas content. |
+| `fill` | Optional enclosing widget background, separate from the captured canvas content. |
+| `rotate`, `origin-x`, `origin-y`, `shift`, `align`, `display` | Same placement and transform attributes supported by other widgets. |
+| `alt` | When `ua="true"`, opt the draw placement into tagged output and use this text as `/ActualText`. |
+| `role` | Override the default tagged role when `ua="true"`. Draws with `alt` default to `Figure`. |
+
+In v1, `<draw>` places only `<canvas>` assets even though the tag name is
+generic.
 
 ---
 

--- a/ltml/canvas_capture.go
+++ b/ltml/canvas_capture.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Brent Rowland.
+// Use of this source code is governed by the Apache License, Version 2.0, as described in the LICENSE file.
+
+package ltml
+
+import (
+	"fmt"
+	"strings"
+)
+
+func renderCanvasCapture(canvas *StdCanvas, w Writer) error {
+	if canvas == nil {
+		return nil
+	}
+	doc := documentForContainer(canvas.Container())
+	if doc == nil {
+		return fmt.Errorf("canvas %q document is not set", canvas.Key())
+	}
+	if err := doc.pushCanvasCapture(canvas.Key()); err != nil {
+		return err
+	}
+	defer doc.popCanvasCapture()
+
+	resetCanvasWidgetRenderState(canvas)
+	return withDocumentVisualCapture(doc, func() error {
+		canvas.LayoutWidget(w)
+		return Print(canvas, w)
+	})
+}
+
+func withDocumentVisualCapture(doc *StdDocument, fn func() error) error {
+	if fn == nil {
+		return nil
+	}
+	if doc == nil {
+		return fn()
+	}
+	doc.visualCaptureDepth++
+	defer func() {
+		doc.visualCaptureDepth--
+	}()
+	return fn()
+}
+
+func documentVisualCaptureActive(doc *StdDocument) bool {
+	return doc != nil && doc.visualCaptureDepth > 0
+}
+
+func resetCanvasWidgetRenderState(root Widget) {
+	walkWidgets(root, func(widget Widget) bool {
+		widget.SetPrinted(false)
+		widget.SetVisible(true)
+		widget.SetDisabled(false)
+		switch value := widget.(type) {
+		case *StdContainer:
+			value.activeChildren = nil
+		case *StdIndex:
+			value.clearSplitOverride()
+		}
+		return true
+	})
+}
+
+func (d *StdDocument) pushCanvasCapture(key string) error {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return nil
+	}
+	for _, active := range d.canvasCaptureStack {
+		if active == key {
+			path := append(append([]string(nil), d.canvasCaptureStack...), key)
+			return fmt.Errorf("recursive canvas draw detected: %s", strings.Join(path, " -> "))
+		}
+	}
+	d.canvasCaptureStack = append(d.canvasCaptureStack, key)
+	return nil
+}
+
+func (d *StdDocument) popCanvasCapture() {
+	if d == nil || len(d.canvasCaptureStack) == 0 {
+		return
+	}
+	d.canvasCaptureStack = d.canvasCaptureStack[:len(d.canvasCaptureStack)-1]
+}

--- a/ltml/canvas_draw_test.go
+++ b/ltml/canvas_draw_test.go
@@ -1,0 +1,333 @@
+// Copyright 2026 Brent Rowland.
+// Use of this source code is governed the Apache License, Version 2.0, as described in the LICENSE file.
+
+package ltml
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/rowland/leadtype/ltml/ltpdf"
+)
+
+var _ CanvasDrawer = (*ltpdf.DocWriter)(nil)
+
+type canvasDrawCall struct {
+	key          string
+	x            float64
+	y            float64
+	width        float64
+	height       float64
+	canvasWidth  float64
+	canvasHeight float64
+	capture      *labelTestWriter
+}
+
+type canvasTestWriter struct {
+	labelTestWriter
+	drawCalls []canvasDrawCall
+}
+
+func (w *canvasTestWriter) DrawCanvas(key string, x, y, width, height, canvasWidth, canvasHeight float64, draw func(any) error) error {
+	capture := &labelTestWriter{t: w.t}
+	if draw != nil {
+		if err := draw(capture); err != nil {
+			return err
+		}
+	}
+	w.drawCalls = append(w.drawCalls, canvasDrawCall{
+		key:          key,
+		x:            x,
+		y:            y,
+		width:        width,
+		height:       height,
+		canvasWidth:  canvasWidth,
+		canvasHeight: canvasHeight,
+		capture:      capture,
+	})
+	return nil
+}
+
+func parseCanvasDoc(t *testing.T, input string) *Doc {
+	t.Helper()
+	doc, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return doc
+}
+
+func renderCanvasPDF(t *testing.T, input string) string {
+	t.Helper()
+	doc := parseCanvasDoc(t, input)
+	writer := newLTMLPDFWriter(t)
+	if err := doc.Print(writer); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if _, err := writer.WriteTo(&buf); err != nil {
+		t.Fatal(err)
+	}
+	return buf.String()
+}
+
+func captureTexts(w *labelTestWriter) string {
+	if w == nil {
+		return ""
+	}
+	var b strings.Builder
+	for _, rt := range w.printed {
+		if rt != nil {
+			b.WriteString(rt.String())
+		}
+	}
+	for _, text := range w.plainPrinted {
+		b.WriteString(text)
+	}
+	return b.String()
+}
+
+func TestParse_CanvasMustBeDirectChildOfDocument(t *testing.T) {
+	_, err := Parse([]byte(`
+<ltml>
+  <page>
+    <canvas key="board" width="120" height="80" />
+  </page>
+</ltml>`))
+	if err == nil || !strings.Contains(err.Error(), "direct child") {
+		t.Fatalf("Parse error = %v, want direct-child canvas error", err)
+	}
+}
+
+func TestParse_CanvasAndDrawRequireKeysAndCanvasSize(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name: "<canvas> key",
+			input: `
+<ltml>
+  <canvas width="120" height="80" />
+  <page />
+</ltml>`,
+			want: "requires a key",
+		},
+		{
+			name: "<canvas> width",
+			input: `
+<ltml>
+  <canvas key="board" height="80" />
+  <page />
+</ltml>`,
+			want: "requires a positive width",
+		},
+		{
+			name: "<canvas> height",
+			input: `
+<ltml>
+  <canvas key="board" width="120" />
+  <page />
+</ltml>`,
+			want: "requires a positive height",
+		},
+		{
+			name: "<draw> key",
+			input: `
+<ltml>
+  <page><draw /></page>
+  <canvas key="board" width="120" height="80" />
+</ltml>`,
+			want: "<draw> requires a key",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Parse([]byte(tc.input))
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Parse error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestParse_DuplicateCanvasKeysRejected(t *testing.T) {
+	_, err := Parse([]byte(`
+<ltml>
+  <canvas key="board" width="120" height="80" />
+  <canvas key="board" width="120" height="80" />
+  <page />
+</ltml>`))
+	if err == nil || !strings.Contains(err.Error(), "duplicate canvas key") {
+		t.Fatalf("Parse error = %v, want duplicate key error", err)
+	}
+}
+
+func TestStdDocument_DrawCanvasOrderIndependentLookup(t *testing.T) {
+	doc := parseCanvasDoc(t, `
+<ltml units="pt">
+  <page>
+    <draw key="board" />
+  </page>
+  <canvas key="board" width="120" height="80" />
+</ltml>`)
+
+	writer := &canvasTestWriter{labelTestWriter: labelTestWriter{t: t}}
+	if err := doc.Print(writer); err != nil {
+		t.Fatal(err)
+	}
+	if len(writer.drawCalls) != 1 {
+		t.Fatalf("draw call count = %d, want 1", len(writer.drawCalls))
+	}
+	call := writer.drawCalls[0]
+	if call.key != "board" || call.canvasWidth != 120 || call.canvasHeight != 80 {
+		t.Fatalf("draw call = %#v, want board 120x80", call)
+	}
+}
+
+func TestStdDraw_PlacementSizingUsesNaturalSizeAndAspectRatio(t *testing.T) {
+	doc := parseCanvasDoc(t, `
+<ltml units="pt">
+  <page layout="vbox">
+    <draw key="board" />
+    <draw key="board" width="60" />
+    <draw key="board" height="20" />
+    <draw key="board" width="50" height="50" />
+  </page>
+  <canvas key="board" width="120" height="80" />
+</ltml>`)
+
+	writer := &canvasTestWriter{labelTestWriter: labelTestWriter{t: t}}
+	if err := doc.Print(writer); err != nil {
+		t.Fatal(err)
+	}
+	if len(writer.drawCalls) != 4 {
+		t.Fatalf("draw call count = %d, want 4", len(writer.drawCalls))
+	}
+
+	got := [][2]float64{
+		{writer.drawCalls[0].width, writer.drawCalls[0].height},
+		{writer.drawCalls[1].width, writer.drawCalls[1].height},
+		{writer.drawCalls[2].width, writer.drawCalls[2].height},
+		{writer.drawCalls[3].width, writer.drawCalls[3].height},
+	}
+	want := [][2]float64{
+		{120, 80},
+		{60, 40},
+		{30, 20},
+		{50, 50},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("unexpected sizing results: %#v", got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("draw %d size = %v, want %v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestStdDraw_CanvasCaptureUsesLocalScopeAndCanvasChrome(t *testing.T) {
+	doc := parseCanvasDoc(t, `
+<ltml units="pt">
+  <page>
+    <draw key="badge" alt="Badge" />
+  </page>
+  <canvas key="badge" width="120" height="60" padding="8" fill.color="#ffeeaa" border.color="black" border.width="1">
+    <font id="canvasfont" name="Helvetica" size="9" />
+    <label left="0" top="0" width="40" height="12" font="canvasfont">Local</label>
+  </canvas>
+</ltml>`)
+
+	writer := &canvasTestWriter{labelTestWriter: labelTestWriter{t: t}}
+	if err := doc.Print(writer); err != nil {
+		t.Fatal(err)
+	}
+	if len(writer.drawCalls) != 1 {
+		t.Fatalf("draw call count = %d, want 1", len(writer.drawCalls))
+	}
+	call := writer.drawCalls[0]
+	if call.canvasWidth != 120 || call.canvasHeight != 60 {
+		t.Fatalf("canvas size = %vx%v, want 120x60", call.canvasWidth, call.canvasHeight)
+	}
+	if captureTexts(call.capture) != "Local" {
+		t.Fatalf("capture text = %q, want Local", captureTexts(call.capture))
+	}
+	if call.capture.fontSize != 9 {
+		t.Fatalf("capture fontSize = %v, want 9", call.capture.fontSize)
+	}
+	if len(call.capture.rectPages) == 0 {
+		t.Fatalf("expected canvas fill/border rectangle output, got %#v", call.capture.rectPages)
+	}
+}
+
+func TestStdDocument_Print_RejectsUnknownCanvasKey(t *testing.T) {
+	doc := parseCanvasDoc(t, `
+<ltml>
+  <page><draw key="missing" /></page>
+</ltml>`)
+
+	err := doc.Print(&labelTestWriter{t: t})
+	if err == nil || !strings.Contains(err.Error(), "missing canvas definition") {
+		t.Fatalf("Print error = %v, want missing canvas definition", err)
+	}
+}
+
+func TestDrawCanvas_ReusesMemoizedFormAcrossPagesAndSizes(t *testing.T) {
+	pdfText := renderCanvasPDF(t, `
+<ltml units="pt">
+  <canvas key="board" width="160" height="160">
+    <circle left="20" top="20" width="120" height="120" border.color="#1f4ea8" border.width="2" />
+    <circle left="52" top="52" width="56" height="56" fill.color="#cfe4ff" border.color="#1f4ea8" border.width="1.5" />
+    <label left="66" top="68">92</label>
+  </canvas>
+  <page layout="absolute">
+    <draw key="board" left="36" top="48" />
+    <draw key="board" left="240" top="48" width="80" />
+  </page>
+  <page layout="absolute">
+    <draw key="board" left="72" top="96" width="56" />
+  </page>
+</ltml>`)
+
+	if count := strings.Count(pdfText, "/Subtype /Form"); count != 1 {
+		t.Fatalf("expected one reusable canvas form, got %d\n%s", count, pdfText)
+	}
+	if count := strings.Count(pdfText, "/Mf0 Do"); count != 3 {
+		t.Fatalf("expected three placements of the shared canvas form, got %d\n%s", count, pdfText)
+	}
+}
+
+func TestDrawCanvas_SuppressesInnerLinksPageNumbersAndTaggedContent(t *testing.T) {
+	pdfText := renderCanvasPDF(t, `
+<ltml ua="true" units="pt">
+  <canvas key="badge" width="180" height="60">
+    <label id="inner">Page <pageno/></label>
+    <p top="26"><a target="inner">Jump</a></p>
+  </canvas>
+  <page layout="absolute">
+    <p><pageno hidden="true" start="777" /></p>
+    <draw key="badge" left="36" top="48" alt="Badge" />
+  </page>
+</ltml>`)
+
+	if strings.Contains(pdfText, "/Subtype /Link") {
+		t.Fatalf("canvas capture should suppress inner link annotations, got:\n%s", pdfText)
+	}
+	if strings.Contains(pdfText, "/S /GoTo") {
+		t.Fatalf("canvas capture should suppress inner target annotations, got:\n%s", pdfText)
+	}
+	if strings.Contains(pdfText, "(777) Tj") {
+		t.Fatalf("canvas capture should suppress inner page-number text, got:\n%s", pdfText)
+	}
+	if !strings.Contains(pdfText, "/StructTreeRoot") || !strings.Contains(pdfText, "/S /Figure") {
+		t.Fatalf("expected tagged outer draw placement, got:\n%s", pdfText)
+	}
+	if count := strings.Count(pdfText, "BDC\n"); count != 1 {
+		t.Fatalf("expected one outer tagged placement and no inner tagged text, got %d\n%s", count, pdfText)
+	}
+}

--- a/ltml/layout_overflow_test.go
+++ b/ltml/layout_overflow_test.go
@@ -661,8 +661,7 @@ func TestStdContainer_SplitForHeight_VBoxSplitsBodyParagraph(t *testing.T) {
 	para := &StdParagraph{}
 	_ = para.SetContainer(box)
 	para.font = &FontStyle{id: "body", entries: []fontEntry{{name: "Helvetica"}}, size: 12}
-	para.splitEnabled = true
-	para.splitExplicit = true
+	para.splitDisabled = false
 	para.bullet = &BulletStyle{text: "*", width: 18, font: para.font}
 	para.AddText("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.")
 	box.AddChild(para)

--- a/ltml/linking.go
+++ b/ltml/linking.go
@@ -288,6 +288,7 @@ func (d *StdDocument) resetRenderState() {
 	d.documentPageNo = 0
 	d.physicalPageNo = 0
 	d.pendingStart = nil
+	d.canvasCaptureStack = nil
 	walkWidgets(d, func(widget Widget) bool {
 		widget.SetPrinted(false)
 		widget.SetVisible(true)
@@ -304,6 +305,9 @@ func (d *StdDocument) resetRenderState() {
 		}
 		return true
 	})
+	d.eachCanvas(func(canvas *StdCanvas) {
+		resetCanvasWidgetRenderState(canvas)
+	})
 }
 
 func registerPrintedWidgetMetadata(widget Widget, writer Writer) error {
@@ -313,6 +317,9 @@ func registerPrintedWidgetMetadata(widget Widget, writer Writer) error {
 	}
 	doc := documentForContainer(containerWidget.Container())
 	if doc == nil || doc.renderContext == nil {
+		return nil
+	}
+	if documentVisualCaptureActive(doc) {
 		return nil
 	}
 	switch value := widget.(type) {

--- a/ltml/ltml.go
+++ b/ltml/ltml.go
@@ -193,7 +193,18 @@ func (doc *Doc) startElement(elem xml.StartElement) (any, bool) {
 	if parentCurrent, ok := doc.current().(Container); ok && err == nil {
 		parent = parentCurrent
 		if widget, ok := e.(Widget); ok {
-			if isRadialLayoutStyle(parent.LayoutStyle()) {
+			if canvas, ok := widget.(*StdCanvas); ok {
+				if _, ok := doc.current().(*StdDocument); !ok {
+					doc.parseErr = fmt.Errorf("<canvas> must be direct child of <ltml>")
+					return e, capturesBody
+				}
+				if wc, ok := any(canvas).(WantsContainer); ok {
+					if err = wc.SetContainer(parentCurrent); err != nil {
+						doc.parseErr = err
+						return e, capturesBody
+					}
+				}
+			} else if isRadialLayoutStyle(parent.LayoutStyle()) {
 				if _, isSector := widget.(*StdSector); !isSector {
 					wrapper = &StdSector{}
 					if ws, ok := any(wrapper).(WantsScope); ok {
@@ -264,6 +275,22 @@ func (doc *Doc) startElement(elem xml.StartElement) (any, bool) {
 	applyElementAttrs(doc.scope(), e, defaultAttrs, attrs, sourcePath)
 	if wrapper != nil {
 		applyElementAttrs(doc.scope(), wrapper, defaultAttrs, attrs, sourcePath)
+	}
+	switch value := e.(type) {
+	case *StdCanvas:
+		if doc.root == nil {
+			doc.parseErr = fmt.Errorf("<canvas> must be direct child of <ltml>")
+			return e, capturesBody
+		}
+		if err := doc.root.registerCanvas(value); err != nil {
+			doc.parseErr = err
+			return e, capturesBody
+		}
+	case *StdDraw:
+		if strings.TrimSpace(value.key) == "" {
+			doc.parseErr = fmt.Errorf("<draw> requires a key")
+			return e, capturesBody
+		}
 	}
 	if widget, ok := e.(interface{ SetRawAttrs(map[string]string) }); ok {
 		widget.SetRawAttrs(attrs)
@@ -358,6 +385,9 @@ func (doc *Doc) applyPseudoRules() {
 	resolver := newSelectorStructureResolver()
 	if doc.root != nil {
 		doc.applyPseudoRulesToWidget(doc.root, resolver)
+		doc.root.eachCanvas(func(canvas *StdCanvas) {
+			doc.applyPseudoRulesToWidget(canvas, resolver)
+		})
 	}
 }
 

--- a/ltml/ltml_test.go
+++ b/ltml/ltml_test.go
@@ -244,6 +244,7 @@ func TestSamples(t *testing.T) {
 		"test_051_paper_sizes",
 		"test_052_large_paper_sizes",
 		"test_053_avery_labels",
+		"test_054_canvas_draw",
 	}
 
 	for _, sample := range samples {

--- a/ltml/ltpdf/canvas_writer.go
+++ b/ltml/ltpdf/canvas_writer.go
@@ -1,0 +1,72 @@
+// Copyright 2026 Brent Rowland.
+// Use of this source code is governed by the Apache License, Version 2.0, as described in the LICENSE file.
+
+package ltpdf
+
+import "github.com/rowland/leadtype/pdf"
+
+type canvasWriter struct {
+	*pdf.PageWriter
+	docWriter *pdf.DocWriter
+}
+
+func (w *canvasWriter) EnableTaggedPDF(bool) {}
+
+func (w *canvasWriter) NewPage() {}
+
+func (w *canvasWriter) TaggedPDFEnabled() bool {
+	return false
+}
+
+func (w *canvasWriter) ImageDimensions(data []byte) (width, height int, err error) {
+	return w.docWriter.ImageDimensions(data)
+}
+
+func (w *canvasWriter) SVGDimensions(data []byte) (width, height int, err error) {
+	return w.docWriter.SVGDimensions(data)
+}
+
+func (w *canvasWriter) ImageDimensionsFromFile(filename string) (width, height int, err error) {
+	return w.docWriter.ImageDimensionsFromFile(filename)
+}
+
+func (w *canvasWriter) SVGDimensionsFromFile(filename string) (width, height int, err error) {
+	return w.docWriter.SVGDimensionsFromFile(filename)
+}
+
+func (w *canvasWriter) SetLineCapStyle(style string) (prev string) {
+	prevStyle := w.PageWriter.LineCapStyle()
+	switch style {
+	case "round_cap":
+		w.PageWriter.SetLineCapStyle(pdf.RoundCap)
+	case "projecting_square_cap":
+		w.PageWriter.SetLineCapStyle(pdf.ProjectingSquareCap)
+	default:
+		w.PageWriter.SetLineCapStyle(pdf.ButtCap)
+	}
+	switch prevStyle {
+	case pdf.RoundCap:
+		return "round_cap"
+	case pdf.ProjectingSquareCap:
+		return "projecting_square_cap"
+	default:
+		return "butt_cap"
+	}
+}
+
+func (w *canvasWriter) SetLineWidth(width float64) {
+	w.PageWriter.SetLineWidth(width, "pt")
+}
+
+func (w *canvasWriter) DrawCanvas(key string, x, y, width, height, canvasWidth, canvasHeight float64, draw func(any) error) error {
+	if draw == nil {
+		return nil
+	}
+	return w.PageWriter.MemoizeFormOnCanvas(canvasMemoKey(key), x, y, width, height, canvasWidth, canvasHeight, func(pw *pdf.PageWriter) error {
+		return draw(&canvasWriter{PageWriter: pw, docWriter: w.docWriter})
+	})
+}
+
+func canvasMemoKey(key string) string {
+	return "ltml-canvas:" + key
+}

--- a/ltml/ltpdf/doc_writer.go
+++ b/ltml/ltpdf/doc_writer.go
@@ -66,6 +66,15 @@ func (dw *DocWriter) SetLineCapStyle(style string) (prev string) {
 	}
 }
 
+func (dw *DocWriter) DrawCanvas(key string, x, y, width, height, canvasWidth, canvasHeight float64, draw func(any) error) error {
+	if draw == nil {
+		return nil
+	}
+	return dw.DocWriter.MemoizeFormOnCanvas(canvasMemoKey(key), x, y, width, height, canvasWidth, canvasHeight, func(pw *pdf.PageWriter) error {
+		return draw(&canvasWriter{PageWriter: pw, docWriter: dw.DocWriter})
+	})
+}
+
 func NewDocWriter() *DocWriter {
 	dw, err := NewDocWriterWithFontDirs(nil)
 	if err != nil {

--- a/ltml/samples/test_054_canvas_draw.ltml
+++ b/ltml/samples/test_054_canvas_draw.ltml
@@ -1,0 +1,126 @@
+<ltml units="pt" margin="36">
+  <font id="page-title" name="Helvetica" size="22" weight="Bold" />
+  <font id="section-title" name="Helvetica" size="20" weight="Bold" />
+  <font id="lead" name="Helvetica" size="11" line-height="1.35" color="#334e68" />
+  <font id="body" name="Helvetica" size="10.25" line-height="1.35" color="#243b53" />
+  <font id="panel-title" name="Helvetica" size="12" weight="Bold" color="#102a43" />
+  <font id="caption" name="Helvetica" size="9.25" line-height="1.25" color="#52667a" />
+
+  <canvas key="target-board" width="240" height="240" fill.color="#f7fbff" border.color="#102a43" border.width="1.25" corners="16">
+    <circle left="26" top="26" width="188" height="188" fill.color="#dbeafe" border.color="#1d4ed8" border.width="2" />
+    <circle left="54" top="54" width="132" height="132" fill.color="#bfdbfe" border.color="#1d4ed8" border.width="1.5" />
+    <circle left="82" top="82" width="76" height="76" fill.color="#93c5fd" border.color="#1d4ed8" border.width="1.5" />
+    <circle left="104" top="104" width="32" height="32" fill.color="#1d4ed8" border.color="#102a43" border.width="1.25" />
+    <label left="18" top="8" width="204" text-align="center" font.weight="Bold" font.size="11">Reusable Canvas Asset</label>
+    <label left="98" top="112" width="44" text-align="center" font.weight="Bold" font.color="white">92</label>
+  </canvas>
+
+  <page layout="vbox" layout.vpadding="18">
+    <label font="page-title">Canvas Definitions And Draw Placements</label>
+    <p font="lead">
+      This sample defines a single reusable canvas, then places it through ordinary LTML layout containers.
+      The page content uses margins, padding, and layout managers rather than hand-positioned coordinates.
+    </p>
+
+    <div layout="hbox" layout.hpadding="18">
+      <div width="268" layout="vbox" layout.vpadding="12" padding="14" border.color="#d7e3f0" border.width="1" corners="14">
+        <label font="panel-title">Natural Size Placement</label>
+        <p font="body">
+          Omit both width and height and LTML uses the canvas natural 240pt square.
+          The draw participates in normal vbox layout and is centered with padding around it.
+        </p>
+        <draw key="target-board" align-self="center" alt="Large target board diagram" />
+        <label font="caption" width="220" align-self="center" text-align="center">
+          The placement matches the definition size exactly.
+        </label>
+      </div>
+
+      <div width="254" layout="vbox" layout.vpadding="12" padding="14" border.color="#d7e3f0" border.width="1" corners="14">
+        <label font="panel-title">Scaled Reuse</label>
+        <p font="body">
+          The same stored geometry can be placed smaller with width-only sizing, or stretched when both dimensions are explicit.
+        </p>
+
+        <div layout="hbox" layout.hpadding="10">
+          <div width="108" layout="vbox" layout.vpadding="8" padding="8" border.color="#e6edf5" border.width="1" corners="10">
+            <draw key="target-board" width="90" align-self="center" alt="Medium target board diagram" />
+            <label font="caption" width="90" align-self="center" text-align="center">90pt wide</label>
+          </div>
+
+          <div width="108" layout="vbox" layout.vpadding="8" padding="8" border.color="#e6edf5" border.width="1" corners="10">
+            <draw key="target-board" width="54" align-self="center" alt="Small target board diagram" />
+            <label font="caption" width="90" align-self="center" text-align="center">54pt wide</label>
+          </div>
+        </div>
+
+        <p font="caption">
+          Width-only draws preserve aspect ratio automatically.
+        </p>
+
+        <div layout="vbox" layout.vpadding="8" padding="10" border.color="#e6edf5" border.width="1" corners="10">
+          <draw key="target-board" width="96" height="72" align-self="center" alt="Stretched target board diagram" />
+          <label font="caption" text-align="center">96pt by 72pt</label>
+        </div>
+
+        <p font="caption">
+          Setting both width and height stretches to the destination box.
+        </p>
+      </div>
+    </div>
+  </page>
+
+  <page layout="vbox" layout.vpadding="18">
+    <label font="section-title">Repeated Placements Across Pages</label>
+    <p font="lead">
+      The detailed geometry lives in the canvas definition. Every placement below reuses the stored form while choosing a different destination size.
+    </p>
+
+    <div layout="vbox" layout.vpadding="12" padding="14" border.color="#d7e3f0" border.width="1" corners="14">
+      <label font="panel-title">Postage-Stamp Placements</label>
+      <p font="body">
+        A flow container lays out several small placements as ordinary widgets with consistent spacing and padding.
+      </p>
+
+      <div layout="flow" layout.hpadding="12" layout.vpadding="12">
+        <div width="92" layout="vbox" layout.vpadding="8" padding="8" border.color="#e6edf5" border.width="1" corners="10">
+          <draw key="target-board" width="76" align-self="center" alt="Target board diagram at 76 points wide" />
+          <label font="caption" width="76" align-self="center" text-align="center">76pt wide</label>
+        </div>
+        <div width="92" layout="vbox" layout.vpadding="8" padding="8" border.color="#e6edf5" border.width="1" corners="10">
+          <draw key="target-board" width="68" align-self="center" alt="Target board diagram at 68 points wide" />
+          <label font="caption" width="76" align-self="center" text-align="center">68pt wide</label>
+        </div>
+        <div width="92" layout="vbox" layout.vpadding="8" padding="8" border.color="#e6edf5" border.width="1" corners="10">
+          <draw key="target-board" width="60" align-self="center" alt="Target board diagram at 60 points wide" />
+          <label font="caption" width="76" align-self="center" text-align="center">60pt wide</label>
+        </div>
+        <div width="92" layout="vbox" layout.vpadding="8" padding="8" border.color="#e6edf5" border.width="1" corners="10">
+          <draw key="target-board" width="52" align-self="center" alt="Target board diagram at 52 points wide" />
+          <label font="caption" width="76" align-self="center" text-align="center">52pt wide</label>
+        </div>
+        <div width="92" layout="vbox" layout.vpadding="8" padding="8" border.color="#e6edf5" border.width="1" corners="10">
+          <draw key="target-board" width="44" align-self="center" alt="Target board diagram at 44 points wide" />
+          <label font="caption" width="76" align-self="center" text-align="center">44pt wide</label>
+        </div>
+      </div>
+    </div>
+
+    <div layout="hbox" layout.hpadding="18">
+      <div width="210" layout="vbox" layout.vpadding="10" padding="14" border.color="#d7e3f0" border.width="1" corners="14">
+        <label font="panel-title">Reference Size</label>
+        <p font="body">
+          A medium placement can still feel crisp without redefining the asset.
+        </p>
+        <draw key="target-board" width="144" align-self="center" alt="Medium target board diagram" />
+      </div>
+
+      <div width="312" layout="vbox" layout.vpadding="10" padding="14" border.color="#d7e3f0" border.width="1" corners="14">
+        <label font="panel-title">Presentation Size</label>
+        <p font="body">
+          Larger placements can move back toward the original scale while continuing to reuse the same captured canvas.
+        </p>
+        <draw key="target-board" width="216" align-self="center" alt="Large target board diagram" />
+      </div>
+    </div>
+  </page>
+</ltml>

--- a/ltml/samples/test_054_canvas_draw.pdf
+++ b/ltml/samples/test_054_canvas_draw.pdf
@@ -1,0 +1,2290 @@
+%PDF-1.7
+1 0 obj
+<<
+/Count 2 
+/Kids [7 0 R 36 0 R ] 
+/Type /Pages 
+>>
+endobj
+2 0 obj
+<<
+/Count 0 
+/Type /Outlines 
+>>
+endobj
+3 0 obj
+<<
+/MarkInfo <<
+/Marked true 
+>>
+
+/Outlines 2 0 R 
+/PageMode /UseNone 
+/Pages 1 0 R 
+/StructTreeRoot 6 0 R 
+/Type /Catalog 
+>>
+endobj
+4 0 obj
+<<
+/Font <<
+/F0 11 0 R 
+/F1 15 0 R 
+>>
+
+/ProcSet [/PDF /Text /ImageB /ImageC ] 
+/XObject <<
+/Mf0 20 0 R 
+/Mf1 26 0 R 
+/Mf2 30 0 R 
+>>
+
+>>
+endobj
+5 0 obj
+<<
+/Nums [0 [8 0 R 12 0 R 12 0 R 16 0 R 17 0 R 17 0 R 17 0 R 17 0 R 18 0 R 21 0 R 22 0 R 23 0 R 23 0 R 23 0 R 24 0 R 27 0 R 28 0 R 31 0 R 32 0 R 33 0 R 34 0 R 35 0 R 35 0 R ] 1 [37 0 R 38 0 R 38 0 R 39 0 R 40 0 R 41 0 R 42 0 R 43 0 R 44 0 R 45 0 R 46 0 R 47 0 R 48 0 R 49 0 R 50 0 R 51 0 R 52 0 R 52 0 R 53 0 R 54 0 R 55 0 R 55 0 R 56 0 R ] ] 
+>>
+endobj
+6 0 obj
+<<
+/K [8 0 R 12 0 R 16 0 R 17 0 R 18 0 R 21 0 R 22 0 R 23 0 R 24 0 R 27 0 R 28 0 R 31 0 R 32 0 R 33 0 R 34 0 R 35 0 R 37 0 R 38 0 R 39 0 R 40 0 R 41 0 R 42 0 R 43 0 R 44 0 R 45 0 R 46 0 R 47 0 R 48 0 R 49 0 R 50 0 R 51 0 R 52 0 R 53 0 R 54 0 R 55 0 R 56 0 R ] 
+/ParentTree 5 0 R 
+/ParentTreeNextKey 2 
+/Type /StructTreeRoot 
+>>
+endobj
+7 0 obj
+<<
+/Contents 57 0 R 
+/CropBox [0 0 612 792 ] 
+/Length 6676 
+/MediaBox [0 0 612 792 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 0 
+/Type /Page 
+>>
+endobj
+8 0 obj
+<<
+/ActualText (Canvas Definitions And Draw Placements) 
+/K <<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+9 0 obj
+<<
+/Ascent 1577 
+/AvgWidth 0 
+/CapHeight 1474 
+/Descent -471 
+/Flags 262144 
+/FontBBox [-2084 -985 2810 1971 ] 
+/FontFamily (Helvetica) 
+/FontFile2 64 0 R 
+/FontName /BAVZRT+Helvetica-Bold 
+/ItalicAngle 0 
+/Leading 2048 
+/MaxWidth 0 
+/MissingWidth 0 
+/StemH 0 
+/StemV 165 
+/Type /FontDescriptor 
+/XHeight 1090 
+>>
+endobj
+10 0 obj
+<<
+/BaseFont /BAVZRT+Helvetica-Bold 
+/CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> 
+/CIDToGIDMap 63 0 R 
+/DW 556 
+/FontDescriptor 9 0 R 
+/Subtype /CIDFontType2 
+/Type /Font 
+/W [1 [722 ] 3 [610 ] 6 [277 722 ] 9 [333 277 333 610 722 610 389 777 666 277 ] 20 [889 722 610 666 500 722 610 ] 29 [610 610 333 ] ] 
+>>
+endobj
+11 0 obj
+<<
+/BaseFont /BAVZRT+Helvetica-Bold 
+/DescendantFonts [10 0 R ] 
+/Encoding /Identity-H 
+/Subtype /Type0 
+/ToUnicode 62 0 R 
+/Type /Font 
+>>
+endobj
+12 0 obj
+<<
+/ActualText (This sample defines a single reusable canvas, then places it through ordinary LTML layout containers. The page content uses margins, padding, and layout managers rather than hand-positioned coordinates. ) 
+/K [<<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 1 
+>>
+<<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 2 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+13 0 obj
+<<
+/Ascent 1577 
+/AvgWidth 0 
+/CapHeight 1469 
+/Descent -471 
+/Flags 0 
+/FontBBox [-1947 -985 2961 2297 ] 
+/FontFamily (Helvetica) 
+/FontFile2 61 0 R 
+/FontName /SXJWDI+Helvetica 
+/ItalicAngle 0 
+/Leading 2048 
+/MaxWidth 0 
+/MissingWidth 0 
+/StemH 0 
+/StemV 87 
+/Type /FontDescriptor 
+/XHeight 1071 
+>>
+endobj
+14 0 obj
+<<
+/BaseFont /SXJWDI+Helvetica 
+/CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> 
+/CIDToGIDMap 60 0 R 
+/DW 556 
+/FontDescriptor 13 0 R 
+/Subtype /CIDFontType2 
+/Type /Font 
+/W [1 [610 ] 3 [222 500 277 ] 7 [833 ] 9 [222 ] 12 [277 ] 15 [333 ] 18 [500 500 277 277 ] 23 [500 ] 25 [833 277 333 777 722 ] 34 [500 500 ] 38 [943 ] 41 [666 666 666 ] 45 [500 ] ] 
+>>
+endobj
+15 0 obj
+<<
+/BaseFont /SXJWDI+Helvetica 
+/DescendantFonts [14 0 R ] 
+/Encoding /Identity-H 
+/Subtype /Type0 
+/ToUnicode 59 0 R 
+/Type /Font 
+>>
+endobj
+16 0 obj
+<<
+/ActualText (Natural Size Placement) 
+/K <<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+17 0 obj
+<<
+/ActualText (Omit both width and height and LTML uses the canvas natural 240pt square. The draw participates in normal vbox layout and is centered with padding around it. ) 
+/K [<<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 4 
+>>
+<<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 5 
+>>
+<<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 6 
+>>
+<<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 7 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+18 0 obj
+<<
+/ActualText (Large target board diagram) 
+/K <<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 8 
+>>
+
+/P 6 0 R 
+/S /Figure 
+/Type /StructElem 
+>>
+endobj
+19 0 obj
+<<
+/Font <<
+/F0 11 0 R 
+/F1 15 0 R 
+>>
+
+/ProcSet [/PDF /Text /ImageB /ImageC ] 
+>>
+endobj
+20 0 obj
+<<
+/BBox [0 0 240 240 ] 
+/FormType 1 
+/Length 1389 
+/Resources 19 0 R 
+/Subtype /Form 
+/Type /XObject 
+>>
+stream
+0.9686 0.9843 1 rg
+0.8431 0.8902 0.9412 RG
+1 w
+[] 0 d
+0 J
+10 M
+240 224 m
+240 232.8366 232.8366 240 224 240 c
+16 240 l
+7.1634 240 0 232.8366 0 224 c
+0 16 l
+0 7.1634 7.1634 0 16 0 c
+224 0 l
+232.8366 0 240 7.1634 240 16 c
+240 224 l
+f
+0.0627 0.1647 0.2627 RG
+1.25 w
+240 224 m
+240 232.8366 232.8366 240 224 240 c
+16 240 l
+7.1634 240 0 232.8366 0 224 c
+0 16 l
+0 7.1634 7.1634 0 16 0 c
+224 0 l
+232.8366 0 240 7.1634 240 16 c
+240 224 l
+S
+0.1137 0.3059 0.8471 RG
+2 w
+214 120 m
+214 171.9148 171.9148 214 120 214 c
+68.0852 214 26 171.9148 26 120 c
+26 68.0852 68.0852 26 120 26 c
+171.9148 26 214 68.0852 214 120 c
+h
+0.8588 0.9176 0.9961 rg
+B
+1.5 w
+186 120 m
+186 156.4508 156.4508 186 120 186 c
+83.5492 186 54 156.4508 54 120 c
+54 83.5492 83.5492 54 120 54 c
+156.4508 54 186 83.5492 186 120 c
+h
+0.749 0.8588 0.9961 rg
+B
+158 120 m
+158 140.9868 140.9868 158 120 158 c
+99.0132 158 82 140.9868 82 120 c
+82 99.0132 99.0132 82 120 82 c
+140.9868 82 158 99.0132 158 120 c
+h
+0.5765 0.7725 0.9922 rg
+B
+0.0627 0.1647 0.2627 RG
+1.25 w
+136 120 m
+136 128.8366 128.8366 136 120 136 c
+111.1634 136 104 128.8366 104 120 c
+104 111.1634 111.1634 104 120 104 c
+128.8366 104 136 111.1634 136 120 c
+h
+0.1137 0.3059 0.8471 rg
+B
+BT
+57.9424 223.5298 Td
+0 0 0 rg
+/F0 11 Tf
+0 Ts
+<00190008001600050002001a0012000800060001000200030004000200050006000d000500050008000b> Tj
+55.3838 -104.77 Td
+1 1 1 rg
+/F0 12 Tf
+0 Ts
+<001b001c> Tj
+ET
+endstream
+endobj
+21 0 obj
+<<
+/ActualText (The placement matches the definition size exactly. ) 
+/K <<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 9 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+22 0 obj
+<<
+/ActualText (Scaled Reuse) 
+/K <<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 10 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+23 0 obj
+<<
+/ActualText (The same stored geometry can be placed smaller with width-only sizing, or stretched when both dimensions are explicit. ) 
+/K [<<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 11 
+>>
+<<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 12 
+>>
+<<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 13 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+24 0 obj
+<<
+/ActualText (Medium target board diagram) 
+/K <<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 14 
+>>
+
+/P 6 0 R 
+/S /Figure 
+/Type /StructElem 
+>>
+endobj
+25 0 obj
+<<
+/Font <<
+/F0 11 0 R 
+/F1 15 0 R 
+>>
+
+/ProcSet [/PDF /Text /ImageB /ImageC ] 
+/XObject <<
+/Mf0 20 0 R 
+>>
+
+>>
+endobj
+26 0 obj
+<<
+/BBox [0 0 240 240 ] 
+/FormType 1 
+/Length 1388 
+/Resources 25 0 R 
+/Subtype /Form 
+/Type /XObject 
+>>
+stream
+0.9686 0.9843 1 rg
+0.902 0.9294 0.9608 RG
+1 w
+[] 0 d
+0 J
+10 M
+240 224 m
+240 232.8366 232.8366 240 224 240 c
+16 240 l
+7.1634 240 0 232.8366 0 224 c
+0 16 l
+0 7.1634 7.1634 0 16 0 c
+224 0 l
+232.8366 0 240 7.1634 240 16 c
+240 224 l
+f
+0.0627 0.1647 0.2627 RG
+1.25 w
+240 224 m
+240 232.8366 232.8366 240 224 240 c
+16 240 l
+7.1634 240 0 232.8366 0 224 c
+0 16 l
+0 7.1634 7.1634 0 16 0 c
+224 0 l
+232.8366 0 240 7.1634 240 16 c
+240 224 l
+S
+0.1137 0.3059 0.8471 RG
+2 w
+214 120 m
+214 171.9148 171.9148 214 120 214 c
+68.0852 214 26 171.9148 26 120 c
+26 68.0852 68.0852 26 120 26 c
+171.9148 26 214 68.0852 214 120 c
+h
+0.8588 0.9176 0.9961 rg
+B
+1.5 w
+186 120 m
+186 156.4508 156.4508 186 120 186 c
+83.5492 186 54 156.4508 54 120 c
+54 83.5492 83.5492 54 120 54 c
+156.4508 54 186 83.5492 186 120 c
+h
+0.749 0.8588 0.9961 rg
+B
+158 120 m
+158 140.9868 140.9868 158 120 158 c
+99.0132 158 82 140.9868 82 120 c
+82 99.0132 99.0132 82 120 82 c
+140.9868 82 158 99.0132 158 120 c
+h
+0.5765 0.7725 0.9922 rg
+B
+0.0627 0.1647 0.2627 RG
+1.25 w
+136 120 m
+136 128.8366 128.8366 136 120 136 c
+111.1634 136 104 128.8366 104 120 c
+104 111.1634 111.1634 104 120 104 c
+128.8366 104 136 111.1634 136 120 c
+h
+0.1137 0.3059 0.8471 rg
+B
+BT
+57.9424 223.5298 Td
+0 0 0 rg
+/F0 11 Tf
+0 Ts
+<00190008001600050002001a0012000800060001000200030004000200050006000d000500050008000b> Tj
+55.3838 -104.77 Td
+1 1 1 rg
+/F0 12 Tf
+0 Ts
+<001b001c> Tj
+ET
+endstream
+endobj
+27 0 obj
+<<
+/ActualText (90pt wide) 
+/K <<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 15 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+28 0 obj
+<<
+/ActualText (Small target board diagram) 
+/K <<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 16 
+>>
+
+/P 6 0 R 
+/S /Figure 
+/Type /StructElem 
+>>
+endobj
+29 0 obj
+<<
+/Font <<
+/F0 11 0 R 
+/F1 15 0 R 
+>>
+
+/ProcSet [/PDF /Text /ImageB /ImageC ] 
+/XObject <<
+/Mf0 20 0 R 
+/Mf1 26 0 R 
+>>
+
+>>
+endobj
+30 0 obj
+<<
+/BBox [0 0 240 240 ] 
+/FormType 1 
+/Length 1388 
+/Resources 29 0 R 
+/Subtype /Form 
+/Type /XObject 
+>>
+stream
+0.9686 0.9843 1 rg
+0.902 0.9294 0.9608 RG
+1 w
+[] 0 d
+0 J
+10 M
+240 224 m
+240 232.8366 232.8366 240 224 240 c
+16 240 l
+7.1634 240 0 232.8366 0 224 c
+0 16 l
+0 7.1634 7.1634 0 16 0 c
+224 0 l
+232.8366 0 240 7.1634 240 16 c
+240 224 l
+f
+0.0627 0.1647 0.2627 RG
+1.25 w
+240 224 m
+240 232.8366 232.8366 240 224 240 c
+16 240 l
+7.1634 240 0 232.8366 0 224 c
+0 16 l
+0 7.1634 7.1634 0 16 0 c
+224 0 l
+232.8366 0 240 7.1634 240 16 c
+240 224 l
+S
+0.1137 0.3059 0.8471 RG
+2 w
+214 120 m
+214 171.9148 171.9148 214 120 214 c
+68.0852 214 26 171.9148 26 120 c
+26 68.0852 68.0852 26 120 26 c
+171.9148 26 214 68.0852 214 120 c
+h
+0.8588 0.9176 0.9961 rg
+B
+1.5 w
+186 120 m
+186 156.4508 156.4508 186 120 186 c
+83.5492 186 54 156.4508 54 120 c
+54 83.5492 83.5492 54 120 54 c
+156.4508 54 186 83.5492 186 120 c
+h
+0.749 0.8588 0.9961 rg
+B
+158 120 m
+158 140.9868 140.9868 158 120 158 c
+99.0132 158 82 140.9868 82 120 c
+82 99.0132 99.0132 82 120 82 c
+140.9868 82 158 99.0132 158 120 c
+h
+0.5765 0.7725 0.9922 rg
+B
+0.0627 0.1647 0.2627 RG
+1.25 w
+136 120 m
+136 128.8366 128.8366 136 120 136 c
+111.1634 136 104 128.8366 104 120 c
+104 111.1634 111.1634 104 120 104 c
+128.8366 104 136 111.1634 136 120 c
+h
+0.1137 0.3059 0.8471 rg
+B
+BT
+57.9424 223.5298 Td
+0 0 0 rg
+/F0 11 Tf
+0 Ts
+<00190008001600050002001a0012000800060001000200030004000200050006000d000500050008000b> Tj
+55.3838 -104.77 Td
+1 1 1 rg
+/F0 12 Tf
+0 Ts
+<001b001c> Tj
+ET
+endstream
+endobj
+31 0 obj
+<<
+/ActualText (54pt wide) 
+/K <<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 17 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+32 0 obj
+<<
+/ActualText (Width-only draws preserve aspect ratio automatically. ) 
+/K <<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 18 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+33 0 obj
+<<
+/ActualText (Stretched target board diagram) 
+/K <<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 19 
+>>
+
+/P 6 0 R 
+/S /Figure 
+/Type /StructElem 
+>>
+endobj
+34 0 obj
+<<
+/ActualText (96pt by 72pt) 
+/K <<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 20 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+35 0 obj
+<<
+/ActualText (Setting both width and height stretches to the destination box. ) 
+/K [<<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 21 
+>>
+<<
+/Type /MCR 
+/Pg 7 0 R 
+/MCID 22 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+36 0 obj
+<<
+/Contents 58 0 R 
+/CropBox [0 0 612 792 ] 
+/Length 7075 
+/MediaBox [0 0 612 792 ] 
+/Parent 1 0 R 
+/Resources 4 0 R 
+/Rotate 0 
+/StructParents 1 
+/Type /Page 
+>>
+endobj
+37 0 obj
+<<
+/ActualText (Repeated Placements Across Pages) 
+/K <<
+/Type /MCR 
+/Pg 36 0 R 
+/MCID 0 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+38 0 obj
+<<
+/ActualText (The detailed geometry lives in the canvas definition. Every placement below reuses the stored form while choosing a different destination size. ) 
+/K [<<
+/Type /MCR 
+/Pg 36 0 R 
+/MCID 1 
+>>
+<<
+/Type /MCR 
+/Pg 36 0 R 
+/MCID 2 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+39 0 obj
+<<
+/ActualText (Postage-Stamp Placements) 
+/K <<
+/Type /MCR 
+/Pg 36 0 R 
+/MCID 3 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+40 0 obj
+<<
+/ActualText (A flow container lays out several small placements as ordinary widgets with consistent spacing and padding. ) 
+/K <<
+/Type /MCR 
+/Pg 36 0 R 
+/MCID 4 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+41 0 obj
+<<
+/ActualText (Target board diagram at 76 points wide) 
+/K <<
+/Type /MCR 
+/Pg 36 0 R 
+/MCID 5 
+>>
+
+/P 6 0 R 
+/S /Figure 
+/Type /StructElem 
+>>
+endobj
+42 0 obj
+<<
+/ActualText (76pt wide) 
+/K <<
+/Type /MCR 
+/Pg 36 0 R 
+/MCID 6 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+43 0 obj
+<<
+/ActualText (Target board diagram at 68 points wide) 
+/K <<
+/Type /MCR 
+/Pg 36 0 R 
+/MCID 7 
+>>
+
+/P 6 0 R 
+/S /Figure 
+/Type /StructElem 
+>>
+endobj
+44 0 obj
+<<
+/ActualText (68pt wide) 
+/K <<
+/Type /MCR 
+/Pg 36 0 R 
+/MCID 8 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+45 0 obj
+<<
+/ActualText (Target board diagram at 60 points wide) 
+/K <<
+/Type /MCR 
+/Pg 36 0 R 
+/MCID 9 
+>>
+
+/P 6 0 R 
+/S /Figure 
+/Type /StructElem 
+>>
+endobj
+46 0 obj
+<<
+/ActualText (60pt wide) 
+/K <<
+/Type /MCR 
+/Pg 36 0 R 
+/MCID 10 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+47 0 obj
+<<
+/ActualText (Target board diagram at 52 points wide) 
+/K <<
+/Type /MCR 
+/Pg 36 0 R 
+/MCID 11 
+>>
+
+/P 6 0 R 
+/S /Figure 
+/Type /StructElem 
+>>
+endobj
+48 0 obj
+<<
+/ActualText (52pt wide) 
+/K <<
+/Type /MCR 
+/Pg 36 0 R 
+/MCID 12 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+49 0 obj
+<<
+/ActualText (Target board diagram at 44 points wide) 
+/K <<
+/Type /MCR 
+/Pg 36 0 R 
+/MCID 13 
+>>
+
+/P 6 0 R 
+/S /Figure 
+/Type /StructElem 
+>>
+endobj
+50 0 obj
+<<
+/ActualText (44pt wide) 
+/K <<
+/Type /MCR 
+/Pg 36 0 R 
+/MCID 14 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+51 0 obj
+<<
+/ActualText (Reference Size) 
+/K <<
+/Type /MCR 
+/Pg 36 0 R 
+/MCID 15 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+52 0 obj
+<<
+/ActualText (A medium placement can still feel crisp without redefining the asset. ) 
+/K [<<
+/Type /MCR 
+/Pg 36 0 R 
+/MCID 16 
+>>
+<<
+/Type /MCR 
+/Pg 36 0 R 
+/MCID 17 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+53 0 obj
+<<
+/ActualText (Medium target board diagram) 
+/K <<
+/Type /MCR 
+/Pg 36 0 R 
+/MCID 18 
+>>
+
+/P 6 0 R 
+/S /Figure 
+/Type /StructElem 
+>>
+endobj
+54 0 obj
+<<
+/ActualText (Presentation Size) 
+/K <<
+/Type /MCR 
+/Pg 36 0 R 
+/MCID 19 
+>>
+
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+55 0 obj
+<<
+/ActualText (Larger placements can move back toward the original scale while continuing to reuse the same captured canvas. ) 
+/K [<<
+/Type /MCR 
+/Pg 36 0 R 
+/MCID 20 
+>>
+<<
+/Type /MCR 
+/Pg 36 0 R 
+/MCID 21 
+>>
+] 
+/P 6 0 R 
+/S /P 
+/Type /StructElem 
+>>
+endobj
+56 0 obj
+<<
+/ActualText (Large target board diagram) 
+/K <<
+/Type /MCR 
+/Pg 36 0 R 
+/MCID 22 
+>>
+
+/P 6 0 R 
+/S /Figure 
+/Type /StructElem 
+>>
+endobj
+57 0 obj
+<<
+/Length 6676 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 739.0596 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 22 Tf
+0 Ts
+<0001000200030004000200050006000700080009000a0003000a000b000a000c000300050006000d0003000e00060007000f00020010000600110012000200130008001400080003000b0005> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -31.5298 Td
+/P <<
+/MCID 1 
+>>
+BDC
+0.2 0.3059 0.4078 rg
+/F1 11 Tf
+0 Ts
+<0001000200030004000500040006000700080009000a0005000b000a000c0003000d000a000400050006000500040003000d000e0009000a0005000f000a00100004000600110009000a000500120006000d0013000600040014000500150002000a000d00050008000900060012000a0004000500030015000500150002000f00160010000e000200050016000f000b0003000d0006000f0017000500180001001900180005000900060017001600100015000500120016000d001500060003000d000a000f0004001a000500010002000a> Tj
+EMC
+0 -14.85 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<00080006000e000a000500120016000d0015000a000d0015000500100004000a0004000500070006000f000e0003000d00040014000500080006000b000b0003000d000e001400050006000d000b0005000900060017001600100015000500070006000d0006000e000a000f00040005000f000600150002000a000f0005001500020006000d000500020006000d000b001b0008001600040003001500030016000d000a000b0005001200160016000f000b0003000d00060015000a0004001a> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+ET
+0.8431 0.8902 0.9412 RG
+1 w
+[] 0 d
+0 J
+304 658.15 m
+304 665.882 297.732 672.15 290 672.15 c
+50 672.15 l
+42.268 672.15 36 665.882 36 658.15 c
+36 306.825 l
+36 299.093 42.268 292.825 50 292.825 c
+290 292.825 l
+297.732 292.825 304 299.093 304 306.825 c
+304 658.15 l
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+50 648.9098 Td
+/P <<
+/MCID 3 
+>>
+BDC
+0.0627 0.1647 0.2627 rg
+/F0 12 Tf
+0 Ts
+<00150002000b0016000f0002001200060017000a00180008000600110012000200130008001400080003000b> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -22.6525 Td
+/P <<
+/MCID 4 
+>>
+BDC
+0.1412 0.2314 0.3255 rg
+/F1 10.25 Tf
+0 Ts
+<001c000700030015000500110016001500020005001d0003000b0015000200050006000d000b00050002000a0003000e0002001500050006000d000b00050018000100190018000500100004000a0004000500150002000a> Tj
+EMC
+0 -13.8375 Td
+/P <<
+/MCID 5 
+>>
+BDC
+<00120006000d0013000600040005000d000600150010000f000600090005001e001f00200008001500050004002100100006000f000a001a000500010002000a0005000b000f0006001d000500080006000f0015000300120003000800060015000a0004> Tj
+EMC
+0 -13.8375 Td
+/P <<
+/MCID 6 
+>>
+BDC
+<0003000d0005000d0016000f00070006000900050013001100160022000500090006001700160010001500050006000d000b00050003000400050012000a000d0015000a000f000a000b0005001d000300150002000500080006000b000b0003000d000e> Tj
+EMC
+0 -13.8375 Td
+/P <<
+/MCID 7 
+>>
+BDC
+<0006000f00160010000d000b000500030015001a> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+ET
+/Figure <<
+/MCID 8 
+>>
+BDC
+q
+1 0 0 1 50 330.3875 cm
+/Mf0 Do
+Q
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+65.3707 311.2648 Td
+/P <<
+/MCID 9 
+>>
+BDC
+0.3216 0.4 0.4784 rg
+/F1 9.25 Tf
+0 Ts
+<00010002000a00050008000900060012000a0007000a000d0015000500070006001500120002000a0004000500150002000a0005000b000a000c0003000d0003001500030016000d0005000400030023000a0005000a002200060012001500090017001a0005> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+ET
+576 658.15 m
+576 665.882 569.732 672.15 562 672.15 c
+336 672.15 l
+328.268 672.15 322 665.882 322 658.15 c
+322 281.0375 l
+322 273.3055 328.268 267.0375 336 267.0375 c
+562 267.0375 l
+569.732 267.0375 576 273.3055 576 281.0375 c
+576 658.15 l
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+336 648.9098 Td
+/P <<
+/MCID 10 
+>>
+BDC
+0.0627 0.1647 0.2627 rg
+/F0 12 Tf
+0 Ts
+<00170013000200120008000e000600190008001600050008> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -22.6525 Td
+/P <<
+/MCID 11 
+>>
+BDC
+0.1412 0.2314 0.3255 rg
+/F1 10.25 Tf
+0 Ts
+<00010002000a0005000400060007000a0005000400150016000f000a000b0005000e000a00160007000a0015000f0017000500120006000d00050011000a00050008000900060012000a000b000500040007000600090009000a000f> Tj
+EMC
+0 -13.8375 Td
+/P <<
+/MCID 12 
+>>
+BDC
+<001d0003001500020005001d0003000b00150002001b0016000d0009001700050004000300230003000d000e001400050016000f000500040015000f000a001500120002000a000b0005001d0002000a000d00050011001600150002> Tj
+EMC
+0 -13.8375 Td
+/P <<
+/MCID 13 
+>>
+BDC
+<000b00030007000a000d000400030016000d000400050006000f000a0005000a0022000800090003001200030015001a> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+ET
+0.902 0.9294 0.9608 RG
+444 574.225 m
+444 579.7478 439.5228 584.225 434 584.225 c
+346 584.225 l
+340.4772 584.225 336 579.7478 336 574.225 c
+336 468.6625 l
+336 463.1397 340.4772 458.6625 346 458.6625 c
+434 458.6625 l
+439.5228 458.6625 444 463.1397 444 468.6625 c
+444 574.225 l
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Figure <<
+/MCID 14 
+>>
+BDC
+q
+0.375 0 0 0.375 345 486.225 cm
+/Mf1 Do
+Q
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+370.2015 471.1023 Td
+/P <<
+/MCID 15 
+>>
+BDC
+0.3216 0.4 0.4784 rg
+/F1 9.25 Tf
+0 Ts
+<00240020000800150005001d0003000b000a> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+ET
+562 574.225 m
+562 579.7478 557.5228 584.225 552 584.225 c
+464 584.225 l
+458.4772 584.225 454 579.7478 454 574.225 c
+454 504.6625 l
+454 499.1397 458.4772 494.6625 464 494.6625 c
+552 494.6625 l
+557.5228 494.6625 562 499.1397 562 504.6625 c
+562 574.225 l
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Figure <<
+/MCID 16 
+>>
+BDC
+q
+0.225 0 0 0.225 481 522.225 cm
+/Mf2 Do
+Q
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+488.2015 507.1023 Td
+/P <<
+/MCID 17 
+>>
+BDC
+/F1 9.25 Tf
+0 Ts
+<0025001f000800150005001d0003000b000a> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+-152.2015 -67.5625 Td
+/P <<
+/MCID 18 
+>>
+BDC
+<00260003000b00150002001b0016000d000900170005000b000f0006001d000400050008000f000a0004000a000f0013000a0005000600040008000a001200150005000f000600150003001600050006001000150016000700060015000300120006000900090017001a> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+ET
+562 415.4125 m
+562 420.9353 557.5228 425.4125 552 425.4125 c
+346 425.4125 l
+340.4772 425.4125 336 420.9353 336 415.4125 c
+336 323.85 l
+336 318.3272 340.4772 313.85 346 313.85 c
+552 313.85 l
+557.5228 313.85 562 318.3272 562 323.85 c
+562 415.4125 l
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Figure <<
+/MCID 19 
+>>
+BDC
+q
+0.4 0 0 0.3 401 343.4125 cm
+/Mf2 Do
+Q
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+346 328.2898 Td
+/P <<
+/MCID 20 
+>>
+BDC
+/F1 9.25 Tf
+0 Ts
+<002400270008001500050011001700050028001e00080015> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+-10 -33.5625 Td
+/P <<
+/MCID 21 
+>>
+BDC
+<0029000a001500150003000d000e000500110016001500020005001d0003000b0015000200050006000d000b00050002000a0003000e00020015000500040015000f000a001500120002000a0004000500150016000500150002000a> Tj
+EMC
+0 -11.5625 Td
+/P <<
+/MCID 22 
+>>
+BDC
+<000b000a000400150003000d0006001500030016000d0005001100160022001a> Tj
+EMC
+ET
+endstream
+endobj
+58 0 obj
+<<
+/Length 7075 
+>>
+stream
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+36 740.5996 Td
+/P <<
+/MCID 0 
+>>
+BDC
+/F0 20 Tf
+0 Ts
+<00190008001d00080002000b0008000e000600110012000200130008001400080003000b00050006000d0013000f000c00050005000600110002001e00080005> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -31.0698 Td
+/P <<
+/MCID 1 
+>>
+BDC
+0.2 0.3059 0.4078 rg
+/F1 11 Tf
+0 Ts
+<00010002000a0005000b000a0015000600030009000a000b0005000e000a00160007000a0015000f00170005000900030013000a000400050003000d000500150002000a000500120006000d0013000600040005000b000a000c0003000d0003001500030016000d001a0005002a0013000a000f001700050008000900060012000a0007000a000d001500050011000a00090016001d0005000f000a00100004000a0004000500150002000a0005000400150016000f000a000b0005000c0016000f00070005001d000200030009000a> Tj
+EMC
+0 -14.85 Td
+/P <<
+/MCID 2 
+>>
+BDC
+<001200020016001600040003000d000e000500060005000b0003000c000c000a000f000a000d00150005000b000a000400150003000d0006001500030016000d0005000400030023000a001a> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+ET
+0.8431 0.8902 0.9412 RG
+1 w
+[] 0 d
+0 J
+576 660.15 m
+576 667.882 569.732 674.15 562 674.15 c
+50 674.15 l
+42.268 674.15 36 667.882 36 660.15 c
+36 502.3375 l
+36 494.6055 42.268 488.3375 50 488.3375 c
+562 488.3375 l
+569.732 488.3375 576 494.6055 576 502.3375 c
+576 660.15 l
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+50 650.9098 Td
+/P <<
+/MCID 3 
+>>
+BDC
+0.0627 0.1647 0.2627 rg
+/F0 12 Tf
+0 Ts
+<0011000c0005000b0002001e0008001f0017000b00020014001d000600110012000200130008001400080003000b0005> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -22.6525 Td
+/P <<
+/MCID 4 
+>>
+BDC
+0.1412 0.2314 0.3255 rg
+/F1 10.25 Tf
+0 Ts
+<002b0005000c00090016001d000500120016000d001500060003000d000a000f00050009000600170004000500160010001500050004000a0013000a000f0006000900050004000700060009000900050008000900060012000a0007000a000d0015000400050006000400050016000f000b0003000d0006000f00170005001d0003000b000e000a001500040005001d000300150002000500120016000d0004000300040015000a000d0015000500040008000600120003000d000e00050006000d000b000500080006000b000b0003000d000e001a> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+ET
+0.902 0.9294 0.9608 RG
+142 603.9 m
+142 609.4228 137.5228 613.9 132 613.9 c
+60 613.9 l
+54.4772 613.9 50 609.4228 50 603.9 c
+50 512.3375 l
+50 506.8147 54.4772 502.3375 60 502.3375 c
+132 502.3375 l
+137.5228 502.3375 142 506.8147 142 512.3375 c
+142 603.9 l
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Figure <<
+/MCID 5 
+>>
+BDC
+q
+0.3167 0 0 0.3167 58 529.9 cm
+/Mf1 Do
+Q
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+76.2015 514.7773 Td
+/P <<
+/MCID 6 
+>>
+BDC
+0.3216 0.4 0.4784 rg
+/F1 9.25 Tf
+0 Ts
+<00280027000800150005001d0003000b000a> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+ET
+246 603.9 m
+246 609.4228 241.5228 613.9 236 613.9 c
+164 613.9 l
+158.4772 613.9 154 609.4228 154 603.9 c
+154 520.3375 l
+154 514.8147 158.4772 510.3375 164 510.3375 c
+236 510.3375 l
+241.5228 510.3375 246 514.8147 246 520.3375 c
+246 603.9 l
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Figure <<
+/MCID 7 
+>>
+BDC
+q
+0.2833 0 0 0.2833 166 537.9 cm
+/Mf2 Do
+Q
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+180.2015 522.7773 Td
+/P <<
+/MCID 8 
+>>
+BDC
+/F1 9.25 Tf
+0 Ts
+<0027002c000800150005001d0003000b000a> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+ET
+350 603.9 m
+350 609.4228 345.5228 613.9 340 613.9 c
+268 613.9 l
+262.4772 613.9 258 609.4228 258 603.9 c
+258 528.3375 l
+258 522.8147 262.4772 518.3375 268 518.3375 c
+340 518.3375 l
+345.5228 518.3375 350 522.8147 350 528.3375 c
+350 603.9 l
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Figure <<
+/MCID 9 
+>>
+BDC
+q
+0.25 0 0 0.25 274 545.9 cm
+/Mf2 Do
+Q
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+284.2015 530.7773 Td
+/P <<
+/MCID 10 
+>>
+BDC
+/F1 9.25 Tf
+0 Ts
+<00270020000800150005001d0003000b000a> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+ET
+454 603.9 m
+454 609.4228 449.5228 613.9 444 613.9 c
+372 613.9 l
+366.4772 613.9 362 609.4228 362 603.9 c
+362 536.3375 l
+362 530.8147 366.4772 526.3375 372 526.3375 c
+444 526.3375 l
+449.5228 526.3375 454 530.8147 454 536.3375 c
+454 603.9 l
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Figure <<
+/MCID 11 
+>>
+BDC
+q
+0.2167 0 0 0.2167 382 553.9 cm
+/Mf2 Do
+Q
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+388.2015 538.7773 Td
+/P <<
+/MCID 12 
+>>
+BDC
+/F1 9.25 Tf
+0 Ts
+<0025001e000800150005001d0003000b000a> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+ET
+558 603.9 m
+558 609.4228 553.5228 613.9 548 613.9 c
+476 613.9 l
+470.4772 613.9 466 609.4228 466 603.9 c
+466 544.3375 l
+466 538.8147 470.4772 534.3375 476 534.3375 c
+548 534.3375 l
+553.5228 534.3375 558 538.8147 558 544.3375 c
+558 603.9 l
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Figure <<
+/MCID 13 
+>>
+BDC
+q
+0.1833 0 0 0.1833 490 561.9 cm
+/Mf2 Do
+Q
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+492.2015 546.7773 Td
+/P <<
+/MCID 14 
+>>
+BDC
+/F1 9.25 Tf
+0 Ts
+<001f001f000800150005001d0003000b000a> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+ET
+0.8431 0.8902 0.9412 RG
+246 456.3375 m
+246 464.0695 239.732 470.3375 232 470.3375 c
+50 470.3375 l
+42.268 470.3375 36 464.0695 36 456.3375 c
+36 256.25 l
+36 248.518 42.268 242.25 50 242.25 c
+232 242.25 l
+239.732 242.25 246 248.518 246 256.25 c
+246 456.3375 l
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+50 447.0973 Td
+/P <<
+/MCID 15 
+>>
+BDC
+0.0627 0.1647 0.2627 rg
+/F0 12 Tf
+0 Ts
+<0019000800090008000f000800030013000800060017000a00180008> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -20.6525 Td
+/P <<
+/MCID 16 
+>>
+BDC
+0.1412 0.2314 0.3255 rg
+/F1 10.25 Tf
+0 Ts
+<002b00050007000a000b00030010000700050008000900060012000a0007000a000d0015000500120006000d0005000400150003000900090005000c000a000a000900050012000f000300040008> Tj
+EMC
+0 -13.8375 Td
+/P <<
+/MCID 17 
+>>
+BDC
+<001d0003001500020016001000150005000f000a000b000a000c0003000d0003000d000e000500150002000a0005000600040004000a0015001a> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+ET
+/Figure <<
+/MCID 18 
+>>
+BDC
+q
+0.6 0 0 0.6 69 256.25 cm
+/Mf0 Do
+Q
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+576 456.3375 m
+576 464.0695 569.732 470.3375 562 470.3375 c
+278 470.3375 l
+270.268 470.3375 264 464.0695 264 456.3375 c
+264 184.25 l
+264 176.518 270.268 170.25 278 170.25 c
+562 170.25 l
+569.732 170.25 576 176.518 576 184.25 c
+576 456.3375 l
+S
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+BT
+278 447.0973 Td
+/P <<
+/MCID 19 
+>>
+BDC
+0.0627 0.1647 0.2627 rg
+/F0 12 Tf
+0 Ts
+<0011000f0008000500080003000b0002000b000a000c000300060017000a00180008> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+0 -20.6525 Td
+/P <<
+/MCID 20 
+>>
+BDC
+0.1412 0.2314 0.3255 rg
+/F1 10.25 Tf
+0 Ts
+<00180006000f000e000a000f00050008000900060012000a0007000a000d00150004000500120006000d0005000700160013000a0005001100060012002d000500150016001d0006000f000b000500150002000a00050016000f0003000e0003000d0006000900050004001200060009000a> Tj
+EMC
+0 -13.8375 Td
+/P <<
+/MCID 21 
+>>
+BDC
+<001d000200030009000a000500120016000d00150003000d00100003000d000e0005001500160005000f000a00100004000a000500150002000a0005000400060007000a000500120006000800150010000f000a000b000500120006000d001300060004001a> Tj
+EMC
+/Artifact BMC
+EMC
+/Artifact BMC
+EMC
+ET
+/Figure <<
+/MCID 22 
+>>
+BDC
+q
+0.9 0 0 0.9 312 184.25 cm
+/Mf0 Do
+Q
+EMC
+endstream
+endobj
+59 0 obj
+<<
+/Length 914 
+>>
+stream
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo << /Registry (Adobe) /Ordering (UCS) /Supplement 0 >> def
+/CMapName /Adobe-Identity-UCS def
+/CMapType 2 def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+45 beginbfchar
+<0001> <0054>
+<0002> <0068>
+<0003> <0069>
+<0004> <0073>
+<0005> <0020>
+<0006> <0061>
+<0007> <006D>
+<0008> <0070>
+<0009> <006C>
+<000A> <0065>
+<000B> <0064>
+<000C> <0066>
+<000D> <006E>
+<000E> <0067>
+<000F> <0072>
+<0010> <0075>
+<0011> <0062>
+<0012> <0063>
+<0013> <0076>
+<0014> <002C>
+<0015> <0074>
+<0016> <006F>
+<0017> <0079>
+<0018> <004C>
+<0019> <004D>
+<001A> <002E>
+<001B> <002D>
+<001C> <004F>
+<001D> <0077>
+<001E> <0032>
+<001F> <0034>
+<0020> <0030>
+<0021> <0071>
+<0022> <0078>
+<0023> <007A>
+<0024> <0039>
+<0025> <0035>
+<0026> <0057>
+<0027> <0036>
+<0028> <0037>
+<0029> <0053>
+<002A> <0045>
+<002B> <0041>
+<002C> <0038>
+<002D> <006B>
+endbfchar
+endcmap
+CMap end
+end
+endstream
+endobj
+60 0 obj
+<<
+/Length 92 
+>>
+stream
+   7 K L V  D P S O H G I Q J U X E F Y  W R \ / 0   2 Z    T [ ]   :   6 ( $  Nendstream
+endobj
+61 0 obj
+<<
+/Length 18440 
+/Length1 18440 
+>>
+stream
+     Ä  POS/2G$N   ‹   `cmap
+
+∞  <   Ócvt ò"A€  ,  åfpgmR≈≠'  ∏  êglyfqÕu⁄  H  &Ëhead°Gı  80   6hhea
+"v  8h   $hmtxã±!  8å  xloca ˛¨  :  |maxp“}  ;Ä    nameqFSy  ;†  postf◊  B∏   ﬁprepƒqä  Cò  n àê   ô3  ô3  – f             ‡ ˇP x[        pyrs @ 	˚ ˛§ =öÕ  üO  /Ω                      ⁄         . 0 2 9 A E M O T W i zˇˇ     , 0 2 4 A E L O S W a kˇˇ                                     * * * , , . . >               $ ( / 0 2 6 7 : D E F G H I J K L N O P Q R S T U V W X Y Z [ \ ]  ¿ Ω (Ä /   ˇŸ  ˇ⁄  ˇŸ˛UˇÊ« ˛mˇÒ;   π   π˛?< ¿ ç õ Ø  ® ¿ ( ^ ò …j π\ ¥ ÷ . Ä  ∏ L Ãˇˇ— f § Ø t ¬ ï ±  ( m  L é%ˇz  @ L b Ñˇ¢ $ 8 Ü Ω 9 ^ é Ìˇ©ˇ≥ @ R U ™ ´ ¬ À#±ˇÆˇ‰  Q t Ñ ™ —ˇLˇØ  , B P Q Ñ æ%⁄ˇh  ; ò ú ü ° ¡ ÏÇ¥ˇhˇvˇ–ˇ·    S S }¥·ØÜˇúˇÍˇ˛  ( * R ` ì £ ™ Ø Ø ¿ Ektìï@Ç¥Ö˛˝  ) G G H o à ¥ π ƒ Ú ˘Ôt≈ˇ5ˇÛ  K L R U e v v á á é ´ ª0CP}îï”*UXwxÊN\y”s≤åò˛ıˇªˇ«ˇ’   [ r ~ ú ¬ – Ù ˙%;B^^Äõπ°πP¿–™ﬂ„Ô˚+tì´¬Œiïôﬂı>°Â%€˛b˛â˛Œˇ;ˇ·ˇ¯   ! 9 B N _ a o p 4  é ≠ ≠ Ø Ω ƒ ≈ … … … „ Ì ¯ ˘ 2MMNOfiû∫∫æ„Ôˆ  	SbmÄ’Ä*JZØØ»÷˚˚GI åmöö¶®≤œ9>NVÄâåc—÷~é≤Ô(Loå ¥ … ¿ ¡             $ Ø 2 n cDb ñC°a ä t dàÔp (ˇ]~G0 ™ æ { b ö } â\ °ˇÿ™ ◊ ì l   Ä ßB ó  Ç 0 * * * * * * ì v † ¨ ∏ ´ ≈   +˛U / !æ '@)*)('&%$#"! 
+	 ,E#F` ∞&`∞&#HH-,E#F#a ∞&a∞&#HH-,E#F`∞ a ∞F`∞&#HH-,E#F#a∞ ` ∞&a∞ a∞&#HH-,E#F`∞@a ∞f`∞&#HH-,E#F#a∞@` ∞&a∞@a∞&#HH-, < <-, E# ∞ÕD# ∏ZQX# ∞çD#Y ∞ÌQX# ∞MD#Y ∞êQX# ∞D#Y!!-,  EhD ∞` E∞FvhäE`D-,π@   
+-, π  @ -, E∞ Ca}h∞ C`D-,E∞#DE∞#D-, E∞%Ead∞PQXED!!Y-, ∞%RX#Y!-,i∞@a∞ ãd#dã∏@ b`d#da\X∞aY∞`-,E∞+∞#D∞zÂ-,E∞+∞#D-,E∞+∞Eå∞#D∞zÂ-,∞%FaeäF∞@`ãH-,∞%F`äF∞@aåH-,KS \X∞ÖYX∞ÖY-, ∞%E∞#jDE∞#DEe#E ∞%`j ∞	#B#häj`a ∞ RX≤@E#aDY∞ PX≤@E#aDY-,π~;!-,π-A-A-,π;!~-,π;!ÁÉ-,π-A“¿-,π~ƒ‡-,KRXED!!Y-, ∞%#I∞@`∞ c ∞ RX#∞%8#∞%e8 äc8!!!!!Y-,Ei ∞	C∞&`∞%∞%Ia∞ÄSX≤@E#ahD≤@E#`jD≤	Ee#E`BY∞	C`ä:-,∞%# äı ∞`#ÌÏ-,∞%# äı ∞a#ÌÏ-,∞%ı ÌÏ-, ∞` < <-, ∞a < <-,vE ∞%E#ah#h`D-,vE∞%E#ah#Eh`D-,vE∞%Eah#E#aD-,Ei∞∞2KPX!∞ YaD-∏ +,K∏ 	PX±éY∏ˇÖ∏ Dπ 	 _^-∏ ,,  EiD∞`-∏ -,∏ ,*!-∏ ., F∞%FRX#Y ä äIdä F had∞%F hadRX#eäY/ ∞ SXi ∞ TX!∞@Yi ∞ TX!∞@eYY:-∏ /, F∞%FRX#äY F jad∞%F jadRX#äY/˝-∏ 0,K ∞&PXQX∞ÄD∞@DY!! E∞¿PX∞¿D!YY-∏ 1,  EiD∞`  E}iD∞`-∏ 2,∏ 1*-∏ 3,K ∞&SX∞Ä∞@Yää ∞&SX#!∞¿äää#Y ∞&SX#!∏ äää#Y ∞&SX#!∏@äää#Y ∏ &SX∞%E∏ÄPX#!∏Ä#!∞%E#!#!Y!YD-∏ 4,KSXED!!Y-∏ 5,K∏ 	PX±éY∏ˇÖ∏ Dπ 	 _^-∏ 6,  EiD∞`-∏ 7,∏ 6*!-∏ 8, F∞%FRX#Y ä äIdä F had∞%F hadRX#eäY/ ∞ SXi ∞ TX!∞@Yi ∞ TX!∞@eYY:-∏ 9, F∞%FRX#äY F jad∞%F jadRX#äY/˝-∏ :,K ∞&PXQX∞ÄD∞@DY!! E∞¿PX∞¿D!YY-∏ ;,  EiD∞`  E}iD∞`-∏ <,∏ ;*-∏ =,K ∞&SX∞Ä∞@Yää ∞&SX#!∞¿äää#Y ∞&SX#!∏ äää#Y ∞&SX#!∏@äää#Y ∏ &SX∞%E∏ÄPX#!∏Ä#!∞%E#!#!Y!YD-∏ >,KSXED!!Y-∏ ?,K∏ 	PX±éY∏ˇÖ∏ Dπ 	 _^-∏ @,  EiD∞`-∏ A,∏ @*!-∏ B, F∞%FRX#Y ä äIdä F had∞%F hadRX#eäY/ ∞ SXi ∞ TX!∞@Yi ∞ TX!∞@eYY:-∏ C, F∞%FRX#äY F jad∞%F jadRX#äY/˝-∏ D,K ∞&PXQX∞ÄD∞@DY!! E∞¿PX∞¿D!YY-∏ E,  EiD∞`  E}iD∞`-∏ F,∏ E*-∏ G,K ∞&SX∞Ä∞@Yää ∞&SX#!∞¿äää#Y ∞&SX#!∏ äää#Y ∞&SX#!∏@äää#Y ∏ &SX∞%E∏ÄPX#!∏Ä#!∞%E#!#!Y!YD-∏ H,KSXED!!Y-∏ I,K∏ 	PX±éY∏ˇÖ∏ Dπ 	 _^-∏ J,  EiD∞`-∏ K,∏ J*!-∏ L, F∞%FRX#Y ä äIdä F had∞%F hadRX#eäY/ ∞ SXi ∞ TX!∞@Yi ∞ TX!∞@eYY:-∏ M, F∞%FRX#äY F jad∞%F jadRX#äY/˝-∏ N,K ∞&PXQX∞ÄD∞@DY!! E∞¿PX∞¿D!YY-∏ O,  EiD∞`  E}iD∞`-∏ P,∏ O*-∏ Q,K ∞&SX∞Ä∞@Yää ∞&SX#!∞¿äää#Y ∞&SX#!∏ äää#Y ∞&SX#!∏@äää#Y ∏ &SX∞%E∏ÄPX#!∏Ä#!∞%E#!#!Y!YD-∏ R,KSXED!!Y-∏ S,K∏ 	PX±éY∏ˇÖ∏ Dπ 	 _^-∏ T,  EiD∞`-∏ U,∏ T*!-∏ V, F∞%FRX#Y ä äIdä F had∞%F hadRX#eäY/ ∞ SXi ∞ TX!∞@Yi ∞ TX!∞@eYY:-∏ W, F∞%FRX#äY F jad∞%F jadRX#äY/˝-∏ X,K ∞&PXQX∞ÄD∞@DY!! E∞¿PX∞¿D!YY-∏ Y,  EiD∞`  E}iD∞`-∏ Z,∏ Y*-∏ [,K ∞&SX∞@∞ Yää ∞&SX#!∞Ääää#Y ∞&SX#!∏ ¿äää#Y ∞&SX#!∏ äää#Y ∞&SX#!∏@äää#Y ∏ &SX∞%E∏ÄPX#!∏Ä#!∞%E#!#!Y!YD-∏ \,KSXED!!Y-∏ ],K∏ 	PX±éY∏ˇÖ∏ Dπ 	 _^-∏ ^,  EiD∞`-∏ _,∏ ^*!-∏ `, F∞%FRX#Y ä äIdä F had∞%F hadRX#eäY/ ∞ SXi ∞ TX!∞@Yi ∞ TX!∞@eYY:-∏ a, F∞%FRX#äY F jad∞%F jadRX#äY/˝-∏ b,K ∞&PXQX∞ÄD∞@DY!! E∞¿PX∞¿D!YY-∏ c,  EiD∞`  E}iD∞`-∏ d,∏ c*-∏ e,K ∞&SX∞@∞ Yää ∞&SX#!∞Ääää#Y ∞&SX#!∏ ¿äää#Y ∞&SX#!∏ äää#Y ∞&SX#!∏@äää#Y ∏ &SX∞%E∏ÄPX#!∏Ä#!∞%E#!#!Y!YD-∏ f,KSXED!!Y-  B  –Ω   C∏ S+∏ /∏ /∏ ∏  –∏  /∏ ∏ ‹∏  ∏ ‹∏ ∏ 	‹ ∫    V+∫   V+013!'!Bé∏¸‚Ω˙C∏M˚≥    ™˛–Ä ⁄  -@ #
+d
+4
+d ce+NÙM<˝ÌNEeDÊ ?MÌ‘Ì1067654&'#53™Em÷`v—U-*⁄ w¥     UﬁKó   @
+ / ∏B≥!∫H++N‰Ê /MÌ10!!Uˆ˛
+óπ    Ø  Ä ⁄  &@*
+d d!ce++NÙM˝NEeDÊ ?MÌ1073#Ø——⁄⁄     @ˇŸò   q@áF558o8Gvƒ‘Ì˝Ì ?Ì?Ì10Cy@4 &%&	%&(  (( (((
+( ( +++++++++++++Å ] ! '&47!64#"3@|`W~˛‚˛˛~i?v5ä¶x≠üì/HÆòÂ±˛Ã˛‹ø˛Ó‡ª;ÙØF˙Â¯RÙ;˛’˛›€ÖÀ     @  ù " ¶@N6FWknzÑá*Zk||µ "! "
+5 u!"!8o"'Å8"$G#vƒ‘ÌÙÌıÌ‰ ?<˝<?Ì9/999999 ]10Cy@%&( 	(
+(
+( ++++++Å ]6?67654&#"#676!2!!JÖ¡¿Å4Rñ}πG&∑Bu(ˆ„yFµâb8d¸)πpoK5Sk}ìåKÖªv–˛ˆ£¨zGeL61Wj™    4  /ú   \@"	
+æ
+uÔ∏µñ¨
+∏X≥Gvƒ‘ıÙ<˝‰ ??Ù<˝<99999á.+}≈10	!533#•˛5Œ˝åêò””˚â˝w˛^∞é¸_ù˛¢     Bˇ‹Ä   ª@+Hà9FWg: 
+u  
+5
+∏"@:5 «8o 8 "G!vƒ‘ÌıÌƒ ?ÌÌ?˝9/‰ÙÌ99999á.+}≈ 99910Cy@(	& (   (	(( ( 
+( +++++<<++ÅÅ ]]32654&#"'!!67632!"$'˝}@T†ö∑Ä]Ö/úmË˝ü=2-Pi≈˚˛ÌØ˛Ûmö;Ã|ñ§H@	Æ˛r&!˛√À˛ ≈Ã    Mˇ€#û  ' ©@9w%'XÜ áà	G
+!'!5«5'5)Å8o
+<
+$1)G(vƒ‘˝9|KRxz/ıÌÙÌ ?Ì?ÌÌ9/Ì910Cy@4%&  & (&$( ( (!(%'( '( (++++<+++++ÅÅÅÅ] ] #&'&#"67632#" 7!654&#"3GΩ≤#AÑó≤
+>^Vj¥˛Î…˛‹A}LÅç~¶tØüçû˘ÑU0Z˛È˛¸[-(Ê‰√˛”1i∫d˙›øÇn«öõàπ    K  /Ä  S@68:9JUVb∑
+|¥≈	: 	  o8	¨Gvƒ‘ÙÌÂ99 ??<˝<99]10]#67!5/EÂXW-.«DËâó¸ËÄùC˛¥¿ªöc‹öñÓ≠µ   Bˇ◊ú   2 À@GVW	ZYde	kiw%	I{v#r%s'|1|2àá á'à.à1òG2%%25,55,8!∏Ü∑8)o/8∏Üµ8/4G3vƒ‘ÌÙÌıÌÙÌ ?Ì?Ì9/Ì999910Cy@5*. -( +(
+( ( (.( *( ( ( +++++++++ÅÅÅÅ] ] 654&#"3654&#"3 '&54632#"$5467§ÜÄÉÇtñfà•™ÖÅ£ïú˛µ*OË’ŒÍD&PY3_˛Ë—˛ﬂ|z@Ö\PÜÜZer˝;áÜãêìÇp£†+PÄ†ÊŸëÜS/-)5d†Ω˛˘„ÿπ1   Iˇÿö  ' ´@.+(HXhâàò	F!''5
+
+!55«<1∏U@ )Å$8)G(vƒ‘ÌÙÌı˝9}KRxz/ ?ÌÌ?Ì9/Ì910Cy@4&%&"$(  ( ( &$( #!(!(( %'( ++++++++++ÅÅÅÅ]326#"543 !"&5 654&#"3k7EÅ∂&<±fœÒÓË9wBOÉ˛«“⁄2±ü{ÑõàïZï9◊I_MÀ√(˛ÊõÈ˛˘À˛Æ‹¶&ç∞ûõ±îå•     =Ω  
+ D∏ ]+ ∏∂EX∏ /π ƒ>Y∏∂EX∏ /π æ>Y∏∂EX∏ 	/π 	æ>Yª  π  a+013#!#éﬂÌÖ·⁄ï˝ªüÃZâ˝wc˙C∏˛H   Ø  ÌΩ   N@$ 	
+ i;	% ∏≥!ïâ++NÙM˝<NˆMÙ‰9/ ??<˝<?<Ì9/˝10!!!!!!Ø/¸ì+¸’|˚¬Ω¥˛B™˛ØΩ     ú  KΩ  1@ % ∏S≥!v^++NÙ<M˝<NÊ ?<M˝<?103!!ú«Ë¸QΩ˙ÚØ  ó  Ω  À@YDK	◊WX‘€‘€
+
+EÜQó)
+(8
+8GWv%d
+∏õ@
+˝˝∏õ∂ vp+NÙ<M˝‰Ù99Ù99‰˝<NEeDÊ ?<?<9KRy±∏™¥
+∏™≤áM.z˝}ƒá.z˝}ƒ10 ]rqr]q!	!#465##ó¶£Ω˛]≈˛ZæΩ˚&⁄˙Cc-–w˚)◊-6›4¸ù    Pˇ’ËÂ    ä@,á« «√»…
+C::	11ÿ!jf++NÙMÌNˆMÌ9/ ??Ì?Ì10Cy@2 &%	%&2  22 222
+2 2 ++++++++++++Å ] ! '&7! 5 #" !õªíßƒ˛ï˛≠¬≠îætÎ˛ÒÎ‰˛‡˜Â˙√˛–˛∑⁄ˇ ‡ÿJ*‘˙¢yı<˛«˛œÙ˛±^  `ˇ’ˆÂ / 0 ˛@^)'#&&65!G&b&zw$	k%Yh™"
+:"$"
+Ü//+::+	0
+$"(00%I%(2%I %/12†!jâ++NÙMÌÙÌNˆMÌÙÌ9/9999 ??Ì?Ì9/Ì9.˝3]q10Cy@M(. &&-%%&, + -., + *++ +-+ 	'+%.+ )+ ++ ++++++<++++<++++++ÅÅÅ ]327654'&/&'&54$32#&'&#"# '&74c˙p\≤KL¢«√Qå˚ÁCª1[⁄∞öZ;–ŒïQå˛ùÎ˛ÓõõM⁄}Ní >†x32%-,5\∑∆˛ﬂıv?sîbl2 0/";gƒÙ“åãÓ   !  …Ω  4@ 	 ˚%˚å^+NÙMÙ<˝<ÙNEeDÊ ??<M˝<10!#!5…˛ ˛ΩØ˙ÚØ     %  qΩ V@ï	xy	xáÜGKDHMB
+âá
+»««»XghâÜÜâôñïö©¶•™
+
+W
+>(E(% %	 
+Ü@Ù
+	ÙÄ Üé^+NÙM˝99˝99˝99˝99NEeDÊ ?<?<9áM.Ìá.ÌKRy¥	
+	
+∏ö@		
+∏ö@
+ á}≈á.+}≈á≈á.+}≈KQy≥ ∏ö∂	
+	∏ö@		 á¿á¿áz˝ƒáz˝}ƒ10r]]q ]r	3	3#	#˝LÿL⁄˛~—˛≠˛´—˛ÄΩ˚U´˚U´˙C¬˚>Ω  Rˇ‹GI  ; < ›@8*0
+'3Hi	j9	2$	;+.);∑;;2*%'"∏ä@#'.5<<<)*®$>)J'8=>ºó ! πñ ++NÙMÌÙÌNˆM‰˝ƒ9/ ??Ì?Ì?ÌÌ99]9.Ì.Ì9910Cy@(67" %6! !  !!" 7! !!! +++<++++ÅÅÅ ]]$3276=67654&#"#>323267#"'&'#"&5467rN_Yñ!h2mb1S¥>Ézç;!
+®˜£Ωvu%*,&]*	7Œ|ïΩ∫óäœZ,I¶ë/gl,-\SL*S∆õHHò˝ó"ÖB#@Hjµàï§‰   vˇﬁ%¬   p@.¶ß◊"  
+' ..)  á!Ω]++NÙ<M˝‰‰NˆMÌ ?Ì??Ì?9910Cy@
+&
+&&	& ++++ÅÅ ]3>32#"'&'#$654&#"3vØ;§`»˘ˆ⁄zT29¶fëëç{π&G¬¬˝ÎMQ˛Ì˛Ù˛˛∞;#Mâ}Ëæ©ﬁ∂—ó^±    ;ˇ·–N   ß@/ßò®™Jõ''
+'∏≥!r}++NÙMÌNˆ<MÌ99Ì9/ ??Ì?Ì9/Ì10Cy@4 %
+& &
+&  !& & 	&!++++<<++<<+++Å ]] #.#"32673#"5 3÷„Ør~¨J0àípÉØª“˙‘N∞◊cÉ®m†°‹âw’≈3Ê:  8ˇ⁄Ì¬   w@27GWß©% 
+..)'á!rB++NÙMÌNˆ<M˝‰‰ ?Ì??Ì?9910Cy@	
+ & 	&  & 
+&++++ÅÅÅ ]32654&#" 3#5#" 543ˆí°}°¶zà©äS0=≠¢?¨o≥˛˙Ôﬁ_Ë◊…À√– 74K˙>ïcX-˙ÍW  Hˇ⁄I  $ %@yóôß@@)K∂«∆«ÿŸ	÷ÿ#ËË#««\!$ö$9!
+%óß∑◊%%
+'''$.'&'‘!¶]++NÙM˝‰NˆMÌ‘˝999999/] ??Ì?Ì9/<˝<Ì910Cy@F #&%"$&   &	& &#!&!&
+& 
+&  ++++<++<+++*+*Åq] q]] !327673#"  3&'&#"¥÷86¸ÔêóçT0±O1RyAR»˛Í‚(J≠|®#GkUQlJ¢£≈]6G;ë.P#B˛&uFÇ≥ä‹       “  M@+
+9
+)¸¸!g~++NÙM˝]9ƒ/<˝<NEeDÊ ??<M˝<?Ì‘Ì107632.#"3###535µ#?¥$R ≤¥≤ïïB4\§UÆé¸dúé®    =˛;ËI  - . ∑@M6II	XY	à©®©'¶+π@")ƒ
+")
+
+.....-)0'>&'/0á!rB++NÙMÌÙÌ9NˆM˝‰ı9/ ??Ì?Ì??ÌÌ9910Cy@,#($%&#&& (&& ! %"&')& !  +++<<+++++ÅÅÅ ] 53!"&'33276'#"$ 3 &#"32765|^35¶<p˛…≠Ï∑'=Éœ@&6ò}Æ˛˚∫D§æF%ì|¬O,˛—B>#Cá¸2Ãv⁄õ•H'<íV›RP˜.˛°¿≤_öµΩØcÑ-    Ñ  Ì¬  S@,''uu  
+)
+) ∏≥!bB++NÙ<M˝<NˆMÌ ?<?Ì?99910 ]367632#4'&#"#Ñ¥@3WÇÈS-π1áp∂¥¬˝‹Q!9£Yû˝Q£v7Xö÷˝»     Ñ  ;Ω   6@Â  
+	) 	™!bB++NÙ<Mƒ˝<ƒNEeDÊ ??<?MÌ103#3#Ñ∑∑∑∑*˚÷ΩÃ    Ä  ¯Ω  ß@dY:Wgyxáπ…⁄
+	Ñî§9		m	
+  
+
+	
+) ≤!bπ ++NÙ<M˝<<NÊ ?<<?<?99áM.+}¡á.+]}¿<<10] q]r33	##Ä≠ŒÊ˛f±Ê˛≤ó≠Ω¸´«˛o˝bä˛n    â  =Ω  )@  
+) ™!bB++NÙ<M˝<NEeDÊ ??103#â¥¥Ω˙C    Ñ  %G & Ö@;'''HVg#%
+#
+%! %
+()∏≤)∏@
+ .%)& '(∏≥!bB++NÙ<M˝‰ÙÌÙ˝NEeDÊ ?<??<MÌÌ99910 ]367632>32#4&#"#4'&#"#Ñ≤@4YqÄN,$<¢eÿN*ªkMjô∑)pfß¥/òO$=?$FVSúTé˝7ËkPé¶˝ëªm2Kûœ˝»   Ñ  ÌI   ^@1∑«'vt 
+ )	.) ∏≥!bB++NÙ<M˝‰NˆMÌ9/ ??<??Ì99910 ]]3>32#4'&#"#Ñ´L™h‰P,∑0~@)J8-¥ß/ò^RüW¢˝Q£b<dB5qi˝œI   ;ˇŸ!N    ê@3òñô•®¶©∏»◊ÂÈ:'	'∏	≥!r]++NÙMÌNˆMÌ9/ ??Ì?Ì10Cy@, &	&  &	& &
+& & &&+++++++++Å ]$54'&#"3 !" 5 3‡Ö0L∫•ññ£÷¸˛˜›˛¸Át¶ñ^î¸≤´‰⁄˛Ï˛Ù˛˝˛Æ+¸@  v˛U%I  " t@,©ß( "'$
+..!)"#$á!Ω]++NÙ<M˝‰‰NˆMÌ ??Ì??Ì9910Cy@ && &&& &++++++ÅÅ ]$654'&#"3367632#"'&'#∆ß%F∫ªE%%F∫˛.Ø6@[{∂˛∑töyR0;¥y”“Ä\±ªdö|W¶±éI(<˛È˛˝˛¢ñ_5I˝›   <˛UÌG    z@38HX®ß®( ..)"'!"á!rB++NÙMÌNˆ<M˝‰‰ ??Ì??Ì9910Cy@ && &  & &+++++ÅÅÅ ]327654'&#" 53##" 3¯'E≤ºG'+I∏ußè[2.´µ-üw´˛Ú˝…~^ß∞aóã]üÀ‘>C$Fï˙&&HUJ    â  íG  O@&'&7G		' 
+.) ∏E≥!b~++NÙ<M˝‰NÊ ??M?ƒ˝ƒ99910 ]3>32.#"#â´§kàí¥/π6õæØr˝ò   Bˇ◊∂K . /.@è8	òñôòò*($%'6!F!G$G'V$W'f$g&yyyv#t$t%t&¶®, -. -.(i&%6%%"
++∆.ö+/	 /!/'>(&'(1'> '.01≤!¶]++NÙMÌÙ˝9NˆM˝9Ù˝9999/999 ??ÌÌ?ÌÌ9q10Cy@L-&%&!! 	&!, ! *!! ! "! !"'
+!&%	
+-! )! !! ++++<<+<<++++++++++Å ]]]32654'&/&'&54632#&'&#"#"&'Ô%D®dò='sèâAt€πÚkC™&>ôfiE(Nw¬BiŸﬁÔ«∑PZ0WW[E$$"*IÅòºéZh=2GN@F*/,Eîè–Ÿ†˘  ˇÔ	Z  Rµ.
+¿∏?@%9
+) ¸¸!g}++NÙM˝]9ƒ/<˝<NEeDÊ /??<M˝<Ì˝‰1033#3267#"&5#53®∂´´&1C'~ZëëZ˛’ì˝E8é	Åg≈ì    Äˇ„ﬁI   ^@:∏»	(w◊ 
+ 
+.
+))“!bB++NÙMÌNˆ<M˝‰9/ ??Ì??<9910 ]]327653#7#"'&5%80ÉºD%¥™#4gìÂS-Ø/˝9R4`®Zù˚—û=*TôRâÿ     Í/ @.B≈ g hhgáàß ®G HEJÜâ«»I(s(∏	≥!g~++KRy∏ˇp¥ ∏É∑m∏É@m   
+Ø∫Ñ  Ñ≥ØNÙM˝‡‡˝NEeDÊ ?<?<999M.+N‰M.+N‰M+KQy@%) ) 
+Ø ØNÙM˝99˝99NEeDÊ ?<?<9++10q] ]q	3#‹+≈˛l¿˛u/¸òh˚—/    °/  @~G™	é	FIáäÖ
+ ƒ∆…∆
+…fje
+ivyv
+yÖä
+FIGw xW((++;;èè	 
+
+õƒ
+	ƒ õg~+NÙM˝99˝99˝99˝99NEeDÊ ?<?<9]KQy@) )á+á+KRy¥	
+	
+∏ã@)		
+∏ã@  )áM.+á}ƒá.+}≈á.+á}ƒá.+}≈10]qqq q]33##◊Œ— “€¥˛…ª⁄”ª˛À/¸¥L¸πG˚—=¸√/     ·/  # ±
+?∞3± ?∞3∞/∞÷ ± 
+±99013	#	#Èˆ˘€˛óyÊ˛ˆ˛˛‰y/˛áy˝˚˝€í˛n%   ˛IËI    @näàß8HXgwwåò óòóó® ®H KG…D∆á¶ ¶ß®$(  ØØè‘!g~++NÙM‰˝99˝99NEeDÊ9/ ??M˝92/?<<<99KRy@ mm  á.+}ƒá.+}ƒ]q10q] ]3#"&'53267>73!«&ÉbBúÄú&)/*2/>˛tÃ/g˛ë˛ÏÆ˛f¥§!î$N¸òÇ   4  ¥I 	 
+ l@B7H W XWg hgw	)  
+
+9 9	
+
+>J ≤!r]++NÙM‰NˆM‰ ??<˝<9?<˝<9999/á.+á}≈10]7!5!!!4{˝¥>˝âä¸Äœé °ì˝°I       Å ÓD_<ı      _Mè     ﬁ‡.÷¯e¸'ë˘   	         )˛)  ¯e¸Ìë                ^ B    9  9  9 Ì◊ Rs  s @ BV Yá ú™ é™ D N¨ \9 ™™ U9 Ø9  s @s ƒs @s 1s 4s Bs Ms Ks Bs I9 „9 „¨ ¨ \¨ s ú ·V V ó« Z« •V Ø„ Ø9 c« °9 …  #V ús ú™ ó« ú9 PV Ø9 P« ¥V `„ !« ™V 4ç %V *V *„ /9 Ä9ˇª9 /¡ xs  ™ &s Rs v  ;s 8s H9 s =s Ñ« Ñ«ˇ⁄  Ä« â™ Ñs Ñs ;s vs <™ â  B9 s Ä  «       4       l   l   l   l   l   l   l   l   l   l   l   l   l   l   l   –    L  L  (  (  @  @  ‹    0  ƒ  (  	T  	T  	T  	T  	T  	T  	T  	T  	–  	–  	–  	–  
+X  
+X  
+X  
+X  
+X  
+X  
+X  
+®  ¿  ¿  º  º  º  º  T  ∞  ∞  ∞  H  H  H  H  H  H  H  H  H  H  ‹  ∞  ¥  å     ∏    ®      ‰  (     ÿ  »  ¨  î      ‡  !Ä  "4  #`  $º  %  &H  &Ë    ^ o 	 k     g  Ëê     9≤        P         	 P        Y       "       	A       J       	R       2[       	       	            &      4      H      	Z      /ç      <º      0¯      :(      6b      0ò      <»    `     Ã    |     Ê     |    ò  	   `     ˙     n    ®    ∞     ™    
+ ä     ∫     ö    
+         ⁄    ⁄    2    n    Ê    @    L    T  !  ¬  "  Ù  *    9    >  
+–     î  	  ä    $     “  
+   ¿© 1990-2006 Apple Computer Inc. © 1981 Linotype AG © 1990-91 Type Solutions Inc.HelveticaRegular R e g u l a r C o u r a n t R e g u l a r0Ï0Æ0Â0È0¸^8âƒOS R e g u l i e r R e g o l a r e«|ºÃ¥ N o r m a ljnñö‘9'/J N o r m a l A l m i n d e l i g N o r m a a l i N o r m a l R e g u l a r R e g u l a r1KG=K9 N o r m a l4 N o r m a l R e g u l a r R e g u l a r R e g u l a r R e g u l a rö±ΩøΩπ∫¨Ë“Ÿ‹ S z a b · l y o s R e g u l e r B i a s a N o r m a l R e g u l a r28G09=89	0	G		M	/	A	2	0 T h∞› n gHelvetica; 17.0d1e1; 2020-09-21Helvetica17.0d1e1HelveticaHelvetica is a registered trademark of Linotype AGHelvetica est une marque déposée de Linotype AGHelvetica ist ein eingetragenes Warenzeichen der Linotype AGHelvetica è un marchio registrato di Linotype AGHelvetica is een geregistreerd handelsmerk van Linotype AGHelvetica är ett registrerat varumärke för Linotype AGHelvetica es una marca registrada de Linotype AGHelvetica er et registreret varemærke tilhørende Linotype AGHelveticaLigaturesCommon LigaturesNumber SpacingProportional NumbersMonospaced NumbersNo Change          ˇe e                     ^           	 
+                        ! " # $ % & ' ( ) * + , - . / 0 1 2 3 4 5 6 7 8 9 : ; < = > ? @ A B C D E F G H I J K L M N O P Q R S T U V W X Y Z [ \ ]  ∏ ]+∫ π _+øª > 4 )     e+øº B 4 )     e+øΩ : 4 )     e+ ø∑ M = 7 (    e+ø∏ ` O 7 (    e+øπ G = )     e+ø∫ B 4 )     e+ ∫æ  d+∏∂ E}iD∏ S+∏ I+∏ ?+∏ 5+∏ ++A Ä¶ ê¶ †¶  iã yã âã ôã  âã ôã ©ã πã≤@∫y J@T
+“∏¥ûŸ„ª  ·≤ 	A
+†ü d • %z H (ö≥)l`A
+© p© Ä©  Ä© ©≤2æ, % & ∂Á1-Â1∏≤¬'∏≤¡∏@¿ûøgæg´'∏≤™)∏∂©lì∏ö≤í∏≤ë∏≤u∏∂m)ñd1∏ö≤Lñ∏´≤9∏V@68!5‰/'∏@-L*1Õ$∏´≤ ∏%@ì:LE':E'ª™õ *õ≤%J∫õ %z≥I)8ñ∏{≥H(1%∏z@6H(ñ)H'%)L%)F'')H'V»Ñ[A2+(&!
+∏¨≤?ª´ ? ´≥∏Æ≤?ª≠ ? ≠∑ ∏ˇ‡¥   ∏´¥   ∏´∂   ∏≠≥   ∏≠@               J ∞ç∏ Öv??>9FD>9FD>9FD>9FD>9FD>9F`D>9F`D>9F`D+++++++++++++++++++++++++++∞ñKSX∞™Y∞2KSX∞ˇY+++++++++++++++++++++++++++++++++++++++++tu+++eB++KRy≥vpjfEe#E`#Ee`#E`∞ãvh∞Äb  ±jpEe#E ∞&`bch ∞&ae∞p#eD∞j#D ±vfEe#E ∞&`bch ∞&ae∞f#eD∞v#D± fETX±f@eD≤v@vE#aDY≥bBr]Ee#E`#Ee`#E`∞âvh∞Äb  ±rBEe#E ∞&`bch ∞&ae∞B#eD∞r#D ±b]Ee#E ∞&`bch ∞&ae∞]#eD∞b#D± ]ETX±]@eD≤b@bE#aDY++++EiSBst∏ö EiK ∞(S∞IQZX∞ aYD∏¶ EiDu  endstream
+endobj
+62 0 obj
+<<
+/Length 718 
+>>
+stream
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo << /Registry (Adobe) /Ordering (UCS) /Supplement 0 >> def
+/CMapName /Adobe-Identity-UCS def
+/CMapType 2 def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+31 beginbfchar
+<0001> <0043>
+<0002> <0061>
+<0003> <006E>
+<0004> <0076>
+<0005> <0073>
+<0006> <0020>
+<0007> <0044>
+<0008> <0065>
+<0009> <0066>
+<000A> <0069>
+<000B> <0074>
+<000C> <006F>
+<000D> <0041>
+<000E> <0064>
+<000F> <0072>
+<0010> <0077>
+<0011> <0050>
+<0012> <006C>
+<0013> <0063>
+<0014> <006D>
+<0015> <004E>
+<0016> <0075>
+<0017> <0053>
+<0018> <007A>
+<0019> <0052>
+<001A> <0062>
+<001B> <0039>
+<001C> <0032>
+<001D> <0070>
+<001E> <0067>
+<001F> <002D>
+endbfchar
+endcmap
+CMap end
+end
+endstream
+endobj
+63 0 obj
+<<
+/Length 64 
+>>
+stream
+   & D Q Y V  ' H I L W R $ G U Z 3 O F P 1 X 6 ] 5 E   S J endstream
+endobj
+64 0 obj
+<<
+/Length 12560 
+/Length1 12560 
+>>
+stream
+     Ä  POS/2á,√   ‹   `cmap	≠
+  <   ⁄cvt 
+5„     fpgm”'õi  4  sglyfÓÛn  ®   òhead„˜≠  $@   6hhea	Üd  $x   $hmtxù“f  $ú  xloca ò»  &  |maxp€ã  'ê    namemÒ$   '∞  ¸postf◊  /¨   ﬁprepRÀ‡o  0å   Ñ ˘º   ô3  ô3  – f             ‡ ˇR x[        pyrs   	ˇˇ ˛§ =Æ€  üO  B¬                      ∆         - 2 9 A D N P S g i p w zˇˇ     - 2 9 A C N P R a i l r zˇˇ                                           " . . 6 @       $ & ' 1 3 5 6 D E F G H I J L O P Q R S U V W X Y Z ]   * ˛ ò*4   )˛P B #¬ -∏ f,K∏ 	PX±éY∏ˇÖ∏ Dπ 	 _^-∏ g,  EiD∞`-∏ h,∏ g*!-∏ i, F∞%FRX#Y ä äIdä F had∞%F hadRX#eäY/ ∞ SXi ∞ TX!∞@Yi ∞ TX!∞@eYY:-∏ j, F∞%FRX#äY F jad∞%F jadRX#äY/˝-∏ k,K ∞&PXQX∞ÄD∞@DY!! E∞¿PX∞¿D!YY-∏ l,  EiD∞`  E}iD∞`-∏ m,∏ l*-∏ n,K ∞&SX∞@∞ Yää ∞&SX#!∞Ääää#Y ∞&SX#!∏ ¿äää#Y ∞&SX#!∏ äää#Y ∞&SX#!∏@äää#Y ∏ &SX∞%E∏ÄPX#!∏Ä#!∞%E#!#!Y!YD-∏ o,KSXED!!Y-   ö  =¬   ^∏ f+ ∏  EX∏  /π   >Y∏  EX∏ /π  >Y∏ ‹∏  ∏ ‹∏ /∏ 	/∏ ∏  –∏  /∏ 	∏ ‹∏ ‹∏  ∏ ‹01!!%!ö£˚]Î¸Õ¬˙>∏R˚Æ  /¥m¬   ∏ f+ ∫   i+∫    i+∏ ∏ ‹01!!/>˝¬¬˛Ú   @  !± " (∏ f+ ∏  EX∏ /π  >Y∫   i+∏ ∏ ‹01&#"!676!2!!676767654»3_Ç/˛Î<r#Ê`?êrkOy¸?=„≈:YÉ=a8zπrŸˇ“°}SfQLD-˚úÅë¢ç=_q\    =ˇ÷-∂  * œ∏ f+ ∏  EX∏  /π   >Y∫  ) i+∫ "  i+∏  ∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∫   "9∫   i+A     &  6  F  V  f  v  Ü  ñ  ¶  ∂  ∆  ]A ’  Â  ]01"$'!32767#"$54 3 327654&#"£˛¸
+XIç9',Pu≠˛Ù◊K{FCÄ˛FRim;4asdI*¡π@PúV•10Ô·È!˛€¶˛Ò˛˘∞˛±…@ôÅÅ">ô{ê     4  ®¬  
+ B∏ f+ ∏  EX∏ /π  >Y∏  EX∏ /π  >Y∏  EX∏ /π  >Y∫    i+01!!!!˚˝·f˛æ\
+˛≤µ∏æ/˛—¬˙>-D˝º  \ˇ◊{ﬁ ∏ f+ ∏  EX∏ 
+/π 
+ >Y∏  EX∏ /π  >Y∏ 
+∏ ‹A Ÿ  È  ]A     (  8  H  X  h  x  à  ò  ®  ∏  »  ]∏ ∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∫   i+A     &  6  F  V  f  v  Ü  ñ  ¶  ∂  ∆  ]A ’  Â  ]01%! '&76! !&'&#"32767!¨•˛ˇ˛¬∂∂œ¥t¨_˛Ã/T•®¬Õû¢U/1(nóÃÕeÇ—∂Ùâäj6`˛Ò¯¯˜j9rÒ    ú  {¬   ¨∏ f+ ∏  EX∏ /π  >Y∏  EX∏  /π   >Y∏ ∏ ‹∏  ∏ ‹∏ /∏ /∏ ∏ –∏ /∏ ∏ 
+‹∏ ∏ ‹∏ 
+∏ ‹A ⁄  Í  ]A 	    )  9  I  Y  i  y  â  ô  ©  π  …  ]01)!&#!!27654˝Ö{â[õ`M8v†iG“˛‰⁄V/¬3ànˇ t˛⁄Ã˛ÌJx¸>◊v£·     ó  D¬ 	 Ñ∏ f+ ∏  EX∏ /π  >Y∏  EX∏ /π  >Y∏  EX∏  /π   >Y∏  EX∏ /π  >Y∫    9∫    9∏ 
+/∏ /∏  ‹∏ 
+∏ –∏ /∏ ‹∏  ∏ ‹01)!!!D˛Ã˝¶˛·CK˚È¬˚˚  £  ¬ 
+  ¨∏ f+ ∏  EX∏ /π  >Y∏  EX∏ /π  >Y∫    i+∏ ∏ ‹∏ /∏ /∏ ∏ –∏ /∏ ‹∏ ∏ ‹∏ ‹A ⁄  Í  ]A 	    )  9  I  Y  i  y  â  ô  ©  π  …  ]∏ ∏ –01!!!2654&#!!2˛«˛ŒÇﬁ˛¯e<ym˛·m˝Ó¬‰Ô˛˚ÿ35ssb˛N    £  q¬  * £∏ f+ ∏  EX∏ /π  >Y∏  EX∏ /π  >Y∏  EX∏ /π  >Y∫ )   i+∫    )9∏ ∏ &‹∏ +/∏ ,/∏ +∏ –∏ /∏ ‹∏ ,∏ ‹∏ ‹∫   9∏ ∏ –∏ /∏ ∏ –∏ /∏ ∏ '–01!!!!&'&/.654'&#!!2˛¬˛””õß:08jzfU,˛≠c3\Y2d˛ö]hB˝æ¬FD8àWiÀ*)óõce$9%1>Aâç^*|Ü.˛t     Uˇ⁄Ì .∏ f+ ∏  EX∏ /π  >Y∏  EX∏ '/π ' >Y∏  ‹A       '   7   G   W   g   w   á   ó   ß   ∑   «   ]A ÷   Ê   ]∏ ∏ ‹A Ÿ  È  ]A     (  8  H  X  h  x  à  ò  ®  ∏  »  ]∫   i+A     &  6  F  V  f  v  Ü  ñ  ¶  ∂  ∆  ]A ’  Â  ]01%27654'&/&'&54 !2!&'&#" !  5!≥mDÅ@@âúÊXï ÈI˛ÿlHkwéF-ì˛ßUÑ˛À˛Ê˛‡˛∂&)K’.}I('#4=fŸ∆˜ÎÖ8%`VO'#=(Ch≈ ˛ıÊe2[    ;ˇﬁ8\ * : —∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∏  EX∏ /π  >Y∫   9∏ ∏ $‹A Ÿ $ È $ ]A  $  $ ( $ 8 $ H $ X $ h $ x $ à $ ò $ ® $ ∏ $ » $ ]∫ 1  9∫  0 i+∏ ∏ 	–∏ 	/∏ 0∏ –∏ /∏ 0∏ !–∏ !/∏ ∏ <‹016!2!.'#"&5476?67654&#"!632675Æq≥ãã˛ 
+;M\tî¡õU•aO"=]Ze*
+˛Ì	(:\õ70@Z'BÃêGG≈˛4J8(*!:%@-5©õ…Z1
+7C32%?è˝^!lèj	'RI  {ˇ„ú¿   ∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏  /π   >Y∏  EX∏ /π  >Y∏  ∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∫    9∫ 	   9∏ !/∏ "/∏ !∏ –∏ /∏ 	‹∏ –∏ /∏ "∏ ‹∏ ‹A ⁄  Í  ]A 	    )  9  I  Y  i  y  â  ô  ©  π  …  ]∏ 	∏ –∏ /01"'&'!!676324'&#"326’áR19˛È6AMw◊Û;9ôõ:|nz6 Pâ¿˝ÙL(2˛ ı˛˛≤.tLêçKwå∏≤     Gˇ⁄4\ ∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∏ ∏ ‹A Ÿ  È  ]A     (  8  H  X  h  x  à  ò  ®  ∏  »  ]∏ ∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∫ 	  i+A  	  	 & 	 6 	 F 	 V 	 f 	 v 	 Ü 	 ñ 	 ¶ 	 ∂ 	 ∆ 	 ]A ’ 	 Â 	 ]01!&'&#"3267!! 5 324˛‹!0eê53çdT	#
+TÜ˛˘˛˘¯ÒÕª=1BèL~xIàlVÇtª8˘8∏     ?ˇﬁe¿  o∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∏  EX∏ /π  >Y∏ ∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∫   9∏ ∏ ‹A Ÿ  È  ]A     (  8  H  X  h  x  à  ò  ®  ∏  »  ]∫   9∏ /∏  /∏  ‹∏ ‹∏ –∏ /∫    9∏ ∏ 	–∏ 	/∏ ‹A     &  6  F  V  f  v  Ü  ñ  ¶  ∂  ∆  ]A ’  Â  ]∏ ∏ –∏ /01!5#" 5 3232654'&#"e˛Î=útø˛˚◊cö0˛!<;yy~e>R}u¿˙@óaX5Ú@WM¸ZóZ[¥è»V4Ω   /ˇ‹:_  ! Õ∏ f+ ∏  EX∏ 
+/π 
+ 
+>Y∏  EX∏ /π  >Y∫   i+∏ ∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∏ 
+∏ ‹A Ÿ  È  ]A     (  8  H  X  h  x  à  ò  ®  ∏  »  ]01#"  32!32767.#"*Zå¸–˛¬Âà⁄G@˝a;SX7	{[cm@adü..fnaÄKç§B)20Nqu|j      ã—  o∏ f+ ∏  EX∏  /π   >Y∏  EX∏ /π  >Y∏  EX∏ 
+/π 
+ >Y∫   i+∏ ∏ –∏ ∏ –∫ 
+  i+∏ 
+∏ –∏ ∏ –∏ /01.3#!#53547632Ñq+ªª˛‰üú;>Ì,ÀË5 \…¸ëo…FØBb   B˛B^\ ! /’∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏ /π  
+>Y∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∏  EX∏ /π  >Y∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∏ ∏ $‹A  $  $ ' $ 7 $ G $ W $ g $ w $ á $ ó $ ß $ ∑ $ « $ ]A ÷ $ Ê $ ]∫   $9∏ ∏ *‹A Ÿ * È * ]A  *  * ( * 8 * H * X * h * x * à * ò * ® * ∏ * » * ]∫   *9∏ 0/∏ 1/∏ ‹∏ ‹∏ –∏ /∏ 0∏ –∏ /∏ ∏ '–∏ '/∏ ∏ .‹A  .  . & . 6 . F . V . f . v . Ü . ñ . ¶ . ∂ . ∆ . ]A ’ . Â . ]013276=#"54325!!"$'!32654&#"π.mö4")/Uà“˚ÚﬁR=h@Gz˛¶—˛¯6:ñdäÉnñ9ø'gBúFF#A'¸ÛK+sù˚ˆ”k∏§£2äó•õ¢çKn_     â  ™À   [∏ f+ ∏  EX∏  /π   
+>Y∏  EX∏ /π  >Y∏  EX∏ /π  >Y∏ ∏ ‹∫   i+∏ ∏ –∏ ∏ –01!!™˛ﬂ!˛ﬂB˚æBâ˛˘   ã  ®¬  2∏ f+ ∏  EX∏  /π   >Y∏  EX∏ /π  >Y∫    i+01!!ã˛„¬˙>     Ä  úZ - ±∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∏  EX∏ /π  >Y∏  EX∏ */π * >Y∫   9∫   9∫   i+∫ * + i+∫  ! i+∏ ∏ 
+–∏ 
+/∫   9∫  + *9∏ ∏ /‹01&#"!!6763267632!4'&#"!4È$iz*˛ﬂ5/SÑ}M> 8SXlHå9.
+˛‹&fv-˛·OO-Y˝p@üU$@73P`--8F9S7j˝Q∂>(Lb4I˝wâa    á  a\  {∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∏  EX∏ /π  >Y∫ 	  9∏ /∏ /∏ ∏ –∏ /∏ ‹∏ –∏ /∫ 	  9∏ ∏ ‹∏ ‹01"!!67632!4'&Üë6˛‰71Xá©◊˛‹*o{Ae˝≤@üT%B±Õ˝"óV.T     Bˇ⁄úe  j∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∏ ∏ ‹A Ÿ  È  ]A     (  8  H  X  h  x  à  ò  ®  ∏  »  ]∏ ∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∫   i+∫   i+A     &  6  F  V  f  v  Ü  ñ  ¶  ∂  ∆  ]A ’  Â  ]A ⁄  Í  ]A 	    )  9  I  Y  i  y  â  ô  ©  π  …  ]∏ ∏ ‹01 !  54 ! "32654&ä˛Ï˛Á˛Á˛Ï˛Ê}áá}}ÜÜ∏≠Ï˛´UÏZÒ±§§≤≤§§±   }˛SöZ  !!∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∫ 	  9∫   9∏ "/∏ #/∏ ‹∏ "∏ –∏ /∏ 
+‹∏ –∏ /∫   
+9∏ ∏ ‹A ⁄  Í  ]A 	    )  9  I  Y  i  y  â  ô  ©  π  …  ]∏ 
+∏ –∏ /01 #"'&'!!676324&#"326Ñ˛˝ÃÇV/-˛Ê.4_ÉøsÅõ:e<Rw}Õç˛Ô˛‡˛“A$E˝»Ô°G)I˝«~¬ìNxæM-∏  Ç  ˚\  h∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏ /π  
+>Y∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∫ 	  9∫   i+∫ 	  901"!!67632.©¨;!˛·B1PÄ*;p?É˝˜Bæm(C˛‹   Bˇ€%a , ≈∏ f+ ∏  EX∏ +/π + 
+>Y∏  EX∏ /π  >Y∏ +∏ ‹A Ÿ  È  ]A     (  8  H  X  h  x  à  ò  ®  ∏  »  ]∏ ∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]01!&'&#"# &5!32654'&%&'&54632tÄ˛„/q]O**ˇ™UTÒ¸˛ˇı!	5èTc((˛ˇπLLÌ◊ÃR»7 ::'18(QR{¢ÕŸ®L 9220=.EDÄóŸ     ˇÍxh  Y∏ f+ ∏  EX∏ /π  >Y∫ 
+  i+∏ ∏  ‹∏ 
+∏ –∏ ∏ –∏  ∏ –∫   i+∏ ∏ 
+–∏ ∏ –01%'&5#53!3#326xá J0òò±±"WÀ’M1füÀ0˛–À˝¿C!    }ˇËUB  »∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∏  EX∏ /π  >Y∏ ‹A     '  7  G  W  g  w  á  ó  ß  ∑  «  ]A ÷  Ê  ]∫    9∏ /∏ /∏ ‹∏ ‹∏  –∏  /∏ ∏ 
+–∏ 
+/∏ ‹01%#"'&5!32765!!@ C}TÚT/$'rí6!˛Îö2<,Æ`ªë˝o]/Sv@iQ˚æ      WB  D∏ f+ ∏  EX∏  /π   
+>Y∏  EX∏ /π  
+>Y∏  EX∏ /π  >Y∫    901!!!@„Ë2˛w˛”B¸‹$˚æ    !B  z∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏ /π  
+>Y∏  EX∏ 
+/π 
+ 
+>Y∏  EX∏  /π   >Y∏  EX∏ /π  >Y∫    9∫    9∫ 	   901!!!!!¿´≠˛ÿ˛Œ2™ù!¶™)˛ƒ¸ÊB¸Ú¸Ô˚æ     !  ŒB 	 9∏ f+ ∏  EX∏ /π  
+>Y∏  EX∏  /π   >Y∏ ∏ ‹∏  ∏ ‹01)5!5!!Œ¸S/˝˜t˝◊<ﬁ|ËÌ˝ï        ÂÀá_<ı      ¢(Ä     ﬁ‡.◊˜‹¸'
+˙≥           )˛)  ˜‹¸€~                ^« ö    9  9  ™ ·À ßs  s 8 /« oÁ c™ Y™  /¨ I9 v™ /9 Ä9ˇês @s és @s 6s 6s 6s @s 4s 6s =™ Ë™ Ë¨ ¨ I¨ „ {Õ «« 4« °« \« úV •„ ú9 U« ö9 Ñs -« °„ ú™ ó« ó9 eV £9 e« £V U„ !« úV /ç V !V #„ 4™ Ä9ˇê™ /¨ ãs  ™ˇŒs ;„ {s G„ ?s /™ „ B„ á9 â9 	s Ç9 ã Ä„ á„ B„ }„ < Çs B™ „ }s 9 s s   !       à   à   à   à   à   à   à   à   à   à   à   à   à   à   à   à   ƒ   ƒ   ƒ   ƒ   ƒ  `  `  `  `  `  `  `  º  º  º  º  º  º  º  º  8  8  ∏  ¿  ¿  ¿  ¿  ¿  ¿  ¿  ¿  ¿  ¿  t  t  p  p  †  
+H  
+H  
+H  
+H  
+H  
+H  
+H  
+H  
+H  
+H  
+H  
+H  
+H  
+H  Ã  T  –  ®  Ï  §      î  î  î  ‰  $    ¥  D  D  Ù  D  Ë    t   0   0   0   ò    ^ k 	 k     p  Ë¢     EB        P         	 P        Y       $©       Õ       î       ú       2™       S       	a      j      z      à      ú      	Æ      €      /‹      È      <      ˜      0G      
+      :w            6±      $      0Á      <      5    	  H      Y     i     w   
+  á         ≠    
+3     «     m    E  	   ]     Õ     e    Q    W     á     u     ô     Å     ﬂ     Â     π    
+{     ˚    +    Ö            
+  !  
+g  "  ç  *  £  9  
+ô  >  
+q     }  	  =     Ì     ±  
+   ü© 1990-2006 Apple Computer Inc. © 1981 Linotype AG © 1990-91 Type Solutions Inc.HelveticaBold B o l d G r a s F e t t0‹0¸0Î0…|óOS V e t G r a s s e t t oº¸¥‹Ã¥ N e g r i t a|óö‘91J6 N e g r i t o F e d L i h a v o i t u F e t B o l d N e g r i t o8@=K9 F e t+2 K a l1 n N e g r e t a B o l d T u n È B o l dàΩƒøΩ±‚—‘ F È l k ˆ v È r T e b a l T e b a l A l d i n B o l d8@=89	,	K	2	M	!≠ mHelvetica Bold; 17.0d1e1; 2020-09-21Helvetica BoldHelvetica GrasHelvetica FettHelvetica grassettoHelvetica vetHelvetica FetHelvetica NegritaHelvetica CarregadoHelvetica HalvfetHelvetica lihavaHelvetica √”ËœHelvetica »—Ã” ÁHelvetica Ú·‰17.0d1e1Helvetica-BoldHelvetica is a registered trademark of Linotype AGHelvetica est une marque déposée de Linotype AGHelvetica ist ein eingetragenes Warenzeichen der Linotype AGHelvetica è un marchio registrato di Linotype AGHelvetica is een geregistreerd handelsmerk van Linotype AGHelvetica är ett registrerat varumärke för Linotype AGHelvetica es una marca registrada de Linotype AGHelvetica er et registreret varemærke tilhørende Linotype AGHelvetica BoldLigaturesCommon LigaturesNumber SpacingProportional NumbersMonospaced NumbersNo Change          ˇe e                     ^           	 
+                        ! " # $ % & ' ( ) * + , - . / 0 1 2 3 4 5 6 7 8 9 : ; < = > ? @ A B C D E F G H I J K L M N O P Q R S T U V W X Y Z [ \ ]  ∏ f+ ∫   h+∫   h+ø  (       n+ø  %       n+ ø  - %      n+ø  K = 0 "    n+ø  &       n+ ∫   m+∏   E}iDendstream
+endobj
+xref
+0 65
+0000000000 65535 f
+0000000009 00000 n
+0000000077 00000 n
+0000000125 00000 n
+0000000267 00000 n
+0000000420 00000 n
+0000000782 00000 n
+0000001125 00000 n
+0000001304 00000 n
+0000001457 00000 n
+0000001786 00000 n
+0000002142 00000 n
+0000002298 00000 n
+0000002658 00000 n
+0000002977 00000 n
+0000003375 00000 n
+0000003526 00000 n
+0000003664 00000 n
+0000004055 00000 n
+0000004202 00000 n
+0000004301 00000 n
+0000005829 00000 n
+0000005996 00000 n
+0000006125 00000 n
+0000006442 00000 n
+0000006591 00000 n
+0000006719 00000 n
+0000008246 00000 n
+0000008372 00000 n
+0000008520 00000 n
+0000008661 00000 n
+0000010188 00000 n
+0000010314 00000 n
+0000010485 00000 n
+0000010637 00000 n
+0000010766 00000 n
+0000010989 00000 n
+0000011169 00000 n
+0000011318 00000 n
+0000011621 00000 n
+0000011762 00000 n
+0000011987 00000 n
+0000012147 00000 n
+0000012273 00000 n
+0000012433 00000 n
+0000012559 00000 n
+0000012719 00000 n
+0000012846 00000 n
+0000013007 00000 n
+0000013134 00000 n
+0000013295 00000 n
+0000013422 00000 n
+0000013554 00000 n
+0000013785 00000 n
+0000013935 00000 n
+0000014070 00000 n
+0000014341 00000 n
+0000014490 00000 n
+0000021219 00000 n
+0000028347 00000 n
+0000029313 00000 n
+0000029456 00000 n
+0000047966 00000 n
+0000048736 00000 n
+0000048851 00000 n
+trailer
+<<
+/Root 3 0 R 
+/Size 65 
+>>
+startxref
+61481
+%%EOF

--- a/ltml/std_canvas.go
+++ b/ltml/std_canvas.go
@@ -1,0 +1,66 @@
+// Copyright 2026 Brent Rowland.
+// Use of this source code is governed by the Apache License, Version 2.0, as described in the LICENSE file.
+
+package ltml
+
+import (
+	"fmt"
+	"strings"
+)
+
+type StdCanvas struct {
+	StdContainer
+	Scope
+	key string
+}
+
+func (c *StdCanvas) DefaultAttrs(HasScope) map[string]string {
+	return map[string]string{
+		"layout": "absolute",
+	}
+}
+
+func (c *StdCanvas) Key() string {
+	return c.key
+}
+
+func (c *StdCanvas) SetAttrs(attrs map[string]string) {
+	c.StdContainer.SetAttrs(attrs)
+	c.key = strings.TrimSpace(attrs["key"])
+}
+
+func (c *StdCanvas) SetContainer(container Container) error {
+	if _, ok := container.(*StdDocument); !ok {
+		return fmt.Errorf("canvas must be direct child of ltml")
+	}
+	return c.StdContainer.SetContainer(container)
+}
+
+func (c *StdCanvas) validateDefinition() error {
+	if strings.TrimSpace(c.key) == "" {
+		return fmt.Errorf("<canvas> requires a key")
+	}
+	if !c.WidthIsSet() || c.Width() <= 0 {
+		return fmt.Errorf("<canvas key=%q> requires a positive width", c.key)
+	}
+	if !c.HeightIsSet() || c.Height() <= 0 {
+		return fmt.Errorf("<canvas key=%q> requires a positive height", c.key)
+	}
+	return nil
+}
+
+func (c *StdCanvas) String() string {
+	return fmt.Sprintf("StdCanvas key=%s %s", c.key, &c.StdContainer)
+}
+
+func init() {
+	registerTag(DefaultSpace, "canvas", func() any { return &StdCanvas{} })
+}
+
+var _ Container = (*StdCanvas)(nil)
+var _ HasAttrs = (*StdCanvas)(nil)
+var _ HasDefaultAttrs = (*StdCanvas)(nil)
+var _ HasScope = (*StdCanvas)(nil)
+var _ WantsContainer = (*StdCanvas)(nil)
+var _ WantsDoc = (*StdCanvas)(nil)
+var _ WantsScope = (*StdCanvas)(nil)

--- a/ltml/std_container.go
+++ b/ltml/std_container.go
@@ -372,6 +372,20 @@ func (c *StdContainer) SplitForHeight(avail float64, w Writer) (*SplitResult, er
 	}
 }
 
+func (c *StdContainer) SplitEnabled() bool {
+	if c == nil || c.LayoutStyle() == nil {
+		return false
+	}
+	switch c.LayoutStyle().manager {
+	case "table":
+		return c.tableSplitEnabled()
+	case "vbox":
+		return c.vboxSplitEnabled()
+	default:
+		return false
+	}
+}
+
 func (c *StdContainer) tableSplitEnabled() bool {
 	if c.splitExplicit {
 		return c.splitEnabled

--- a/ltml/std_document.go
+++ b/ltml/std_document.go
@@ -5,6 +5,8 @@ package ltml
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/rowland/leadtype/pdf"
 )
@@ -21,6 +23,9 @@ type StdDocument struct {
 	compressEmbeddedFonts      bool
 	svgGradientStopOpacityMode string
 	renderContext              *documentRenderContext
+	canvases                   map[string]*StdCanvas
+	canvasCaptureStack         []string
+	visualCaptureDepth         int
 }
 
 func (d *StdDocument) Font() *FontStyle {
@@ -72,10 +77,86 @@ func (d *StdDocument) SetPendingStart(start int) {
 }
 
 func (d *StdDocument) Print(w Writer) error {
+	if err := d.validateCanvasAssets(); err != nil {
+		return err
+	}
 	applyWriterAccessibility(w, d)
 	d.applyWriterCompression(w)
 	d.applyWriterSVGCompatibility(w)
 	return d.printWithIndexes(w)
+}
+
+func (d *StdDocument) Canvas(key string) *StdCanvas {
+	if d == nil || d.canvases == nil {
+		return nil
+	}
+	return d.canvases[key]
+}
+
+func (d *StdDocument) registerCanvas(canvas *StdCanvas) error {
+	if d == nil || canvas == nil {
+		return nil
+	}
+	if err := canvas.validateDefinition(); err != nil {
+		return err
+	}
+	if d.canvases == nil {
+		d.canvases = make(map[string]*StdCanvas)
+	}
+	key := canvas.Key()
+	if _, exists := d.canvases[key]; exists {
+		return fmt.Errorf("duplicate canvas key %q", key)
+	}
+	d.canvases[key] = canvas
+	return nil
+}
+
+func (d *StdDocument) eachCanvas(fn func(*StdCanvas)) {
+	if d == nil || len(d.canvases) == 0 || fn == nil {
+		return
+	}
+	keys := make([]string, 0, len(d.canvases))
+	for key := range d.canvases {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		fn(d.canvases[key])
+	}
+}
+
+func (d *StdDocument) validateCanvasAssets() error {
+	if d == nil {
+		return nil
+	}
+	missing := make(map[string]struct{})
+	walkWidgets(d, func(widget Widget) bool {
+		draw, ok := widget.(*StdDraw)
+		if !ok {
+			return true
+		}
+		key := strings.TrimSpace(draw.key)
+		if key == "" {
+			missing["<blank>"] = struct{}{}
+			return true
+		}
+		if d.Canvas(key) == nil {
+			missing[key] = struct{}{}
+		}
+		return true
+	})
+	if len(missing) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(missing))
+	for key := range missing {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	if len(keys) == 1 && keys[0] == "<blank>" {
+		return fmt.Errorf("<draw> requires a key")
+	}
+	return fmt.Errorf("missing canvas definition(s): %s", strings.Join(keys, ", "))
 }
 
 func (d *StdDocument) NetworkAssetsEnabled() bool {

--- a/ltml/std_draw.go
+++ b/ltml/std_draw.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Brent Rowland.
+// Use of this source code is governed by the Apache License, Version 2.0, as described in the LICENSE file.
+
+package ltml
+
+import (
+	"fmt"
+	"strings"
+)
+
+// CanvasDrawer is an optional writer capability for placing LTML canvas assets.
+type CanvasDrawer interface {
+	DrawCanvas(key string, x, y, width, height, canvasWidth, canvasHeight float64, draw func(any) error) error
+}
+
+type StdDraw struct {
+	StdWidget
+	key string
+}
+
+func (d *StdDraw) DrawContent(w Writer) error {
+	return withGraphicAccessibility(w, &d.StdWidget, "Figure", func() error {
+		canvas, err := d.resolveCanvas()
+		if err != nil {
+			return err
+		}
+		drawer, ok := w.(CanvasDrawer)
+		if !ok {
+			return fmt.Errorf("draw requires a canvas-capable writer")
+		}
+		width, height := d.placementSize(canvas)
+		if width <= 0 || height <= 0 {
+			return nil
+		}
+		return drawer.DrawCanvas(
+			canvas.Key(),
+			ContentLeft(d),
+			ContentTop(d),
+			width,
+			height,
+			canvas.Width(),
+			canvas.Height(),
+			func(raw any) error {
+				capture, ok := raw.(Writer)
+				if !ok {
+					return fmt.Errorf("canvas capture writer %T does not implement ltml.Writer", raw)
+				}
+				return renderCanvasCapture(canvas, capture)
+			},
+		)
+	})
+}
+
+func (d *StdDraw) PreferredHeight(Writer) float64 {
+	if d.height != 0 {
+		return d.height
+	}
+	naturalWidth, naturalHeight, ok := d.naturalSize()
+	if !ok || naturalWidth <= 0 {
+		return NonContentHeight(d)
+	}
+	if d.width != 0 {
+		return d.width*naturalHeight/naturalWidth + NonContentHeight(d)
+	}
+	return naturalHeight + NonContentHeight(d)
+}
+
+func (d *StdDraw) PreferredWidth(Writer) float64 {
+	if d.width != 0 {
+		return d.width
+	}
+	naturalWidth, naturalHeight, ok := d.naturalSize()
+	if !ok || naturalHeight <= 0 {
+		return NonContentWidth(d)
+	}
+	if d.height != 0 {
+		return d.height*naturalWidth/naturalHeight + NonContentWidth(d)
+	}
+	return naturalWidth + NonContentWidth(d)
+}
+
+func (d *StdDraw) SetAttrs(attrs map[string]string) {
+	d.StdWidget.SetAttrs(attrs)
+	d.key = strings.TrimSpace(attrs["key"])
+}
+
+func (d *StdDraw) String() string {
+	return fmt.Sprintf("StdDraw key=%s %s", d.key, &d.StdWidget)
+}
+
+func (d *StdDraw) placementSize(canvas *StdCanvas) (width, height float64) {
+	if canvas == nil {
+		return 0, 0
+	}
+	if d.WidthIsSet() && d.HeightIsSet() {
+		return ContentWidth(d), ContentHeight(d)
+	}
+	if d.WidthIsSet() {
+		width = ContentWidth(d)
+		if canvas.Width() == 0 {
+			return width, 0
+		}
+		return width, width * canvas.Height() / canvas.Width()
+	}
+	if d.HeightIsSet() {
+		height = ContentHeight(d)
+		if canvas.Height() == 0 {
+			return 0, height
+		}
+		return height * canvas.Width() / canvas.Height(), height
+	}
+	return canvas.Width(), canvas.Height()
+}
+
+func (d *StdDraw) naturalSize() (width, height float64, ok bool) {
+	canvas, err := d.resolveCanvas()
+	if err != nil || canvas == nil {
+		return 0, 0, false
+	}
+	return canvas.Width(), canvas.Height(), true
+}
+
+func (d *StdDraw) resolveCanvas() (*StdCanvas, error) {
+	if strings.TrimSpace(d.key) == "" {
+		return nil, fmt.Errorf("<draw> requires a key")
+	}
+	doc := documentForContainer(d.container)
+	if doc == nil {
+		return nil, fmt.Errorf("draw document is not set")
+	}
+	canvas := doc.Canvas(d.key)
+	if canvas == nil {
+		return nil, fmt.Errorf("missing canvas key %q", d.key)
+	}
+	return canvas, nil
+}
+
+func init() {
+	registerTag(DefaultSpace, "draw", func() any { return &StdDraw{} })
+}
+
+var _ HasAttrs = (*StdDraw)(nil)
+var _ Identifier = (*StdDraw)(nil)
+var _ Printer = (*StdDraw)(nil)
+var _ WantsContainer = (*StdDraw)(nil)
+var _ WantsDoc = (*StdDraw)(nil)
+var _ WantsScope = (*StdDraw)(nil)

--- a/ltml/std_index.go
+++ b/ltml/std_index.go
@@ -70,6 +70,10 @@ func (i *StdIndex) SplitForHeight(avail float64, w Writer) (*SplitResult, error)
 	}, nil
 }
 
+func (i *StdIndex) SplitEnabled() bool {
+	return i != nil
+}
+
 func (i *StdIndex) clearSplitOverride() {
 	i.entriesOverride = nil
 }
@@ -98,7 +102,7 @@ func (i *StdIndex) currentEntries() []resolvedIndexEntry {
 		return i.entriesOverride
 	}
 	doc := documentForContainer(i.container)
-	if doc == nil {
+	if doc == nil || documentVisualCaptureActive(doc) {
 		return nil
 	}
 	return doc.activeIndexEntries(i.ID)

--- a/ltml/std_pageno.go
+++ b/ltml/std_pageno.go
@@ -21,7 +21,7 @@ func (p *StdPageNo) Dynamic() bool {
 }
 
 func (p *StdPageNo) Resolve(doc *StdDocument) string {
-	if p.hidden || doc == nil {
+	if p.hidden || doc == nil || documentVisualCaptureActive(doc) {
 		return ""
 	}
 	return formatPageNo(doc.CurrentPageNo())

--- a/ltml/std_paragraph.go
+++ b/ltml/std_paragraph.go
@@ -19,8 +19,7 @@ type StdParagraph struct {
 	richText           *rich_text.RichText
 	textFill           *BrushStyle
 	bullet             *BulletStyle
-	splitEnabled       bool
-	splitExplicit      bool
+	splitDisabled      bool
 	orphans            int
 	widows             int
 	splitLines         []*rich_text.RichText
@@ -237,7 +236,6 @@ func (p *StdParagraph) SetAttrs(attrs map[string]string) {
 		}
 		p.textFill.SetAttrs(addUnits(filterMapAttrs("text-fill.", attrs), p.Units()))
 	}
-	p.splitEnabled = true
 	p.orphans = 2
 	p.widows = 2
 	if style, ok := attrs["style"]; ok {
@@ -251,8 +249,7 @@ func (p *StdParagraph) SetAttrs(attrs map[string]string) {
 		p.bullet = BulletStyleFor(bullet, p.scope)
 	}
 	if split, ok := attrs["split"]; ok {
-		p.splitExplicit = true
-		p.splitEnabled = split != "false"
+		p.splitDisabled = split == "false"
 	}
 	if orphans, ok := attrs["orphans"]; ok {
 		if value, err := strconv.Atoi(orphans); err == nil {
@@ -290,7 +287,7 @@ func (p *StdParagraph) paintTextFill(w Writer, para []*rich_text.RichText, start
 }
 
 func (p *StdParagraph) SplitForHeight(avail float64, w Writer) (*SplitResult, error) {
-	if !p.splitEnabled {
+	if p.splitDisabled {
 		return nil, nil
 	}
 	lines := p.Lines(w, p.lineWidth())
@@ -315,6 +312,10 @@ func (p *StdParagraph) SplitForHeight(avail float64, w Writer) (*SplitResult, er
 	head := p.cloneForSplit(lines[:fit], p.suppressBullet, p.continuationIndent)
 	tail := p.cloneForSplit(lines[fit:], true, p.textIndent())
 	return &SplitResult{Head: head, Tail: tail}, nil
+}
+
+func (p *StdParagraph) SplitEnabled() bool {
+	return !p.splitDisabled
 }
 
 func (p *StdParagraph) cloneForSplit(lines []*rich_text.RichText, suppressBullet bool, continuationIndent float64) *StdParagraph {

--- a/ltml/std_paragraph_bullet.go
+++ b/ltml/std_paragraph_bullet.go
@@ -114,7 +114,7 @@ func (p *StdParagraph) drawBulletShape(w Writer, layout paragraphBulletLayout, b
 func (p *StdParagraph) bulletLayout(w Writer, bullet *BulletStyle, line *rich_text.RichText, slotX, baselineY, textHeight float64) paragraphBulletLayout {
 	slotWidth := bullet.Width()
 	lineHeight, lineAscent := bulletLineMetrics(w, line)
-	renderWidth, renderHeight := p.bulletRenderSize(w, bullet, line, lineHeight)
+	renderWidth, renderHeight := p.bulletRenderSize(w, bullet, lineHeight)
 	if renderWidth <= 0 {
 		renderWidth = min(slotWidth, renderHeight)
 	}
@@ -168,7 +168,7 @@ func bulletLineMetrics(w Writer, line *rich_text.RichText) (lineHeight, lineAsce
 	return lineHeight, lineAscent
 }
 
-func (p *StdParagraph) bulletRenderSize(w Writer, bullet *BulletStyle, line *rich_text.RichText, lineHeight float64) (renderWidth, renderHeight float64) {
+func (p *StdParagraph) bulletRenderSize(w Writer, bullet *BulletStyle, lineHeight float64) (renderWidth, renderHeight float64) {
 	if bullet.IsImage() {
 		renderHeight = bullet.Height()
 		if renderHeight <= 0 {
@@ -241,7 +241,7 @@ func (p *StdParagraph) bulletBoxHeightForLines(w Writer, lines []*rich_text.Rich
 
 func (p *StdParagraph) bulletBoxHeight(w Writer, bullet *BulletStyle, line *rich_text.RichText, textHeight float64) float64 {
 	lineHeight, _ := bulletLineMetrics(w, line)
-	_, renderHeight := p.bulletRenderSize(w, bullet, line, lineHeight)
+	_, renderHeight := p.bulletRenderSize(w, bullet, lineHeight)
 	boxHeight := renderHeight
 	if bullet.Height() > boxHeight {
 		boxHeight = bullet.Height()

--- a/ltml/std_paragraph_text_test.go
+++ b/ltml/std_paragraph_text_test.go
@@ -285,7 +285,7 @@ func TestStdParagraph_SplitForHeight_RespectsDefaultsAndSuppressesBullet(t *test
 	_ = p.SetContainer(page)
 	p.font = &FontStyle{id: "body", entries: []fontEntry{{name: "Helvetica"}}, size: 12}
 	p.bullet = &BulletStyle{text: "*", width: 18, font: p.font}
-	p.splitEnabled = true
+	p.splitDisabled = false
 	p.orphans = 2
 	p.widows = 2
 	p.SetWidth(90)
@@ -750,7 +750,7 @@ func TestStdParagraph_SplitForHeight_ImageBulletSuppressesContinuationRendering(
 	p.font = &FontStyle{id: "body", entries: []fontEntry{{name: "Helvetica"}}, size: 12}
 	p.paragraphStyle = &ParagraphStyle{}
 	p.bullet = &BulletStyle{src: "fixture.jpg", width: 18, height: 12}
-	p.splitEnabled = true
+	p.splitDisabled = false
 	p.orphans = 2
 	p.widows = 2
 	p.SetWidth(90)

--- a/ltml/widget.go
+++ b/ltml/widget.go
@@ -209,7 +209,7 @@ func shouldSkipRenderForPreflight(widget Widget) bool {
 		return false
 	}
 	switch widget.(type) {
-	case *StdA, *StdIndex, *StdIndexEntry, *StdLabel, *StdPageNo, *StdParagraph, *StdPre, *StdSpan, *StdTarget:
+	case *StdA, *StdDraw, *StdIndex, *StdIndexEntry, *StdLabel, *StdPageNo, *StdParagraph, *StdPre, *StdSpan, *StdTarget:
 		return true
 	default:
 		_, isContainer := widget.(Container)

--- a/pdf/doc_writer.go
+++ b/pdf/doc_writer.go
@@ -43,6 +43,7 @@ type DocWriter struct {
 	fontDescriptors       map[string]*fontDescriptor // PostScript name → descriptor, for FontFile2 at Close
 	images                map[string]*cachedImage
 	svgForms              map[string]*cachedSVGForm
+	memoForms             map[string]*cachedForm
 	gradientShadings      map[string]string // gradient key → shading resource name
 	gradientPatterns      map[string]string // gradient key → pattern resource name
 	extGStates            map[string]string // graphics-state key → ExtGState resource name
@@ -103,6 +104,7 @@ func NewDocWriter() *DocWriter {
 		fontDescriptors:  make(map[string]*fontDescriptor),
 		images:           make(map[string]*cachedImage),
 		svgForms:         make(map[string]*cachedSVGForm),
+		memoForms:        make(map[string]*cachedForm),
 		gradientShadings: make(map[string]string),
 		gradientPatterns: make(map[string]string),
 		extGStates:       make(map[string]string),
@@ -914,6 +916,52 @@ func (dw *DocWriter) loadSVGForm(data []byte, key string, renderOptions options.
 	}
 	dw.svgForms[key] = cached
 	return cached, nil
+}
+
+func (dw *DocWriter) loadMemoForm(cacheKey string, base *PageWriter, canvasWidthPts, canvasHeightPts float64, render func(*PageWriter) error) (*cachedForm, error) {
+	if cached, ok := dw.memoForms[cacheKey]; ok {
+		return cached, nil
+	}
+
+	content := newContentWriterFromPage(base, canvasWidthPts, canvasHeightPts)
+	if err := render(content); err != nil {
+		return nil, err
+	}
+	content.endText()
+	content.endGraph()
+
+	formResources := dw.resources.clone(dw.nextSeq(), 0)
+	form := newPDFForm(dw.nextSeq(), 0, content.stream.Bytes())
+	form.setBBox(canvasWidthPts, canvasHeightPts)
+	form.setResources(formResources)
+	if dw.compressPages {
+		if err := form.compress(); err != nil {
+			return nil, err
+		}
+	}
+
+	name := fmt.Sprintf("Mf%d", len(dw.memoForms))
+	dw.file.body.add(formResources, form)
+	dw.resources.setXObject(name, &indirectObjectRef{form})
+
+	cached := &cachedForm{
+		form:   form,
+		name:   name,
+		width:  canvasWidthPts,
+		height: canvasHeightPts,
+	}
+	dw.memoForms[cacheKey] = cached
+	return cached, nil
+}
+
+func (dw *DocWriter) MemoizeForm(key string, x, y, width, height float64, render func(*PageWriter) error) error {
+	return dw.CurPage().MemoizeForm(key, x, y, width, height, render)
+}
+
+// MemoizeFormOnCanvas captures a form once on the supplied logical canvas size,
+// then places that form at the requested destination size.
+func (dw *DocWriter) MemoizeFormOnCanvas(key string, x, y, width, height, canvasWidth, canvasHeight float64, render func(*PageWriter) error) error {
+	return dw.CurPage().MemoizeFormOnCanvas(key, x, y, width, height, canvasWidth, canvasHeight, render)
 }
 
 func (dw *DocWriter) gradientKey(prefix string, coords []float64, stops []GradientStop) string {

--- a/pdf/form_memo.go
+++ b/pdf/form_memo.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Brent Rowland.
+// Use of this source code is governed the Apache License, Version 2.0, as described in the LICENSE file.
+
+package pdf
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/rowland/leadtype/options"
+)
+
+type cachedForm struct {
+	form   *pdfForm
+	name   string
+	width  float64
+	height float64
+}
+
+func memoFormOptionsKey(opts options.Options, units string) string {
+	if len(opts) == 0 && units == "" {
+		return ""
+	}
+	keys := make([]string, 0, len(opts)+1)
+	for key := range opts {
+		switch key {
+		case "page_width", "page_height", "crop_width", "crop_height", "rotate":
+			continue
+		case "units":
+			continue
+		default:
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	if units != "" {
+		fmt.Fprintf(&b, "units=%s;", units)
+	}
+	for _, key := range keys {
+		fmt.Fprintf(&b, "%s=%s;", key, memoFormOptionValue(opts[key]))
+	}
+	return b.String()
+}
+
+func memoFormOptionValue(value any) string {
+	switch value := value.(type) {
+	case nil:
+		return "<nil>"
+	case string:
+		return value
+	case bool:
+		if value {
+			return "true"
+		}
+		return "false"
+	case int:
+		return fmt.Sprintf("%d", value)
+	case float64:
+		return g(value)
+	default:
+		return fmt.Sprintf("%v", value)
+	}
+}

--- a/pdf/form_memo_test.go
+++ b/pdf/form_memo_test.go
@@ -1,0 +1,278 @@
+// Copyright 2026 Brent Rowland.
+// Use of this source code is governed the Apache License, Version 2.0, as described in the LICENSE file.
+
+package pdf
+
+import (
+	"bytes"
+	"image"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/rowland/leadtype/afm_fonts"
+	"github.com/rowland/leadtype/colors"
+	"github.com/rowland/leadtype/options"
+	"github.com/rowland/leadtype/rich_text"
+)
+
+func TestDocWriter_MemoizeForm_ReusesFormAcrossPages(t *testing.T) {
+	var buf bytes.Buffer
+
+	dw := NewDocWriter()
+	dw.SetUnits("in")
+	fonts, err := afm_fonts.Default()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dw.AddFontSource(fonts)
+
+	render := func(pw *PageWriter) error {
+		pw.MoveTo(0.15, 0.3)
+		return pw.Print("Memo form")
+	}
+
+	pw1 := dw.NewPage()
+	if _, err := pw1.SetFont("Helvetica", 12, options.Options{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := pw1.MemoizeForm("memo-card", 1, 1, 2.25, 0.6, render); err != nil {
+		t.Fatal(err)
+	}
+
+	pw2 := dw.NewPage()
+	if _, err := pw2.SetFont("Helvetica", 12, options.Options{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := pw2.MemoizeForm("memo-card", 0.75, 1.5, 2.25, 0.6, render); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := dw.WriteTo(&buf); err != nil {
+		t.Fatal(err)
+	}
+	pdfText := buf.String()
+	if count := strings.Count(pdfText, "/Subtype /Form"); count != 1 {
+		t.Fatalf("expected one memoized form, got %d\n%s", count, pdfText)
+	}
+	if count := strings.Count(pdfText, "/Mf0 Do"); count != 2 {
+		t.Fatalf("expected two placements of memoized form, got %d\n%s", count, pdfText)
+	}
+}
+
+func TestDocWriter_MemoizeFormOnCanvas_ReusesFormAcrossDifferentPlacementSizes(t *testing.T) {
+	var buf bytes.Buffer
+
+	dw := NewDocWriter()
+	dw.SetUnits("pt")
+	pw := dw.NewPage()
+
+	render := func(pw *PageWriter) error {
+		pw.SetLineWidth(2, "pt")
+		pw.SetLineColor(colors.DarkBlue)
+		return pw.Circle(120, 120, 100, true, false, false)
+	}
+
+	if err := pw.MemoizeFormOnCanvas("memo-board", 72, 72, 96, 96, 240, 240, render); err != nil {
+		t.Fatal(err)
+	}
+	if err := pw.MemoizeFormOnCanvas("memo-board", 204, 72, 48, 48, 240, 240, render); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := dw.WriteTo(&buf); err != nil {
+		t.Fatal(err)
+	}
+	pdfText := buf.String()
+	if count := strings.Count(pdfText, "/Subtype /Form"); count != 1 {
+		t.Fatalf("expected one memoized form for shared canvas geometry, got %d\n%s", count, pdfText)
+	}
+	if count := strings.Count(pdfText, "/Mf0 Do"); count != 2 {
+		t.Fatalf("expected two placements of shared memoized form, got %d\n%s", count, pdfText)
+	}
+}
+
+func TestDocWriter_MemoizeForm_DifferentSizesDoNotCollide(t *testing.T) {
+	var buf bytes.Buffer
+
+	dw := NewDocWriter()
+	dw.SetUnits("in")
+	fonts, err := afm_fonts.Default()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dw.AddFontSource(fonts)
+
+	pw := dw.NewPage()
+	if _, err := pw.SetFont("Helvetica", 12, options.Options{}); err != nil {
+		t.Fatal(err)
+	}
+	render := func(pw *PageWriter) error {
+		pw.MoveTo(0.1, 0.25)
+		return pw.Print("Sized form")
+	}
+
+	if err := pw.MemoizeForm("memo-card", 1, 1, 2, 0.5, render); err != nil {
+		t.Fatal(err)
+	}
+	if err := pw.MemoizeForm("memo-card", 1, 2, 2.75, 0.5, render); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := dw.WriteTo(&buf); err != nil {
+		t.Fatal(err)
+	}
+	pdfText := buf.String()
+	if count := strings.Count(pdfText, "/Subtype /Form"); count != 2 {
+		t.Fatalf("expected two memoized forms for distinct sizes, got %d\n%s", count, pdfText)
+	}
+	if !strings.Contains(pdfText, "/Mf0 Do") || !strings.Contains(pdfText, "/Mf1 Do") {
+		t.Fatalf("expected both memoized form placements, got:\n%s", pdfText)
+	}
+}
+
+func TestDocWriter_MemoizeFormOnCanvas_DifferentCanvasSizesDoNotCollide(t *testing.T) {
+	var buf bytes.Buffer
+
+	dw := NewDocWriter()
+	dw.SetUnits("pt")
+	pw := dw.NewPage()
+
+	render := func(canvas float64) func(*PageWriter) error {
+		return func(pw *PageWriter) error {
+			pw.SetLineWidth(2, "pt")
+			pw.SetLineColor(colors.FireBrick)
+			return pw.Circle(canvas/2, canvas/2, canvas*0.4, true, false, false)
+		}
+	}
+
+	if err := pw.MemoizeFormOnCanvas("memo-board", 72, 72, 60, 60, 180, 180, render(180)); err != nil {
+		t.Fatal(err)
+	}
+	if err := pw.MemoizeFormOnCanvas("memo-board", 150, 72, 60, 60, 240, 240, render(240)); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := dw.WriteTo(&buf); err != nil {
+		t.Fatal(err)
+	}
+	pdfText := buf.String()
+	if count := strings.Count(pdfText, "/Subtype /Form"); count != 2 {
+		t.Fatalf("expected two memoized forms for distinct canvas sizes, got %d\n%s", count, pdfText)
+	}
+	if !strings.Contains(pdfText, "/Mf0 Do") || !strings.Contains(pdfText, "/Mf1 Do") {
+		t.Fatalf("expected both memoized form placements, got:\n%s", pdfText)
+	}
+}
+
+func TestDocWriter_MemoizeForm_ReusesNestedImageResources(t *testing.T) {
+	var buf bytes.Buffer
+
+	dw := NewDocWriter()
+	dw.SetUnits("in")
+	dw.SetAssetFS(fstest.MapFS{
+		"logo.png": &fstest.MapFile{Data: mustEncodePNG(t, image.NewGray(image.Rect(0, 0, 8, 4)))},
+	})
+	pw := dw.NewPage()
+
+	render := func(pw *PageWriter) error {
+		width := 1.0
+		_, _, err := pw.PrintImageFile("logo.png", 0, 0, &width, nil)
+		return err
+	}
+
+	if err := pw.MemoizeForm("memo-image", 1, 1, 1, 0.5, render); err != nil {
+		t.Fatal(err)
+	}
+	if err := pw.MemoizeForm("memo-image", 2.5, 1, 1, 0.5, render); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := dw.WriteTo(&buf); err != nil {
+		t.Fatal(err)
+	}
+	pdfText := buf.String()
+	if count := strings.Count(pdfText, "/Subtype /Form"); count != 1 {
+		t.Fatalf("expected one memoized form, got %d\n%s", count, pdfText)
+	}
+	if count := strings.Count(pdfText, "/Subtype /Image"); count != 1 {
+		t.Fatalf("expected one nested image resource, got %d\n%s", count, pdfText)
+	}
+}
+
+func TestDocWriter_MemoizeForm_SuppressesInnerTargetLinks(t *testing.T) {
+	var buf bytes.Buffer
+
+	dw := newAFMDocWriter(t)
+	pw := dw.NewPage()
+
+	if err := pw.MemoizeForm("memo-target", 1, 1, 2, 0.5, func(form *PageWriter) error {
+		form.RegisterDestination("memo-target", 0.1, 0.1)
+		return form.AddTargetLink(0.1, 0.1, 0.75, 0.2, "memo-target")
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := dw.WriteTo(&buf); err != nil {
+		t.Fatal(err)
+	}
+	pdfText := buf.String()
+	if strings.Contains(pdfText, "/Subtype /Link") {
+		t.Fatalf("memoized form should suppress inner target annotations, got:\n%s", pdfText)
+	}
+	if strings.Contains(pdfText, "/S /GoTo") {
+		t.Fatalf("memoized form should suppress inner destinations, got:\n%s", pdfText)
+	}
+}
+
+func TestDocWriter_MemoizeForm_SuppressesInnerLinksAndAccessibility(t *testing.T) {
+	var buf bytes.Buffer
+
+	dw := NewDocWriter()
+	dw.SetUnits("in")
+	dw.EnableTaggedPDF(true)
+	fonts, err := afm_fonts.Default()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dw.AddFontSource(fonts)
+
+	pw := dw.NewPage()
+	if _, err := pw.SetFont("Helvetica", 12, options.Options{}); err != nil {
+		t.Fatal(err)
+	}
+	rt, err := rich_text.New("Memoized link", pw.Fonts(), pw.FontSize(), options.Options{
+		"link_uri": "https://example.com",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var memoErr error
+	if err := pw.WithAccessibilityTag("Figure", AccessibilityOptions{ID: "outer-form"}, func() {
+		memoErr = pw.MemoizeForm("memo-link", 1, 1, 2.5, 0.5, func(form *PageWriter) error {
+			form.MoveTo(0.1, 0.3)
+			form.PrintRichText(rt)
+			return nil
+		})
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if memoErr != nil {
+		t.Fatal(memoErr)
+	}
+
+	if _, err := dw.WriteTo(&buf); err != nil {
+		t.Fatal(err)
+	}
+	pdfText := buf.String()
+	if strings.Contains(pdfText, "/Subtype /Link") {
+		t.Fatalf("memoized form should suppress inner link annotations, got:\n%s", pdfText)
+	}
+	if !strings.Contains(pdfText, "/StructTreeRoot") {
+		t.Fatalf("expected tagged PDF structure, got:\n%s", pdfText)
+	}
+	if count := strings.Count(pdfText, "BDC\n"); count != 1 {
+		t.Fatalf("expected one outer tagged placement and no inner tagged text, got %d\n%s", count, pdfText)
+	}
+}

--- a/pdf/page_writer.go
+++ b/pdf/page_writer.go
@@ -75,6 +75,7 @@ type PageWriter struct {
 	flushing              boolean
 	artifactDepth         int
 	accessibilityStack    []*structElem
+	memoCapture           bool
 }
 
 type pathState struct {
@@ -96,6 +97,21 @@ func newPageWriter(dw *DocWriter, options options.Options) *PageWriter {
 
 func newContentWriter(dw *DocWriter, options options.Options, pageWidth, pageHeight float64) *PageWriter {
 	return new(PageWriter).initContent(dw, options, pageWidth, pageHeight)
+}
+
+func newContentWriterFromPage(base *PageWriter, pageWidth, pageHeight float64) *PageWriter {
+	opts := base.options
+	if opts == nil {
+		opts = options.Options{}
+	}
+	content := newContentWriter(base.dw, opts.Merge(options.Options{"units": base.Units()}), pageWidth, pageHeight)
+	content.drawState = base.drawState
+	content.loc = Location{}
+	content.last = drawState{}
+	content.fonts = append([]*font.Font(nil), base.fonts...)
+	content.supportsArabicShaping = base.supportsArabicShaping
+	content.memoCapture = true
+	return content
 }
 
 func clonePageWriter(opw *PageWriter) *PageWriter {
@@ -165,6 +181,12 @@ func fontsSupportArabicShaping(fonts []*font.Font) bool {
 }
 
 func (pw *PageWriter) WithAccessibilityTag(tag string, opts AccessibilityOptions, fn func()) error {
+	if pw.memoCapture {
+		if fn != nil {
+			fn()
+		}
+		return nil
+	}
 	if tag == "" {
 		if fn != nil {
 			fn()
@@ -198,6 +220,12 @@ func (pw *PageWriter) WithAccessibilityTag(tag string, opts AccessibilityOptions
 }
 
 func (pw *PageWriter) WithAccessibilityArtifact(fn func()) error {
+	if pw.memoCapture {
+		if fn != nil {
+			fn()
+		}
+		return nil
+	}
 	if !pw.dw.taggedPDFEnabled() {
 		if fn != nil {
 			fn()
@@ -245,6 +273,9 @@ func (pw *PageWriter) beginActualTextContent(actualText string) bool {
 }
 
 func (pw *PageWriter) currentStructElem() *structElem {
+	if pw.memoCapture {
+		return nil
+	}
 	if len(pw.accessibilityStack) > 0 {
 		return pw.accessibilityStack[len(pw.accessibilityStack)-1]
 	}
@@ -1367,8 +1398,17 @@ func (pw *PageWriter) flushText() {
 	pw.flushing = true
 	line := pw.line
 	pw.line = nil
-	pw.emitRichTextLine(line, visibleTextEmission)
+	pw.emitRichTextLine(line, pw.visibleTextEmission())
 	pw.flushing = false
+}
+
+func (pw *PageWriter) visibleTextEmission() textEmissionOptions {
+	emit := visibleTextEmission
+	if pw.memoCapture {
+		emit.emitLinks = false
+		emit.emitAccessibility = false
+	}
+	return emit
 }
 
 func (pw *PageWriter) emitRichTextLine(line *rich_text.RichText, emit textEmissionOptions) {
@@ -1957,6 +1997,89 @@ func (pw *PageWriter) Loc() (x, y float64) {
 	return pw.X(), pw.Y()
 }
 
+func (pw *PageWriter) MemoizeForm(key string, x, y, width, height float64, render func(*PageWriter) error) error {
+	return pw.MemoizeFormOnCanvas(key, x, y, width, height, width, height, render)
+}
+
+// MemoizeFormOnCanvas captures a form once on the supplied logical canvas size,
+// then places that form at the requested destination size.
+func (pw *PageWriter) MemoizeFormOnCanvas(key string, x, y, width, height, canvasWidth, canvasHeight float64, render func(*PageWriter) error) error {
+	if key == "" {
+		return fmt.Errorf("memo form key must not be empty")
+	}
+	if render == nil || width <= 0 || height <= 0 || canvasWidth <= 0 || canvasHeight <= 0 {
+		return nil
+	}
+
+	xPts := pw.units.toPts(x)
+	yPts := pw.units.toPts(y)
+	widthPts := pw.units.toPts(width)
+	heightPts := pw.units.toPts(height)
+	canvasWidthPts := pw.units.toPts(canvasWidth)
+	canvasHeightPts := pw.units.toPts(canvasHeight)
+	cacheKey := pw.memoFormCacheKey(key, canvasWidthPts, canvasHeightPts)
+	form, err := pw.dw.loadMemoForm(cacheKey, pw, canvasWidthPts, canvasHeightPts, render)
+	if err != nil {
+		return err
+	}
+	return pw.placeFormXObject(
+		form.name,
+		xPts,
+		yPts,
+		widthPts,
+		heightPts,
+		form.width,
+		form.height,
+		1,
+	)
+}
+
+func (pw *PageWriter) memoFormCacheKey(key string, widthPts, heightPts float64) string {
+	return fmt.Sprintf(
+		"memo:%s;w=%s;h=%s;state=%s;opts=%s",
+		key,
+		g(widthPts),
+		g(heightPts),
+		pw.memoFormStateKey(),
+		memoFormOptionsKey(pw.options, pw.Units()),
+	)
+}
+
+func (pw *PageWriter) memoFormStateKey() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "fillColor=%06x;", int32(pw.fillColor))
+	fmt.Fprintf(&b, "fillGradient=%s;", pw.fillGradient)
+	fmt.Fprintf(&b, "fontColor=%06x;", int32(pw.fontColor))
+	fmt.Fprintf(&b, "fontKey=%s;", pw.fontKey)
+	fmt.Fprintf(&b, "fontSize=%s;", g(pw.fontSize))
+	fmt.Fprintf(&b, "lineCap=%d;", pw.lineCapStyle)
+	fmt.Fprintf(&b, "lineJoin=%d;", pw.lineJoinStyle)
+	fmt.Fprintf(&b, "lineColor=%06x;", int32(pw.lineColor))
+	fmt.Fprintf(&b, "lineGradient=%s;", pw.lineGradient)
+	fmt.Fprintf(&b, "lineDash=%s;", pw.lineDashPattern)
+	fmt.Fprintf(&b, "lineSpacing=%s;", g(pw.lineSpacing))
+	fmt.Fprintf(&b, "lineWidth=%s;", g(pw.lineWidth))
+	fmt.Fprintf(&b, "miter=%s;", g(pw.miterLimit))
+	fmt.Fprintf(&b, "strikeout=%t;", pw.strikeout)
+	fmt.Fprintf(&b, "underline=%t;", pw.underline)
+	fmt.Fprintf(&b, "vTextAlign=%s;", pw.vTextAlign.String())
+	fmt.Fprintf(&b, "charSpacing=%s;", g(pw.charSpacing))
+	fmt.Fprintf(&b, "wordSpacing=%s;", g(pw.wordSpacing))
+	if len(pw.fonts) > 0 {
+		b.WriteString("fonts=")
+		for _, current := range pw.fonts {
+			if current == nil {
+				b.WriteString("<nil>,")
+				continue
+			}
+			b.WriteString(current.PostScriptName())
+			b.WriteByte(',')
+		}
+		b.WriteByte(';')
+	}
+	return b.String()
+}
+
 func (pw *PageWriter) MoveTo(x, y float64) {
 	xpts, ypts := pw.units.toPts(x), pw.translate(pw.units.toPts(y))
 	pw.moveTo(xpts, ypts)
@@ -2348,6 +2471,9 @@ var errEmptyLinkURI = errors.New("uri link requires a non-empty URI")
 var errEmptyLinkTarget = errors.New("target link requires a non-empty destination name")
 
 func (pw *PageWriter) RegisterDestination(name string, x, y float64) {
+	if pw.memoCapture {
+		return
+	}
 	if name == "" {
 		return
 	}
@@ -2357,6 +2483,9 @@ func (pw *PageWriter) RegisterDestination(name string, x, y float64) {
 }
 
 func (pw *PageWriter) AddURILink(x, y, width, height float64, uri string) error {
+	if pw.memoCapture {
+		return nil
+	}
 	if uri == "" {
 		return errEmptyLinkURI
 	}
@@ -2369,6 +2498,9 @@ func (pw *PageWriter) AddURILink(x, y, width, height float64, uri string) error 
 }
 
 func (pw *PageWriter) AddTargetLink(x, y, width, height float64, target string) error {
+	if pw.memoCapture {
+		return nil
+	}
 	if target == "" {
 		return errEmptyLinkTarget
 	}
@@ -2389,6 +2521,9 @@ func (pw *PageWriter) annotationRect(x, y, width, height float64) rectangle {
 }
 
 func (pw *PageWriter) addTextLinkAnnotation(rect rectangle, uri, target string, elem *structElem) {
+	if pw.memoCapture {
+		return
+	}
 	if rect.x2 <= rect.x1 || rect.y2 <= rect.y1 {
 		return
 	}

--- a/pdf/page_writer.go
+++ b/pdf/page_writer.go
@@ -752,9 +752,7 @@ func (pw *PageWriter) Clip(fn func()) error {
 	if fn != nil {
 		fn()
 	}
-	if pw.inText {
-		pw.endText()
-	}
+	pw.endText()
 	if pw.inGraph {
 		pw.endGraph()
 	}
@@ -768,14 +766,7 @@ func (pw *PageWriter) scopedTransform(a, b, c, d, x, y float64, fn func()) error
 		return errTransformInsideManualPath
 	}
 	savedLast := pw.last
-	if pw.inText {
-		pw.endText()
-	} else if pw.line != nil {
-		pw.flushText()
-		if pw.inText {
-			pw.endText()
-		}
-	}
+	pw.endText()
 	if pw.inGraph {
 		pw.endGraph()
 	}
@@ -784,14 +775,7 @@ func (pw *PageWriter) scopedTransform(a, b, c, d, x, y float64, fn func()) error
 	if fn != nil {
 		fn()
 	}
-	if pw.inText {
-		pw.endText()
-	} else if pw.line != nil {
-		pw.flushText()
-		if pw.inText {
-			pw.endText()
-		}
-	}
+	pw.endText()
 	if pw.inGraph {
 		pw.endGraph()
 	}
@@ -1396,6 +1380,7 @@ func (pw *PageWriter) flushText() {
 		return
 	}
 	pw.flushing = true
+	pw.startText()
 	line := pw.line
 	pw.line = nil
 	pw.emitRichTextLine(line, pw.visibleTextEmission())
@@ -2156,14 +2141,7 @@ func (pw *PageWriter) clipRichTextWithOptions(text *rich_text.RichText, emit tex
 	if len(pw.pathStates) > 0 {
 		return errTextClipInsideManualPath
 	}
-	if pw.inText {
-		pw.endText()
-	} else if pw.line != nil {
-		pw.flushText()
-		if pw.inText {
-			pw.endText()
-		}
-	}
+	pw.endText()
 	if pw.inGraph {
 		pw.endGraph()
 	}
@@ -2180,14 +2158,7 @@ func (pw *PageWriter) clipRichTextWithOptions(text *rich_text.RichText, emit tex
 	if fn != nil {
 		fn()
 	}
-	if pw.inText {
-		pw.endText()
-	} else if pw.line != nil {
-		pw.flushText()
-		if pw.inText {
-			pw.endText()
-		}
-	}
+	pw.endText()
 	if pw.inGraph {
 		pw.endGraph()
 	}
@@ -2230,9 +2201,7 @@ func (pw *PageWriter) prepareXObjectDraw() {
 	if pw.inPath {
 		pw.endPath()
 	}
-	if pw.inText {
-		pw.endText()
-	}
+	pw.endText()
 	if pw.inGraph {
 		pw.endGraph()
 	}
@@ -2924,22 +2893,20 @@ func (pw *PageWriter) SetVTextAlign(vTextAlign string) (prev string) {
 }
 
 func (pw *PageWriter) startGraph() {
+	pw.endText()
 	if pw.inGraph {
 		return
-	}
-	if pw.inText {
-		pw.endText()
 	}
 	pw.last.loc = Location{0, 0}
 	pw.inGraph = true
 }
 
 func (pw *PageWriter) startText() {
-	if pw.inText {
-		return
-	}
 	if pw.inGraph {
 		pw.endGraph()
+	}
+	if pw.inText {
+		return
 	}
 	pw.last.loc = Location{0, 0}
 	pw.resetTextStateCache()

--- a/pdf/page_writer_test.go
+++ b/pdf/page_writer_test.go
@@ -507,6 +507,114 @@ func TestPageWriter_ClipEllipseClosesPath(t *testing.T) {
 	}
 }
 
+func TestPageWriter_RoundedRectangleDoesNotSplitPathWhenTextIsPending(t *testing.T) {
+	dw := NewDocWriter()
+	fc, err := afm_fonts.Default()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dw.AddFontSource(fc)
+	pw := dw.NewPage()
+
+	if _, err := pw.SetFont("Helvetica", 12, options.Options{}); err != nil {
+		t.Fatal(err)
+	}
+	pw.MoveTo(72, 720)
+	pw.Print("Hello")
+	pw.Rectangle2(10, 10, 40, 20, true, false, []float64{6}, false, false)
+
+	got := pw.stream.String()
+	if strings.Contains(got, "c\nET\nS\n") {
+		t.Fatalf("expected pending text flush not to split rounded rectangle path, got:\n%s", got)
+	}
+}
+
+func TestPageWriter_RoundedRectangleClosesQueuedRichTextBeforePathOperators(t *testing.T) {
+	dw := NewDocWriter()
+	fc, err := afm_fonts.Default()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dw.AddFontSource(fc)
+	pw := dw.NewPage()
+
+	if _, err := pw.SetFont("Helvetica", 12, options.Options{}); err != nil {
+		t.Fatal(err)
+	}
+	rt, err := pw.richTextForString("Hello")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pw.MoveTo(72, 720)
+	pw.PrintRichText(rt)
+	pw.Rectangle2(10, 10, 40, 20, true, false, []float64{6}, false, false)
+
+	got := pw.stream.String()
+	moveIdx := strings.Index(got, "50 776 m\n")
+	if moveIdx < 0 {
+		t.Fatalf("expected rounded rectangle moveTo in stream, got:\n%s", got)
+	}
+	textEndIdx := strings.Index(got, "ET\n")
+	if textEndIdx < 0 {
+		t.Fatalf("expected text object close in stream, got:\n%s", got)
+	}
+	if textEndIdx > moveIdx {
+		t.Fatalf("expected rounded rectangle path to start after ET, got:\n%s", got)
+	}
+	if strings.Contains(got[textEndIdx+3:moveIdx], "BT\n") {
+		t.Fatalf("unexpected reopened text object before rounded rectangle path, got:\n%s", got)
+	}
+}
+
+func TestPageWriter_PrintImageClosesQueuedRichTextBeforeXObject(t *testing.T) {
+	dw := NewDocWriter()
+	fc, err := afm_fonts.Default()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dw.AddFontSource(fc)
+	pw := dw.NewPage()
+
+	if _, err := pw.SetFont("Helvetica", 12, options.Options{}); err != nil {
+		t.Fatal(err)
+	}
+	rt, err := pw.richTextForString("Hello")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pw.MoveTo(72, 720)
+	pw.PrintRichText(rt)
+	img := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	if _, _, err := pw.PrintImage(mustEncodePNG(t, img), 10, 20, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	got := pw.stream.String()
+	tjIdx := strings.Index(got, " Tj\n")
+	if tjIdx < 0 {
+		t.Fatalf("expected text show operator in stream, got:\n%s", got)
+	}
+	textEndIdx := strings.Index(got, "ET\n")
+	if textEndIdx < 0 {
+		t.Fatalf("expected text object close in stream, got:\n%s", got)
+	}
+	doIdx := strings.Index(got, " Do\n")
+	if doIdx < 0 {
+		t.Fatalf("expected image XObject draw operator in stream, got:\n%s", got)
+	}
+	if tjIdx > doIdx {
+		t.Fatalf("expected queued rich text to flush before image draw, got:\n%s", got)
+	}
+	if textEndIdx > doIdx {
+		t.Fatalf("expected image draw to begin after ET, got:\n%s", got)
+	}
+	if strings.Contains(got[textEndIdx+3:doIdx], "BT\n") {
+		t.Fatalf("unexpected reopened text object before image draw, got:\n%s", got)
+	}
+}
+
 func TestPageWriter_CircleUsesTranslatedMoveTo(t *testing.T) {
 	dw := NewDocWriter()
 	pw := newPageWriter(dw, options.Options{"units": "in"})

--- a/pdf/svg_render.go
+++ b/pdf/svg_render.go
@@ -521,9 +521,7 @@ func (r *svgRenderer) withMask(maskRef string, fn func() error) error {
 	if fn != nil {
 		err = fn()
 	}
-	if r.pw.inText {
-		r.pw.endText()
-	}
+	r.pw.endText()
 	if r.pw.inGraph {
 		r.pw.endGraph()
 	}
@@ -547,9 +545,7 @@ func (r *svgRenderer) withScopedGraphicsState(fillAlpha, strokeAlpha float64, bl
 	if fn != nil {
 		err = fn()
 	}
-	if r.pw.inText {
-		r.pw.endText()
-	}
+	r.pw.endText()
 	if r.pw.inGraph {
 		r.pw.endGraph()
 	}
@@ -577,9 +573,7 @@ func clipPathWithRule(pw *PageWriter, rule string, fn func() error) error {
 	if fn != nil {
 		err = fn()
 	}
-	if pw.inText {
-		pw.endText()
-	}
+	pw.endText()
 	if pw.inGraph {
 		pw.endGraph()
 	}

--- a/samples/test_027_form_memo_canvas.go
+++ b/samples/test_027_form_memo_canvas.go
@@ -1,0 +1,167 @@
+// Copyright 2026 Brent Rowland.
+// Use of this source code is governed the Apache License, Version 2.0, as described in the LICENSE file.
+
+package main
+
+import (
+	"math"
+
+	"github.com/rowland/leadtype/afm_fonts"
+	"github.com/rowland/leadtype/colors"
+	"github.com/rowland/leadtype/options"
+	"github.com/rowland/leadtype/pdf"
+)
+
+func init() {
+	registerSample("test_027_form_memo_canvas", "reuse one logical-canvas form at multiple placement sizes", runTest027FormMemoCanvas)
+}
+
+type targetBoardMode uint8
+
+const (
+	targetBoardDetailed targetBoardMode = iota
+	targetBoardSimplified
+)
+
+func runTest027FormMemoCanvas() (string, error) {
+	return writeDoc("test_027_form_memo_canvas.pdf", func(doc *pdf.DocWriter) error {
+		doc.SetUnits("pt")
+		if fonts, err := afm_fonts.Default(); err == nil {
+			doc.AddFontSource(fonts)
+		}
+
+		page := doc.NewPage()
+		if _, err := page.SetFont("Helvetica", 18, options.Options{"weight": "bold"}); err == nil {
+			page.MoveTo(48, 44)
+			_ = page.Print("Memoized form with a logical canvas")
+		}
+		if _, err := page.SetFont("Helvetica", 10, options.Options{}); err == nil {
+			page.MoveTo(48, 66)
+			_ = page.Print("The detailed board below is drawn directly. The smaller boards reuse a simplified form captured once on a 240pt canvas.")
+			page.MoveTo(48, 84)
+			_ = page.Print("That simplified version is never placed at full size, but it keeps a consistent coordinate system for every reuse.")
+		}
+
+		if err := drawTargetBoard(page, 164, 250, 108, targetBoardDetailed); err != nil {
+			return err
+		}
+		if _, err := page.SetFont("Helvetica", 9, options.Options{"weight": "bold"}); err == nil {
+			page.MoveTo(82, 382)
+			_ = page.Print("Detailed geometry drawn directly")
+		}
+
+		placements := []struct {
+			x     float64
+			y     float64
+			size  float64
+			label string
+		}{
+			{x: 340, y: 154, size: 96, label: "96pt placement"},
+			{x: 468, y: 172, size: 64, label: "64pt placement"},
+			{x: 340, y: 292, size: 48, label: "48pt placement"},
+			{x: 428, y: 280, size: 34, label: "34pt placement"},
+			{x: 492, y: 296, size: 24, label: "24pt placement"},
+		}
+		for _, placement := range placements {
+			if err := page.MemoizeFormOnCanvas(
+				"target-board:simplified",
+				placement.x,
+				placement.y,
+				placement.size,
+				placement.size,
+				240,
+				240,
+				func(form *pdf.PageWriter) error {
+					return drawTargetBoard(form, 120, 120, 108, targetBoardSimplified)
+				},
+			); err != nil {
+				return err
+			}
+			if _, err := page.SetFont("Helvetica", 8, options.Options{}); err == nil {
+				page.MoveTo(placement.x, placement.y+placement.size+14)
+				_ = page.Print(placement.label)
+			}
+		}
+
+		page.SetLineColor(colors.Gainsboro)
+		page.SetLineWidth(1, "pt")
+		page.Line(300, 120, 90, 270)
+
+		return nil
+	})
+}
+
+func drawTargetBoard(pw *pdf.PageWriter, cx, cy, radius float64, mode targetBoardMode) error {
+	pw.SetLineColor(colors.DarkSlateBlue)
+	pw.SetLineWidth(1.25, "pt")
+	pw.SetFillColor(colors.WhiteSmoke)
+	if err := pw.Circle(cx, cy, radius, true, true, false); err != nil {
+		return err
+	}
+
+	if err := fillTargetBoardBands(pw, cx, cy, radius, mode); err != nil {
+		return err
+	}
+
+	pw.SetFillColor(colors.Gold)
+	if err := pw.Circle(cx, cy, radius*0.2, true, true, false); err != nil {
+		return err
+	}
+	pw.SetFillColor(colors.FireBrick)
+	if err := pw.Circle(cx, cy, radius*0.09, true, true, false); err != nil {
+		return err
+	}
+
+	for _, ring := range []float64{1.0, 0.82, 0.58, 0.34, 0.2, 0.09} {
+		if err := pw.Circle(cx, cy, radius*ring, true, false, false); err != nil {
+			return err
+		}
+	}
+
+	spokes := []float64{0, 90, 180, 270}
+	if mode == targetBoardDetailed {
+		spokes = []float64{0, 22.5, 45, 67.5, 90, 112.5, 135, 157.5, 180, 202.5, 225, 247.5, 270, 292.5, 315, 337.5}
+	}
+	for _, angle := range spokes {
+		x1, y1 := pointOnCircle(cx, cy, radius*0.2, angle)
+		x2, y2 := pointOnCircle(cx, cy, radius, angle)
+		pw.MoveTo(x1, y1)
+		pw.LineTo(x2, y2)
+	}
+
+	return nil
+}
+
+func fillTargetBoardBands(pw *pdf.PageWriter, cx, cy, radius float64, mode targetBoardMode) error {
+	if mode == targetBoardSimplified {
+		palette := []colors.Color{colors.LightSteelBlue, colors.PeachPuff, colors.LightCyan, colors.LightGoldenRodYellow}
+		for i := 0; i < 4; i++ {
+			pw.SetFillColor(palette[i%len(palette)])
+			if err := pw.Pie(cx, cy, radius*0.82, float64(i)*90, float64(i+1)*90, false, true, false); err != nil {
+				return err
+			}
+		}
+		pw.SetFillColor(colors.WhiteSmoke)
+		return pw.Circle(cx, cy, radius*0.34, false, true, false)
+	}
+
+	palette := []colors.Color{colors.LightSteelBlue, colors.LightGoldenRodYellow, colors.MistyRose, colors.HoneyDew}
+	for i := 0; i < 16; i++ {
+		pw.SetFillColor(palette[i%len(palette)])
+		if err := pw.Arch(cx, cy, radius*0.58, radius*0.82, float64(i)*22.5, float64(i+1)*22.5, false, true, false); err != nil {
+			return err
+		}
+	}
+	for i := 0; i < 8; i++ {
+		pw.SetFillColor(palette[(i+1)%len(palette)])
+		if err := pw.Arch(cx, cy, radius*0.2, radius*0.34, float64(i)*45, float64(i+1)*45, false, true, false); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func pointOnCircle(cx, cy, radius, angle float64) (x, y float64) {
+	radians := angle * math.Pi / 180.0
+	return cx + (radius * math.Cos(radians)), cy - (radius * math.Sin(radians))
+}


### PR DESCRIPTION
## Summary
- Add memoized canvas/form capture so repeated LTML draw content can be rendered once and reused as a form XObject.
- Thread memoization support through the LTML writer stack, PDF form handling, and canvas capture/draw paths.
- Update canvas drawing, link/index handling, and sample output to exercise the new memoized flow.

## Testing
- Added and updated unit/integration coverage for form memoization, canvas drawing, and layout behavior.
- Verified the affected PDF and LTML test suites pass locally, including the new canvas memoization scenarios.